### PR TITLE
Editable Project Descriptions (fixed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "unnamed-frontend",
+  "name": "recogito-client",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "unnamed-frontend",
+      "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
         "@annotorious/react": "^3.0.0-pre-alpha-28",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "unnamed-frontend",
+  "name": "recogito-client",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -36,7 +36,7 @@ export interface Project {
 
   name: string;
 
-  description: string;
+  description?: string;
 
 }
 
@@ -58,7 +58,7 @@ export interface ExtendedProjectData {
 
   name: string;
 
-  description: string;
+  description?: string;
 
   contexts: Context[];
 

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.css
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.css
@@ -29,6 +29,27 @@
   width: 60ch;
 }
 
+.project-description .buttons button {
+  border-radius: var(--border-radius);
+  font-weight: 500;
+  padding: 0.3em 0.5em 0.2em 0.3em;
+}
+
+.project-description .buttons button:hover:not(:disabled) {
+  box-shadow: none;
+  color: var(--font-dark);
+  text-decoration: underline;
+}
+
+.project-description .buttons button:hover svg {
+  color: var(--font-dark);
+}
+
+.project-description .buttons button:disabled,
+.project-description .buttons button:disabled svg {
+  color: var(--gray-400);
+}
+
 .project-description .tiny-save-indicator {
   padding-left: 5px;
 } 

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.css
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.css
@@ -1,0 +1,35 @@
+.project-description {
+  margin-bottom: 3em;
+}
+
+.project-description p,
+.project-description textarea {
+  border: 1px dashed transparent;
+  border-radius: var(--border-radius);
+  font-size: var(--font-small);
+  line-height: 160%;
+  margin: 0 0 0 -8px;
+  padding: 5px 8px;
+}
+
+.project-description p {
+  color: var(--font-light);
+  cursor: pointer;
+  max-width: 60ch;
+  transition: all 250ms;
+}
+
+.project-description p:hover {
+  background-color: #e6eaf1;
+  border-color: var(--gray-400);
+}
+
+.project-description textarea {
+  resize: none;
+  width: 60ch;
+}
+
+.project-description .tiny-save-indicator {
+  padding-left: 5px;
+} 
+

--- a/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
@@ -1,0 +1,87 @@
+import { useRef, useState } from 'react';
+import { PlusCircle } from '@phosphor-icons/react';
+import type { PostgrestError } from '@supabase/supabase-js';
+import TextareaAutosize from 'react-textarea-autosize';
+import { updateProject } from '@backend/crud';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { SaveState, TinySaveIndicator } from '@components/TinySaveIndicator';
+import type { ExtendedProjectData, Translations } from 'src/Types';
+
+import './ProjectDescription.css';
+
+interface ProjectDescriptionProps {
+
+  i18n: Translations;
+
+  project: ExtendedProjectData;
+
+  onChanged(project: ExtendedProjectData): void;
+
+  onError(error: PostgrestError): void;
+
+}
+
+export const ProjectDescription = (props: ProjectDescriptionProps) => {
+
+  const [description, setDescription] = useState(props.project.description);
+
+  const el = useRef<HTMLTextAreaElement>(null);
+
+  const [editable, setEditable] = useState(false);
+
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+
+  const [value, setValue] = useState(description);
+
+  const onSave = () => {
+    const description = value.trim();
+
+    setDescription(description);
+    setSaveState('saving');
+    setEditable(false);
+
+    updateProject(supabase, { id: props.project.id, description })
+      .then(({ error }) => {
+        if (error) {
+          setSaveState('failed');
+          setDescription(props.project.description);
+          props.onError(error);
+        } else {
+          setSaveState('success');
+          setValue(description);
+          props.onChanged({ ...props.project, description });
+        }
+      });
+  }
+
+  // TODO needs an explicit button for accessibility
+  return (
+    <div className="project-description">
+      {editable ? (
+        <TextareaAutosize 
+          autoFocus
+          ref={el}
+          rows={1} 
+          maxRows={20}
+          value={value}
+          onChange={evt => setValue(evt.target.value)}
+          placeholder="Add a project description..." 
+          onBlur={onSave} />
+      ) : description ? (
+        <p onClick={() => setEditable(true)}>
+          {description}
+          {saveState !== 'idle' && (
+            <TinySaveIndicator 
+              state={saveState} 
+              fadeOut={1500} />
+          )}
+        </p>
+      ) : (
+        <button className="minimal" onClick={() => setEditable(true)}>
+          <PlusCircle size={16} /> <span>Add a project description</span>
+        </button>
+      )}
+    </div>
+  )
+
+}

--- a/src/apps/project-home/ProjectDescription/index.ts
+++ b/src/apps/project-home/ProjectDescription/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectDescription';

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -6,8 +6,8 @@
   position: relative;
 }
 
-.project-description {
-  padding: 0 0 1.5em 0;
+.project-home h1 {
+  margin-bottom: 0.5em;
 }
 
 .project-home-grid-wrapper {
@@ -20,7 +20,7 @@
   gap: 1rem;
   grid-auto-rows: 1fr;  
   grid-template-columns: repeat(auto-fill, 180px);
-  padding: 70px 0 40px 0;
+  padding: 2em 0 40px 0;
 }
 
 .dropzone-hint-wrapper {

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -6,6 +6,10 @@
   position: relative;
 }
 
+.project-description {
+  padding: 0 0 1.5em 0;
+}
+
 .project-home-grid-wrapper {
   flex-grow: 1;
   position: relative;

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CloudArrowUp } from '@phosphor-icons/react';
+import { CloudArrowUp, PlusCircle } from '@phosphor-icons/react';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { archiveLayer, renameDocument, updateProject } from '@backend/crud';
 import { DocumentCard } from '@components/DocumentCard';
@@ -158,6 +158,12 @@ export const ProjectHome = (props: ProjectHomeProps) => {
               value={project.name} 
               onSubmit={onRenameProject} />
           </h1>
+
+          <div className="project-description">
+            <button className="minimal">
+              <PlusCircle size={16} /> <span>Add Project Description</span>
+            </button>
+          </div>
           
           <UploadActions 
             i18n={props.i18n} 

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
-import { CloudArrowUp, PlusCircle } from '@phosphor-icons/react';
+import { CloudArrowUp } from '@phosphor-icons/react';
+import type { FileRejection } from 'react-dropzone';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { archiveLayer, renameDocument, updateProject } from '@backend/crud';
 import { DocumentCard } from '@components/DocumentCard';
 import { EditableText } from '@components/EditableText';
 import { Toast, ToastContent, ToastProvider } from '@components/Toast';
 import { UploadActions, UploadFormat, UploadTracker, useUpload, useDragAndDrop } from './upload';
+import { ProjectDescription } from './ProjectDescription';
 import type { DocumentInProject, ExtendedProjectData, Translations } from 'src/Types';
-import type { FileRejection } from 'react-dropzone';
 
 import './ProjectHome.css';
+import type { PostgrestError } from '@supabase/supabase-js';
 
 export interface ProjectHomeProps {
 
@@ -25,7 +27,7 @@ export const ProjectHome = (props: ProjectHomeProps) => {
 
   const { t } = props.i18n;
 
-  const { project } = props;
+  const [project, setProject] = useState(props.project);
 
   // Temporary hack!
   const defaultContext = project.contexts[0];
@@ -85,11 +87,10 @@ export const ProjectHome = (props: ProjectHomeProps) => {
   }
 
   const onRenameProject = (name: string) => {
-    updateProject(supabase, {
-      ...props.project, name
-    }).then(response => {
-      console.log(response);
-    });
+    updateProject(supabase, { id: project.id, name })
+      .then(response => {
+        console.log(response);
+      });
   }
 
   /**
@@ -149,6 +150,16 @@ export const ProjectHome = (props: ProjectHomeProps) => {
       });
   }
 
+  const onError = (error: PostgrestError, message: string) => {
+    console.error(error);
+
+    setToast({ 
+      title: t['Something went wrong'], 
+      description: t[message] || message, 
+      type: 'error' 
+    });
+  }
+
   return (
     <div className="project-home">
       <ToastProvider>
@@ -159,11 +170,11 @@ export const ProjectHome = (props: ProjectHomeProps) => {
               onSubmit={onRenameProject} />
           </h1>
 
-          <div className="project-description">
-            <button className="minimal">
-              <PlusCircle size={16} /> <span>Add Project Description</span>
-            </button>
-          </div>
+          <ProjectDescription 
+            i18n={props.i18n}
+            project={project} 
+            onChanged={setProject} 
+            onError={error => onError(error, 'Error updating project description.')} />
           
           <UploadActions 
             i18n={props.i18n} 

--- a/src/backend/crud/projects.ts
+++ b/src/backend/crud/projects.ts
@@ -70,7 +70,7 @@ export const listMyProjects = (supabase: SupabaseClient): Response<Project[]> =>
       `)
       .then(({ error, data }) => ({ error, data: data as unknown as Project[] })));
 
-export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string }): Response<Project> =>
+export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string | null }): Response<Project> =>
   supabase 
     .from('projects')
     .update({...partial })

--- a/src/backend/crud/projects.ts
+++ b/src/backend/crud/projects.ts
@@ -70,11 +70,11 @@ export const listMyProjects = (supabase: SupabaseClient): Response<Project[]> =>
       `)
       .then(({ error, data }) => ({ error, data: data as unknown as Project[] })));
 
-export const updateProject = (supabase: SupabaseClient, project: Project): Response<Project> =>
+export const updateProject = (supabase: SupabaseClient, partial: { id: string, [key: string]: string }): Response<Project> =>
   supabase 
     .from('projects')
-    .update({...project })
-    .eq('id', project.id)
+    .update({...partial })
+    .eq('id', partial.id)
     .select()
     .single()
     .then(({ error, data }) => ({ error, data: data as Project }));

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -38,6 +38,7 @@
   display: block;
   display: -webkit-box;
   font-size: var(--font-tiny);
+  height: 3.2em;
   line-clamp: 2;
   line-height: 160%;
   overflow: hidden;

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -19,7 +19,7 @@ interface ProjectCardProps {
 
 export const ProjectCard = (props: ProjectCardProps) => {
 
-  const { layers, id, groups, name } = props.project;
+  const { description, layers, id, groups, name } = props.project;
 
   const members = groups.reduce((members, group) => (
     [...members, ...group.members]
@@ -45,13 +45,17 @@ export const ProjectCard = (props: ProjectCardProps) => {
     <div className="project-card">
       <div className="project-card-body" onClick={onClick}>
         <h1><a href={`/${props.i18n.lang}/projects/${id}`}>{name}</a></h1>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt 
-          ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
-          ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in 
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
-          occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </p>
+        {description ? (
+          <p>{description}</p>
+        ) : (
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt 
+            ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
+            ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in 
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint 
+            occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+        )}
         <ul className="document-stats">
           {images.length > 0 && (
             <li>

--- a/src/components/TinySaveIndicator/TinySaveIndicator.tsx
+++ b/src/components/TinySaveIndicator/TinySaveIndicator.tsx
@@ -16,7 +16,9 @@ interface TinySaveIndicatorProps {
 
 export const TinySaveIndicator = (props: TinySaveIndicatorProps) => {
 
-  const { fadeOut, state } = props;
+  const { state } = props;
+
+  const fadeOut = props.fadeOut || 5000;
 
   const [opacity, setOpacity] = useState(1);
 

--- a/src/themes/default/button/index.css
+++ b/src/themes/default/button/index.css
@@ -1,4 +1,5 @@
 @import './danger.css';
+@import './minimal.css';
 @import './primary.css';
 @import './success.css';
 @import './unstyled.css';

--- a/src/themes/default/button/minimal.css
+++ b/src/themes/default/button/minimal.css
@@ -1,0 +1,10 @@
+button.minimal, a[href].button.minimal {
+  background-color: transparent;
+  border-color: var(--gray-500);
+  border-radius: 99999px;
+  border-style: dashed;
+  color: var(--font-light);
+  font-size: 11px;
+  line-height: 100%;
+  padding: 3px 9px 3px 4px;
+}

--- a/src/themes/default/button/unstyled.css
+++ b/src/themes/default/button/unstyled.css
@@ -5,10 +5,14 @@ button.unstyled {
   box-shadow: none;
   color: var(--font-light);
   cursor: pointer;
-  display: inline;
   font-size: var(--font-small);
   margin: 0;
   padding: 0;
+}
+
+button.unstyled svg {
+  position: relative;
+  top: -1px;
 }
 
 button.unstyled:disabled {

--- a/src/themes/default/index.css
+++ b/src/themes/default/index.css
@@ -191,7 +191,7 @@ h1 {
   font-size: 1.6em;
   font-weight: 600;
   letter-spacing: 0.02ch;
-  margin: 1em 0;
+  margin: 0.8em 0;
   padding: 0;
 }
 


### PR DESCRIPTION
## In this PR

This PR adds the feature request from [issue #105](https://github.com/performant-software/vico/issues/105): editable project descriptions.

There's a new button underneath the project title __Add a project description__.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 34 33" src="https://github.com/recogito/recogito-client/assets/470971/fa20b7cb-4dfa-4fcf-bec8-90c5b1fee398">

The button will open a text area & a row of buttons to Save/Cancel/Clear the project description.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 34 50" src="https://github.com/recogito/recogito-client/assets/470971/bbc3fe11-a832-406c-bf03-5db48770fad8">

When a description exists, hovering the mouse over the description will emphasize it. Clicking will open the description in the text area for editing.

<img width="631" alt="Bildschirmfoto 2023-08-01 um 15 37 22" src="https://github.com/recogito/recogito-client/assets/470971/fb548736-7e07-49b3-93d3-cfab652042f8">

