### PR TITLE
Archiving or Projects and Layers

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -60,13 +60,7 @@ export interface ExtendedProjectData {
 
   description: string;
 
-  contexts: [{
-
-    id: string;
-
-    name: string;
-
-  }];
+  contexts: Context[];
 
   layers: [{
 
@@ -157,6 +151,12 @@ export interface Document {
 
 }
 
+export interface DocumentInProject extends Document {
+
+  layers: Layer[];
+
+}
+
 export const ContentTypes = ['text/plain', 'application/tei+xml'] as const;
 
 export type ContentType = typeof ContentTypes[number];
@@ -169,14 +169,6 @@ export interface Context {
 
   id: string;
 
-  created_at: string;
-
-  created_by: string;
-
-  updated_at?: string;
-
-  updated_by?: string;
-
   name: string;
 
   project_id: string;
@@ -186,16 +178,10 @@ export interface Context {
 export interface Layer {
 
   id: string;
-
-  created_at: string;
-
-  created_by: string;
-
-  updated_at?: string;
-
-  updated_by?: string;
   
   document_id: string;
+
+  project_id: string;
 
   name?: string;
 

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react';
-import type { Document, Layer, Translations } from 'src/Types';
+import type { DocumentInProject, Translations } from 'src/Types';
 import { Annotation } from '@components/Annotation';
 import { Toolbar } from './Toolbar';
 import { createAppearenceProvider, PresenceStack } from '@components/Presence';
@@ -26,9 +26,7 @@ export interface ImageAnnotationDesktopProps {
 
   i18n: Translations;
 
-  document: Document;
-
-  layers: Layer[];
+  document: DocumentInProject;
 
   channelId: string;
 
@@ -84,7 +82,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
             base={SUPABASE}
             apiKey={SUPABASE_API_KEY} 
             channel={props.channelId}
-            layerId={props.layers[0].id} 
+            layerId={props.document.layers[0].id} 
             appearanceProvider={appearance}
             onPresence={setPresent} 
             onConnectError={onConnectError}

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -5,7 +5,7 @@ import { PresenceStack, createAppearenceProvider } from '@components/Presence';
 import { Annotation } from '@components/Annotation';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
 import { Toolbar } from './Toolbar';
-import type { Document, Layer, Translations } from 'src/Types';
+import type { DocumentInProject, Layer, Translations } from 'src/Types';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import {
   TextAnnotator, 
@@ -25,9 +25,7 @@ export interface TextAnnotationDesktopProps {
 
   i18n: Translations;
 
-  document: Document;
-
-  layers: Layer[];
+  document: DocumentInProject;
 
   channelId: string;
 
@@ -78,7 +76,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
           base={SUPABASE}
           apiKey={SUPABASE_API_KEY} 
           channel={props.channelId}
-          layerId={props.layers[0].id} 
+          layerId={props.document.layers[0].id} 
           appearanceProvider={createAppearenceProvider()}
           onPresence={setPresent} 
           privacyMode={privacy === 'PRIVATE'}/>

--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { RocketLaunch } from '@phosphor-icons/react';
-import type { Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Translations } from 'src/Types';
 import { Button } from '@components/Button';
 import { initProject } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
@@ -9,7 +9,7 @@ export interface ProjectsEmptyProps {
 
   i18n: Translations;
 
-  onProjectCreated(project: Project): void;
+  onProjectCreated(project: ExtendedProjectData): void;
 
   onError(error: string): void;
 
@@ -28,7 +28,7 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
     setFetching(true);
 
     initProject(supabase, t['Untitled Project'])
-      .then(({ project }) => {
+      .then(project => {
         props.onProjectCreated(project);
         setFetching(false);
       })

--- a/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
+++ b/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
@@ -1,15 +1,15 @@
 import { ProjectCard } from '@components/ProjectCard';
-import type { Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Translations } from 'src/Types';
 
 export interface ProjectsGridProps {
 
   i18n: Translations;
 
-  projects: Project[];
+  projects: ExtendedProjectData[];
 
-  onDeleteProject(project: Project): void;
+  onDeleteProject(project: ExtendedProjectData): void;
 
-  onRenameProject(project: Project): void;
+  onRenameProject(project: ExtendedProjectData): void;
 
 }
 

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react';
 import { FunnelSimple, Kanban, MagnifyingGlass, Plus, User } from '@phosphor-icons/react';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { getMyProfile } from '@backend/crud';
+import { initProject } from '@backend/helpers';
 import { AccountActions } from '@components/AccountActions';
 import { Button } from '@components/Button';
 import { Notifications } from '@components/Notifications';
-import type { Invitation, MyProfile, Project, Translations } from 'src/Types';
+import type { Invitation, MyProfile, ExtendedProjectData, Translations } from 'src/Types';
 import { ProjectFilter } from '../ProjectsHome';
 
 import './Header.css';
-import { initProject } from '@backend/helpers';
 
 interface HeaderProps {
 
@@ -21,9 +21,9 @@ interface HeaderProps {
 
   onChangeFilter(f: ProjectFilter): void;
 
-  onProjectCreated(project: Project): void;
+  onProjectCreated(project: ExtendedProjectData): void;
 
-  onInvitationAccepted(invitation: Invitation, project: Project): void;
+  onInvitationAccepted(invitation: Invitation, project: ExtendedProjectData): void;
 
   onInvitationDeclined(invitation: Invitation): void;
 
@@ -49,7 +49,7 @@ export const Header = (props: HeaderProps) => {
     setCreating(true);
 
     initProject(supabase, t['Untitled Project'])
-      .then(({ project }) => {
+      .then(project => {
         props.onProjectCreated(project);
         setCreating(false);
       })

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Hammer } from '@phosphor-icons/react';
 import type { ExtendedProjectData, Invitation, Translations } from 'src/Types';
 import { supabase } from '@backend/supabaseBrowserClient';
-import { deleteProject, getMyProfile } from '@backend/crud';
+import { archiveProject, getMyProfile } from '@backend/crud';
 import { ToastProvider, Toast, ToastContent } from '@components/Toast';
 import { Header } from './Header';
 import { ProjectsEmpty } from './Empty';
@@ -73,26 +73,18 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
   }
     
   const onDeleteProject = (project: ExtendedProjectData) =>
-    deleteProject(supabase, project.id).then(({ error, data }) => {
-      if (error) {
+    archiveProject(supabase, project.id)
+      .then(() => {
+        setProjects(projects => projects.filter(p => p.id !== project.id));
+      })
+      .catch(error => {
         console.error(error);
         setError({
           title: t['Something went wrong'],
           description: t['Could not delete the project.'],
           type: 'error'
         });
-      } else if (data) {
-        if (data.length === 1 && data[0].id === project.id) {
-          setProjects(projects.filter(p => p.id !== project.id));
-        } else {
-          setError({
-            title: t['Something went wrong'],
-            description: t['Could not delete the project.'],
-            type: 'error'
-          });
-        }
-      }
-    });
+      });
 
   const onError = (error: string) =>
     setError({

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Hammer } from '@phosphor-icons/react';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Invitation, Translations } from 'src/Types';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { deleteProject, getMyProfile } from '@backend/crud';
 import { ToastProvider, Toast, ToastContent } from '@components/Toast';
@@ -17,7 +17,7 @@ export interface ProjectsHomeProps {
 
   me: User;
 
-  projects: Project[];
+  projects: ExtendedProjectData[];
 
   invitations: Invitation[]; 
 
@@ -29,7 +29,9 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const { t } = props.i18n;
 
-  const [projects, setProjects] = useState<Project[]>(props.projects);
+  const { me } = props;
+
+  const [projects, setProjects] = useState<ExtendedProjectData[]>(props.projects);
 
   const [invitations, setInvitations] = useState<Invitation[]>(props.invitations);
 
@@ -46,18 +48,22 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
   }, []);
 
   const filteredProjects = 
+    // All projects
     filter === ProjectFilter.ALL ?
       projects : 
+    // Am I the creator?
     filter === ProjectFilter.MINE ? 
-      projects.filter(p => p.created_by.id === props.me.id) : 
+      projects.filter(p => p.created_by.id === me.id) : 
+    // Am I one of the users in the groups?
     filter === ProjectFilter.SHARED ? 
-      // TODO
-      [] : [];
+      projects.filter(({ groups }) => 
+        groups.find(({ members }) => members.find(m => m.user.id === me.id))) : 
+    [];
 
-  const onProjectCreated = (project: Project) =>
+  const onProjectCreated = (project: ExtendedProjectData) =>
     setProjects([...projects, project]);
 
-  const onRenameProject = (project: Project) => {
+  const onRenameProject = (project: ExtendedProjectData) => {
     setError({
       icon: <Hammer size={16} className="text-bottom" />,
       title: t['We\'re working on it!'],
@@ -66,7 +72,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
     });
   }
     
-  const onDeleteProject = (project: Project) =>
+  const onDeleteProject = (project: ExtendedProjectData) =>
     deleteProject(supabase, project.id).then(({ error, data }) => {
       if (error) {
         console.error(error);
@@ -94,7 +100,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
       type: 'error'
     });
 
-  const onInvitationAccepted = (invitation: Invitation, project: Project) => {
+  const onInvitationAccepted = (invitation: Invitation, project: ExtendedProjectData) => {
     setInvitations(invitations => invitations.filter(i => i.id !== invitation.id));
     setProjects(projects => ([ project, ...projects ]));
   }

--- a/src/apps/project-home/upload/useUpload.ts
+++ b/src/apps/project-home/upload/useUpload.ts
@@ -1,14 +1,14 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { initDocument } from '@backend/helpers';
-import type { Document, Layer } from 'src/Types';
+import type { DocumentInProject } from 'src/Types';
 import type { Upload, UploadProgress, UploadStatus } from './Upload';
 
 let queue = Promise.resolve();
 
 export const useUpload = (
-  onImport: (document: Document, defaultLayer: Layer) => void
+  onImport: (document: DocumentInProject) => void
 ) => {
 
   const [uploads, setUploads] = useState<UploadProgress[]>([]);
@@ -21,14 +21,14 @@ export const useUpload = (
     } : upload));
   };
 
-  const onSuccess = (id: string, document: Document, defaultLayer: Layer) => {
+  const onSuccess = (id: string, document: DocumentInProject) => {
     setUploads(prev => prev.map(upload => upload.id === id ? {
       ...upload,
       progress: 100,
       status: 'success'
     } : upload));
 
-    onImport(document, defaultLayer)
+    onImport(document);
   };
     
   const onError = (id: string, message: string) => {
@@ -57,8 +57,8 @@ export const useUpload = (
       progress => onProgress(id, progress, 'uploading'),
       i.file,
       i.url
-    ).then(({ document, defaultLayer }) => {
-      onSuccess(id, document, defaultLayer);
+    ).then(document => {
+      onSuccess(id, document);
     })).catch(error => {
       onError(id, error);
     });

--- a/src/backend/crud/documents.ts
+++ b/src/backend/crud/documents.ts
@@ -22,11 +22,11 @@ export const createDocument = (
       return { error, data: data as Document }
     });
 
-export const updateDocument = (supabase: SupabaseClient, document: Document): Response<Document> =>
+export const renameDocument = (supabase: SupabaseClient, documentId: string, name: string): Response<Document> =>
   supabase 
     .from('documents')
-    .update({...document })
-    .eq('id', document.id)
+    .update({ name })
+    .eq('id', documentId)
     .select()
     .single()
     .then(({ error, data }) => ({ error, data: data as Document }));

--- a/src/backend/crud/layers.ts
+++ b/src/backend/crud/layers.ts
@@ -20,3 +20,18 @@ export const createLayer = (
     .select()
     .single()
     .then(({ error, data }) => ({ error, data: data as Layer }));
+
+export const archiveLayer = (supabase: SupabaseClient, id: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    supabase
+      .rpc('archive_record_rpc', {
+        _table_name: 'layers',
+        _id: id
+      })
+      .then(({ error }) => {
+        if (error)
+          reject(error);
+        else
+          resolve();
+      })
+  });

--- a/src/backend/helpers/invitationHelpers.ts
+++ b/src/backend/helpers/invitationHelpers.ts
@@ -1,10 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Invitation, Project } from 'src/Types';
+import type { ExtendedProjectData, Invitation } from 'src/Types';
+import { getProjectExtended } from './projectHelpers';
 
 export const joinProject = (
   supabase: SupabaseClient, 
   invitation: Invitation
-): Promise<Project> => new Promise((resolve, reject) => {
+): Promise<ExtendedProjectData> => new Promise((resolve, reject) => {
   supabase
     .from('invites')
     .update({ accepted: true })
@@ -13,23 +14,12 @@ export const joinProject = (
       if (error) {
         reject(error);
       } else {
-        supabase
-          .from('projects')
-          .select(`
-            id,
-            created_at,
-            updated_at,
-            updated_by,
-            name,
-            description
-          `)
-          .eq('id', invitation.project_id)
-          .maybeSingle()
+        getProjectExtended(supabase, invitation.project_id)
           .then(({ error, data }) => {
             if (error || !data)
               reject(error);
             else 
-              resolve(data as Project);
+              resolve(data);
           });
       }
     });

--- a/src/backend/helpers/projectHelpers.ts
+++ b/src/backend/helpers/projectHelpers.ts
@@ -226,7 +226,6 @@ export const getProjectExtended = (supabase: SupabaseClient, projectId: string):
       }
     });
   
-
 export const getGroupMembers = (supabase: SupabaseClient, groupIds: string[]): Response<ProjectMember[]> =>
   supabase
     .from('group_users')

--- a/src/backend/helpers/projectHelpers.ts
+++ b/src/backend/helpers/projectHelpers.ts
@@ -79,10 +79,6 @@ export const getProjectWithContexts = (
     contexts (
       id,
       project_id,
-      created_at,  
-      created_by,
-      updated_at,
-      updated_by,  
       name
     )
   `)
@@ -109,6 +105,7 @@ export const listMyProjectsExtended = (supabase: SupabaseClient): Response<Exten
       description,
       contexts (
         id,
+        project_id,
         name
       ),
       layers (
@@ -178,6 +175,7 @@ export const getProjectExtended = (supabase: SupabaseClient, projectId: string):
       description,
       contexts (
         id,
+        project_id,
         name
       ),
       layers (

--- a/src/components/DocumentCard/DocumentCard.tsx
+++ b/src/components/DocumentCard/DocumentCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Context, Document, Translations } from 'src/Types';
+import type { Context, DocumentInProject, Translations } from 'src/Types';
 import { EditableText } from '@components/EditableText';
 import { DocumentCardActions } from './DocumentCardActions';
 import { ContentTypeIcon } from './ContentTypeIcon';
@@ -12,7 +12,7 @@ interface DocumentCardProps {
 
   context: Context;
 
-  document: Document;
+  document: DocumentInProject;
 
   onDelete(): void;
 

--- a/src/components/Notifications/InvitationItem/InvitationItem.tsx
+++ b/src/components/Notifications/InvitationItem/InvitationItem.tsx
@@ -3,7 +3,7 @@ import { TimeAgo } from '@components/TimeAgo';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Button } from '@components/Button';
 import { declineInvitation, joinProject } from '@backend/helpers/invitationHelpers';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { Invitation, ExtendedProjectData, Translations } from 'src/Types';
 
 import './InvitationItem.css';
 
@@ -13,7 +13,7 @@ interface InvitationItemProps {
 
   invitation: Invitation;
 
-  onAccepted(project: Project): void;
+  onAccepted(project: ExtendedProjectData): void;
 
   onDeclined(): void;
 

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,6 +1,6 @@
 import * as Popover from '@radix-ui/react-popover';
 import { Bell, X } from '@phosphor-icons/react';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Invitation, Translations } from 'src/Types';
 import { EmptyList } from './EmptyList';
 import { InvitationItem } from './InvitationItem';
 
@@ -14,7 +14,7 @@ interface NotificationsProps {
 
   invitations: Invitation[];
 
-  onInvitationAccepted(invitation: Invitation, project: Project): void;
+  onInvitationAccepted(invitation: Invitation, project: ExtendedProjectData): void;
 
   onInvitationDeclined(invitation: Invitation): void;
 

--- a/src/pages/[lang]/annotate/[context]/[document]/index.astro
+++ b/src/pages/[lang]/annotate/[context]/[document]/index.astro
@@ -24,21 +24,12 @@ if (!contextId || !documentId) {
 }
 
 // Will return empty if this user has no access priviliges
-const response = await getDocumentInContext(supabase, documentId, contextId);
+const document = await getDocumentInContext(supabase, documentId, contextId);
 
-if (!response.data) {
+if (document.error || !document.data) {
   // https://javascript.plainenglish.io/return-custom-404-responses-in-astro-b844b0e0146d
   const error = await fetch(`${Astro.url}/404`);
   return new Response(error.body, { headers: error.headers, status: 404 }); 
-}
-
-const [ document, layers ] = response.data;
-
-if (!document || !layers) {
-  // https://javascript.plainenglish.io/return-custom-404-responses-in-astro-b844b0e0146d
-  const path = Astro.url.protocol + '//' + Astro.url.host;
-  const error = await fetch(`${path}/500`);
-  return new Response(error.body, { headers: error.headers, status: 500 }); 
 }
 
 // Compute realtime channel key
@@ -50,9 +41,9 @@ const channelId = data.digest('hex');
 
 let viewer;
 
-if (document.content_type === 'text/plain') {
+if (document.data.content_type === 'text/plain') {
   viewer = 'TEXT';
-} else if (document.meta_data?.protocol === 'IIIF_IMAGE') {
+} else if (document.data.meta_data?.protocol === 'IIIF_IMAGE') {
   viewer ='OPENSEADRAGON';
 } else {
   // Should never happen
@@ -66,23 +57,21 @@ if (document.content_type === 'text/plain') {
       <ImageAnnotationDesktop 
         client:only
         i18n={getTranslations(Astro.request, 'annotation-image')}
-        document={document}
-        layers={layers}
+        document={document.data}
         channelId={channelId} />
     </div>
   ) : (
     <div class="container text">
       <main id="annotatable">
         <PlainText
-          document={document} 
+          document={document.data} 
           supabase={supabase} />
       </main>
 
       <TextAnnotationDesktop 
         client:only
         i18n={getTranslations(Astro.request, 'annotation-text')} 
-        document={document}
-        layers={layers}
+        document={document.data}
         channelId={channelId} />
     </div>
   )}

--- a/src/pages/[lang]/projects/[slug]/index.astro
+++ b/src/pages/[lang]/projects/[slug]/index.astro
@@ -4,7 +4,7 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getUserProfile } from '@backend/auth';
 import { getLangFromUrl, getTranslations } from '@i18n';
 import { ProjectHome } from '@apps/project-home';
-import { getProjectWithContexts, listDocumentsInContext } from '@backend/helpers';
+import { getProjectExtended, listDocumentsInProject } from '@backend/helpers';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -18,36 +18,25 @@ const projectId = Astro.params.slug;
 
 const i18n = getTranslations(Astro.request, 'project-home');
 
-const response = await getProjectWithContexts(supabase, projectId as string);
+const project = await getProjectExtended(supabase, projectId as string);
 
-if (response.error) { 
+if (project.error || !project.data) { 
   const error = await fetch(`${Astro.url}/404`);
   return new Response(error.body, { headers: error.headers, status: 404 }); 
 }
 
-if (!response.data) {
-  const error = await fetch(`${Astro.url}/404`);
-  return new Response(error.body, { headers: error.headers, status: 404 }); 
-}
+const documents = await listDocumentsInProject(supabase, projectId as string);
 
-const { contexts, ...project} = response.data || { contexts: undefined };
-
-// Temporary hack
-const defaultContext = contexts[0];
-
-const { data, error } = await listDocumentsInContext(supabase, defaultContext.id);
-
-if (error) { 
+if (documents.error) { 
   const path = Astro.url.protocol + '//' + Astro.url.host;
   const error = await fetch(`${path}/500`);
   return new Response(error.body, { headers: error.headers, status: 500 }); 
 }
 ---
-<ProjectLayout active="home" user={user} project={response.data}>
+<ProjectLayout active="home" user={user} project={project.data}>
   <ProjectHome 
     client:only
-    i18n={i18n} 
-    project={project} 
-    defaultContext={contexts[0]} 
-    documents={data} />
+    i18n={i18n}
+    project={project.data} 
+    documents={documents.data} />
 </ProjectLayout>

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -2,11 +2,10 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import { listMyInvites, listMyProjects } from '@backend/crud';
+import { listMyInvites } from '@backend/crud';
 import { ProjectsHome } from '@apps/dashboard-projects';
 import { getUser } from '@backend/auth';
 import { listMyProjectsExtended } from '@backend/helpers';
-import type { ExtendedProjectData } from 'src/Types';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -16,8 +15,7 @@ if (!supabase)
 
 const me = await getUser(supabase);
 
-// const projects = await listMyProjectsExtended(supabase);
-const projects = await listMyProjects(supabase);
+const projects = await listMyProjectsExtended(supabase);
 
 const invitations = await listMyInvites(supabase);
 


### PR DESCRIPTION
## In this PR

This PR adds GUI functionality to 'delete' Projects from the dashboard, and documents from a Project.

- When 'deleting' a Project, it is archived using the `archive_record_rpc` function
- When 'deleting' a Document in a Project, what actually happens is that all the Layers associated with this Document in the Project are archived using `archive_record_rpc`. The actual Document record in the `documents` table is left untouched. If the Document is linked to a file upload, this upload is also left untouched.

In addition this PR adds:
- some refactoring in the [Types](https://github.com/recogito/unnamed-frontend/blob/main/src/Types.ts) structure, and the [backend](https://github.com/recogito/unnamed-frontend/tree/main/src/backend) package, for a cleaner domain object API
- a simplified query to retrieve Documents that takes into account the recently added `project_id` column in the `layers` table.