### PR TITLE
Editable Project Descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "unnamed-frontend",
+  "name": "recogito-client",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "unnamed-frontend",
+      "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
         "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "unnamed-frontend",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-28",
+        "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/react": "^2.2.0",
         "@phosphor-icons/react": "^2.0.9",
@@ -45,6 +45,29 @@
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "@types/uuid": "^9.0.1"
+      }
+    },
+    "../../annotorious/annotorious-v3/packages/annotorious-react": {
+      "name": "@annotorious/react",
+      "version": "3.0.0-pre-alpha-28",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
       }
     },
     "../text-annotator/packages/text-annotator-react": {
@@ -85,17 +108,8 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-28",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-28.tgz",
-      "integrity": "sha512-z/W2wDp9VxjGSDskV8Z/BvtnFYM+mv6Nocqfct7k5f7LtoxlYJFUpSJZlyVuNxurKhjJ7w5bt5uMEbvctF2AEA==",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3"
-      },
-      "peerDependencies": {
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
+      "resolved": "../../annotorious/annotorious-v3/packages/annotorious-react",
+      "link": true
     },
     "node_modules/@astrojs/compiler": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unnamed-frontend",
+  "name": "recogito-client",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "^3.0.0-pre-alpha-28",
+    "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/react": "^2.2.0",
     "@phosphor-icons/react": "^2.0.9",

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,7 +36,7 @@ export interface Project {
 
   name: string;
 
-  description: string;
+  description?: string;
 
 }
 
@@ -58,7 +58,7 @@ export interface ExtendedProjectData {
 
   name: string;
 
-  description: string;
+  description?: string;
 
   contexts: Context[];
 

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -8,6 +8,8 @@ import type { PrivacyMode } from '@components/PrivacySelector';
 import {
   Annotation as Anno,
   Annotorious, 
+  Formatter,
+  ImageAnnotation,
   OSDAnnotator, 
   OpenSeadragonAnnotator,
   OpenSeadragonPopup,
@@ -40,7 +42,9 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
 
   const [present, setPresent] = useState<PresentUser[]>([]);
 
-  const [tool, setTool] = useState<string | null>(null);
+  const [tool, setTool] = useState<string | undefined>(undefined);
+
+  const [formatter, setFormatter] = useState<Formatter | undefined>(undefined);
 
   const [usePopup, setUsePopup] = useState(true);
 
@@ -64,7 +68,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
   const beforeSelectAnnotation = (a?: Anno) => {
     if (a && !usePopup && anno.current) {
       // Don't fit the view if the annotation is already selected
-      if (anno.current.selection.isSelected(a))
+      if (anno.current.selection.isSelected(a as ImageAnnotation))
         return;
 
       const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
@@ -77,7 +81,11 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
   return (
     <div className="anno-desktop ia-desktop">
       <Annotorious ref={anno}>
-        <OpenSeadragonAnnotator tool={tool} keepEnabled={true}>
+        <OpenSeadragonAnnotator 
+          tool={tool} 
+          keepEnabled={true}
+          formatter={formatter}>
+
           <SupabasePlugin
             base={SUPABASE}
             apiKey={SUPABASE_API_KEY} 
@@ -115,7 +123,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
               i18n={i18n}
               present={present} 
               onChangePanel={onChangeViewMenuPanel} 
-              beforeSelectAnnotation={beforeSelectAnnotation} />
+              beforeSelectAnnotation={beforeSelectAnnotation} 
+              onChangeStyleConfig={formatter => setFormatter(() => formatter)} />
           </div>
 
           <div className="anno-desktop-bottom">

--- a/src/apps/annotation-image/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-image/Toolbar/Toolbar.tsx
@@ -11,7 +11,7 @@ interface ToolbarProps {
 
   privacy: PrivacyMode;
 
-  onChangeTool(tool: string | null): void;
+  onChangeTool(tool?: string): void;
 
   onChangePrivacy(mode: PrivacyMode): void;
 
@@ -28,7 +28,7 @@ export const Toolbar = (props: ToolbarProps) => {
   const [tool, setTool] = useState<string>('cursor');
 
   const onChangeTool = (tool: string) => {
-    props.onChangeTool && props.onChangeTool(tool === 'cursor' ? null : tool);
+    props.onChangeTool && props.onChangeTool(tool === 'cursor' ? undefined : tool);
     setTool(tool);
   }
 

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.css
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.css
@@ -29,6 +29,27 @@
   width: 60ch;
 }
 
+.project-description .buttons button {
+  border-radius: var(--border-radius);
+  font-weight: 500;
+  padding: 0.3em 0.5em 0.2em 0.3em;
+}
+
+.project-description .buttons button:hover:not(:disabled) {
+  box-shadow: none;
+  color: var(--font-dark);
+  text-decoration: underline;
+}
+
+.project-description .buttons button:hover svg {
+  color: var(--font-dark);
+}
+
+.project-description .buttons button:disabled,
+.project-description .buttons button:disabled svg {
+  color: var(--gray-400);
+}
+
 .project-description .tiny-save-indicator {
   padding-left: 5px;
 } 

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.css
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.css
@@ -1,0 +1,35 @@
+.project-description {
+  margin-bottom: 3em;
+}
+
+.project-description p,
+.project-description textarea {
+  border: 1px dashed transparent;
+  border-radius: var(--border-radius);
+  font-size: var(--font-small);
+  line-height: 160%;
+  margin: 0 0 0 -8px;
+  padding: 5px 8px;
+}
+
+.project-description p {
+  color: var(--font-light);
+  cursor: pointer;
+  max-width: 60ch;
+  transition: all 250ms;
+}
+
+.project-description p:hover {
+  background-color: #e6eaf1;
+  border-color: var(--gray-400);
+}
+
+.project-description textarea {
+  resize: none;
+  width: 60ch;
+}
+
+.project-description .tiny-save-indicator {
+  padding-left: 5px;
+} 
+

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
@@ -1,0 +1,87 @@
+import { useRef, useState } from 'react';
+import { PlusCircle } from '@phosphor-icons/react';
+import type { PostgrestError } from '@supabase/supabase-js';
+import TextareaAutosize from 'react-textarea-autosize';
+import { updateProject } from '@backend/crud';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { SaveState, TinySaveIndicator } from '@components/TinySaveIndicator';
+import type { ExtendedProjectData, Translations } from 'src/Types';
+
+import './ProjectDescription.css';
+
+interface ProjectDescriptionProps {
+
+  i18n: Translations;
+
+  project: ExtendedProjectData;
+
+  onChanged(project: ExtendedProjectData): void;
+
+  onError(error: PostgrestError): void;
+
+}
+
+export const ProjectDescription = (props: ProjectDescriptionProps) => {
+
+  const [description, setDescription] = useState(props.project.description);
+
+  const el = useRef<HTMLTextAreaElement>(null);
+
+  const [editable, setEditable] = useState(false);
+
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+
+  const [value, setValue] = useState(description);
+
+  const onSave = () => {
+    const description = value.trim();
+
+    setDescription(description);
+    setSaveState('saving');
+    setEditable(false);
+
+    updateProject(supabase, { id: props.project.id, description })
+      .then(({ error }) => {
+        if (error) {
+          setSaveState('failed');
+          setDescription(props.project.description);
+          props.onError(error);
+        } else {
+          setSaveState('success');
+          setValue(description);
+          props.onChanged({ ...props.project, description });
+        }
+      });
+  }
+
+  // TODO needs an explicit button for accessibility
+  return (
+    <div className="project-description">
+      {editable ? (
+        <TextareaAutosize 
+          autoFocus
+          ref={el}
+          rows={1} 
+          maxRows={20}
+          value={value}
+          onChange={evt => setValue(evt.target.value)}
+          placeholder="Add a project description..." 
+          onBlur={onSave} />
+      ) : description ? (
+        <p onClick={() => setEditable(true)}>
+          {description}
+          {saveState !== 'idle' && (
+            <TinySaveIndicator 
+              state={saveState} 
+              fadeOut={1500} />
+          )}
+        </p>
+      ) : (
+        <button className="minimal" onClick={() => setEditable(true)}>
+          <PlusCircle size={16} /> <span>Add a project description</span>
+        </button>
+      )}
+    </div>
+  )
+
+}

--- a/src/apps/project-home/ProjectDescription/index.ts
+++ b/src/apps/project-home/ProjectDescription/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectDescription';

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -6,8 +6,8 @@
   position: relative;
 }
 
-.project-description {
-  padding: 0 0 1.5em 0;
+.project-home h1 {
+  margin-bottom: 0.5em;
 }
 
 .project-home-grid-wrapper {
@@ -20,7 +20,7 @@
   gap: 1rem;
   grid-auto-rows: 1fr;  
   grid-template-columns: repeat(auto-fill, 180px);
-  padding: 70px 0 40px 0;
+  padding: 2em 0 40px 0;
 }
 
 .dropzone-hint-wrapper {

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -6,6 +6,10 @@
   position: relative;
 }
 
+.project-description {
+  padding: 0 0 1.5em 0;
+}
+
 .project-home-grid-wrapper {
   flex-grow: 1;
   position: relative;

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CloudArrowUp } from '@phosphor-icons/react';
+import { CloudArrowUp, PlusCircle } from '@phosphor-icons/react';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { archiveLayer, renameDocument, updateProject } from '@backend/crud';
 import { DocumentCard } from '@components/DocumentCard';
@@ -158,6 +158,12 @@ export const ProjectHome = (props: ProjectHomeProps) => {
               value={project.name} 
               onSubmit={onRenameProject} />
           </h1>
+
+          <div className="project-description">
+            <button className="minimal">
+              <PlusCircle size={16} /> <span>Add Project Description</span>
+            </button>
+          </div>
           
           <UploadActions 
             i18n={props.i18n} 

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
-import { CloudArrowUp, PlusCircle } from '@phosphor-icons/react';
+import { CloudArrowUp } from '@phosphor-icons/react';
+import type { FileRejection } from 'react-dropzone';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { archiveLayer, renameDocument, updateProject } from '@backend/crud';
 import { DocumentCard } from '@components/DocumentCard';
 import { EditableText } from '@components/EditableText';
 import { Toast, ToastContent, ToastProvider } from '@components/Toast';
 import { UploadActions, UploadFormat, UploadTracker, useUpload, useDragAndDrop } from './upload';
+import { ProjectDescription } from './ProjectDescription';
 import type { DocumentInProject, ExtendedProjectData, Translations } from 'src/Types';
-import type { FileRejection } from 'react-dropzone';
 
 import './ProjectHome.css';
+import type { PostgrestError } from '@supabase/supabase-js';
 
 export interface ProjectHomeProps {
 
@@ -25,7 +27,7 @@ export const ProjectHome = (props: ProjectHomeProps) => {
 
   const { t } = props.i18n;
 
-  const { project } = props;
+  const [project, setProject] = useState(props.project);
 
   // Temporary hack!
   const defaultContext = project.contexts[0];
@@ -85,11 +87,10 @@ export const ProjectHome = (props: ProjectHomeProps) => {
   }
 
   const onRenameProject = (name: string) => {
-    updateProject(supabase, {
-      ...props.project, name
-    }).then(response => {
-      console.log(response);
-    });
+    updateProject(supabase, { id: project.id, name })
+      .then(response => {
+        console.log(response);
+      });
   }
 
   /**
@@ -149,6 +150,16 @@ export const ProjectHome = (props: ProjectHomeProps) => {
       });
   }
 
+  const onError = (error: PostgrestError, message: string) => {
+    console.error(error);
+
+    setToast({ 
+      title: t['Something went wrong'], 
+      description: t[message] || message, 
+      type: 'error' 
+    });
+  }
+
   return (
     <div className="project-home">
       <ToastProvider>
@@ -159,11 +170,11 @@ export const ProjectHome = (props: ProjectHomeProps) => {
               onSubmit={onRenameProject} />
           </h1>
 
-          <div className="project-description">
-            <button className="minimal">
-              <PlusCircle size={16} /> <span>Add Project Description</span>
-            </button>
-          </div>
+          <ProjectDescription 
+            i18n={props.i18n}
+            project={project} 
+            onChanged={setProject} 
+            onError={error => onError(error, 'Error updating project description.')} />
           
           <UploadActions 
             i18n={props.i18n} 

--- a/src/backend/crud/projects.ts
+++ b/src/backend/crud/projects.ts
@@ -70,7 +70,7 @@ export const listMyProjects = (supabase: SupabaseClient): Response<Project[]> =>
       `)
       .then(({ error, data }) => ({ error, data: data as unknown as Project[] })));
 
-export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string }): Response<Project> =>
+export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string | null }): Response<Project> =>
   supabase 
     .from('projects')
     .update({...partial })

--- a/src/backend/crud/projects.ts
+++ b/src/backend/crud/projects.ts
@@ -70,11 +70,11 @@ export const listMyProjects = (supabase: SupabaseClient): Response<Project[]> =>
       `)
       .then(({ error, data }) => ({ error, data: data as unknown as Project[] })));
 
-export const updateProject = (supabase: SupabaseClient, project: Project): Response<Project> =>
+export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string }): Response<Project> =>
   supabase 
     .from('projects')
-    .update({...project })
-    .eq('id', project.id)
+    .update({...partial })
+    .eq('id', partial.id)
     .select()
     .single()
     .then(({ error, data }) => ({ error, data: data as Project }));

--- a/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.css
+++ b/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.css
@@ -1,0 +1,9 @@
+.anno-sidepanel.style-configuration {
+  font-size: var(--font-small);
+  padding: 15px;
+}
+
+.anno-sidepanel.style-configuration label {
+  display: inline-block;
+  margin-right: 10px;
+}

--- a/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.tsx
+++ b/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import * as Select from '@radix-ui/react-select';
+import { CaretDown, Check } from '@phosphor-icons/react';
+
+import './StyleConfiguration.css';
+
+interface StyleConfigurationProps {
+  
+}
+
+export const StyleConfiguration = (props: StyleConfigurationProps) => {
+
+  const [value, setValue] = useState('privacy');
+
+  return (
+    <div className="anno-sidepanel style-configuration">
+      <form>
+        <label>Color by</label>
+        <Select.Root value={value} onValueChange={setValue}>
+          <Select.Trigger className="select-trigger" aria-label="Annotation color by">
+            <Select.Value />
+            <Select.Icon className="select-icon">
+              <CaretDown />
+            </Select.Icon>
+          </Select.Trigger>
+
+          <Select.Portal>
+            <Select.Content className="select-content">
+              <Select.Viewport className="select-viewport">
+                <Select.Item value="privacy" className="select-item">
+                  <Select.ItemIndicator className="select-item-indicator">
+                    <Check />
+                  </Select.ItemIndicator>
+                  <Select.ItemText>Public vs. Private</Select.ItemText>
+                </Select.Item>
+              </Select.Viewport>
+            </Select.Content>
+          </Select.Portal>
+        </Select.Root>
+      </form>
+    </div>
+  )
+
+}

--- a/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.tsx
+++ b/src/components/AnnotationDesktop/StyleConfiguration/StyleConfiguration.tsx
@@ -1,22 +1,41 @@
 import { useState } from 'react';
 import * as Select from '@radix-ui/react-select';
 import { CaretDown, Check } from '@phosphor-icons/react';
+import { Visibility, type Annotation, type Formatter } from '@annotorious/react';
+import type { Translations } from 'src/Types';
 
 import './StyleConfiguration.css';
 
 interface StyleConfigurationProps {
+
+  i18n: Translations;
+
+  onChange(formatter?: Formatter): void;
   
 }
 
+const PRIVACY_FORMATTER: Formatter = (annotation: Annotation) => ({
+  fill: annotation.visibility === Visibility.PRIVATE ? 0xff0000 : 0x0000ff
+});
+
 export const StyleConfiguration = (props: StyleConfigurationProps) => {
 
-  const [value, setValue] = useState('privacy');
+  const [value, setValue] = useState('none');
+
+  const onValueChange = (value: string) => {
+    setValue(value);
+
+    if (value === 'none')
+      props.onChange();
+    else if (value === 'privacy')
+      props.onChange(PRIVACY_FORMATTER);
+  }
 
   return (
     <div className="anno-sidepanel style-configuration">
       <form>
         <label>Color by</label>
-        <Select.Root value={value} onValueChange={setValue}>
+        <Select.Root value={value} onValueChange={onValueChange}>
           <Select.Trigger className="select-trigger" aria-label="Annotation color by">
             <Select.Value />
             <Select.Icon className="select-icon">
@@ -27,12 +46,19 @@ export const StyleConfiguration = (props: StyleConfigurationProps) => {
           <Select.Portal>
             <Select.Content className="select-content">
               <Select.Viewport className="select-viewport">
+                <Select.Item value="none" className="select-item">
+                  <Select.ItemIndicator className="select-item-indicator">
+                    <Check />
+                  </Select.ItemIndicator>
+                  <Select.ItemText>No color coding</Select.ItemText>
+                </Select.Item>
+
                 <Select.Item value="privacy" className="select-item">
                   <Select.ItemIndicator className="select-item-indicator">
                     <Check />
                   </Select.ItemIndicator>
                   <Select.ItemText>Public vs. Private</Select.ItemText>
-                </Select.Item>
+                </Select.Item> 
               </Select.Viewport>
             </Select.Content>
           </Select.Portal>

--- a/src/components/AnnotationDesktop/StyleConfiguration/index.ts
+++ b/src/components/AnnotationDesktop/StyleConfiguration/index.ts
@@ -1,0 +1,1 @@
+export * from './StyleConfiguration';

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.css
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.css
@@ -60,5 +60,11 @@
   flex-grow: 1;
   overflow-y: auto;
   pointer-events: all;
+  position: relative;
+}
+
+.anno-sidebar-container aside > div {
+  position: absolute;
+  top: 0;
 }
 

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
@@ -7,6 +7,7 @@ import type { Annotation, PresentUser } from '@annotorious/react';
 import type { Translations } from 'src/Types';
 import { AnnotationList } from '../AnnotationList';
 import { ViewMenuPanel } from './ViewMenuPanel';
+import { StyleConfiguration } from '../StyleConfiguration';
 
 import './ViewMenu.css';
 
@@ -33,7 +34,7 @@ export const ViewMenu = (props: ViewMenuProps) => {
     enter: { opacity: 1, width: 140 },
     leave: { opacity: 0, width: 0 }, 
     config: {
-      duration: 125
+      duration: 0
     }
   });
 
@@ -67,7 +68,9 @@ export const ViewMenu = (props: ViewMenuProps) => {
             <Chats />
           </button>
 
-          <button>
+          <button
+            className={panel === ViewMenuPanel.STYLE ? 'active' : undefined}
+            onClick={() => togglePanel(ViewMenuPanel.STYLE)}>
             <StackSimple />
           </button>
 
@@ -95,16 +98,18 @@ export const ViewMenu = (props: ViewMenuProps) => {
         ))}
       </div>
 
-      {panelTransition((style, panel) => panel && (
-        <animated.aside style={style}>
-          {panel === ViewMenuPanel.ANNOTATIONS && (
+      {panel && (
+          <aside>
+          {panel === ViewMenuPanel.ANNOTATIONS ? (
             <AnnotationList 
               i18n={props.i18n}
               present={props.present} 
               beforeSelect={props.beforeSelectAnnotation} />
-          )}
-        </animated.aside>
-      ))}
+          ) : panel === ViewMenuPanel.STYLE ? (
+            <StyleConfiguration />
+          ) : undefined}
+        </aside>
+      )}
     </div>
   )
 

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
@@ -3,7 +3,7 @@ import { Chats, MagnifyingGlass, StackSimple, X } from '@phosphor-icons/react';
 import { useTransition, animated } from '@react-spring/web'
 import { Avatar } from '@components/Avatar';
 import { isMe } from '@annotorious/react';
-import type { Annotation, PresentUser } from '@annotorious/react';
+import type { Annotation, Formatter, PresentUser } from '@annotorious/react';
 import type { Translations } from 'src/Types';
 import { AnnotationList } from '../AnnotationList';
 import { ViewMenuPanel } from './ViewMenuPanel';
@@ -17,9 +17,11 @@ interface ViewMenuProps {
 
   present: PresentUser[];
 
-  onChangePanel(panel: ViewMenuPanel | undefined): void;
-
   beforeSelectAnnotation(a?: Annotation): void;
+
+  onChangePanel(panel?: ViewMenuPanel): void;
+
+  onChangeStyleConfig(formatter?: Formatter): void;
 
 }
 
@@ -106,7 +108,9 @@ export const ViewMenu = (props: ViewMenuProps) => {
               present={props.present} 
               beforeSelect={props.beforeSelectAnnotation} />
           ) : panel === ViewMenuPanel.STYLE ? (
-            <StyleConfiguration />
+            <StyleConfiguration 
+              i18n={props.i18n}
+              onChange={props.onChangeStyleConfig} />
           ) : undefined}
         </aside>
       )}

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenuPanel.ts
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenuPanel.ts
@@ -2,7 +2,7 @@ export enum ViewMenuPanel {
 
   ANNOTATIONS = 'ANNOTATIONS', 
   
-  LAYERS = 'LAYERS', 
+  STYLE = 'STYLE', 
   
   SEARCH = 'SEARCH'
 

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -38,6 +38,7 @@
   display: block;
   display: -webkit-box;
   font-size: var(--font-tiny);
+  height: 3.2em;
   line-clamp: 2;
   line-height: 160%;
   overflow: hidden;

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -19,7 +19,7 @@ interface ProjectCardProps {
 
 export const ProjectCard = (props: ProjectCardProps) => {
 
-  const { layers, id, groups, name } = props.project;
+  const { description, layers, id, groups, name } = props.project;
 
   const members = groups.reduce((members, group) => (
     [...members, ...group.members]
@@ -45,13 +45,17 @@ export const ProjectCard = (props: ProjectCardProps) => {
     <div className="project-card">
       <div className="project-card-body" onClick={onClick}>
         <h1><a href={`/${props.i18n.lang}/projects/${id}`}>{name}</a></h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt 
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
-          ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in 
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
-          occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </p>
+        {description ? (
+          <p>{description}</p>
+        ) : (
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt 
+            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
+            ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in 
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
+            occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        )}
         <ul className="document-stats">
           {images.length > 0 && (
             <li>

--- a/src/components/TinySaveIndicator/TinySaveIndicator.tsx
+++ b/src/components/TinySaveIndicator/TinySaveIndicator.tsx
@@ -16,7 +16,9 @@ interface TinySaveIndicatorProps {
 
 export const TinySaveIndicator = (props: TinySaveIndicatorProps) => {
 
-  const { fadeOut, state } = props;
+  const { state } = props;
+
+  const fadeOut = props.fadeOut || 5000;
 
   const [opacity, setOpacity] = useState(1);
 

--- a/src/themes/default/button/index.css
+++ b/src/themes/default/button/index.css
@@ -1,4 +1,5 @@
 @import './danger.css';
+@import './minimal.css';
 @import './primary.css';
 @import './success.css';
 @import './unstyled.css';

--- a/src/themes/default/button/minimal.css
+++ b/src/themes/default/button/minimal.css
@@ -1,0 +1,10 @@
+button.minimal, a[href].button.minimal {
+  background-color: transparent;
+  border-color: var(--gray-500);
+  border-radius: 99999px;
+  border-style: dashed;
+  color: var(--font-light);
+  font-size: 11px;
+  line-height: 100%;
+  padding: 3px 9px 3px 4px;
+}

--- a/src/themes/default/button/unstyled.css
+++ b/src/themes/default/button/unstyled.css
@@ -5,10 +5,14 @@ button.unstyled {
   box-shadow: none;
   color: var(--font-light);
   cursor: pointer;
-  display: inline;
   font-size: var(--font-small);
   margin: 0;
   padding: 0;
+}
+
+button.unstyled svg {
+  position: relative;
+  top: -1px;
 }
 
 button.unstyled:disabled {

--- a/src/themes/default/index.css
+++ b/src/themes/default/index.css
@@ -191,7 +191,7 @@ h1 {
   font-size: 1.6em;
   font-weight: 600;
   letter-spacing: 0.02ch;
-  margin: 1em 0;
+  margin: 0.8em 0;
   padding: 0;
 }
 


### PR DESCRIPTION
## In this PR

This PR adds the feature request from [issue #105](https://github.com/performant-software/vico/issues/105): editable project descriptions.

There's a new button underneath the project title __Add a project description__.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 34 33" src="https://github.com/recogito/recogito-client/assets/470971/fa20b7cb-4dfa-4fcf-bec8-90c5b1fee398">

The button will open a text area & a row of buttons to Save/Cancel/Clear the project description.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 34 50" src="https://github.com/recogito/recogito-client/assets/470971/bbc3fe11-a832-406c-bf03-5db48770fad8">

When a description exists, hovering the mouse over the description will emphasize it. Clicking will open the description in the text area for editing.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 37 22" src="https://github.com/recogito/recogito-client/assets/470971/fb548736-7e07-49b3-93d3-cfab652042f8">

