### PR TITLE
Edit project details

### DIFF
--- a/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
+++ b/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
@@ -7,9 +7,11 @@ export interface ProjectsGridProps {
 
   projects: ExtendedProjectData[];
 
-  onDeleteProject(project: ExtendedProjectData): void;
+  onProjectDeleted(project: ExtendedProjectData): void;
 
-  onRenameProject(project: ExtendedProjectData): void;
+  onDetailsChanged(project: ExtendedProjectData): void;
+
+  onError(error: string): void;
 
 }
 
@@ -24,8 +26,9 @@ export const ProjectsGrid = (props: ProjectsGridProps) => {
               key={project.id} 
               i18n={props.i18n}
               project={project} 
-              onDelete={() => props.onDeleteProject(project)} 
-              onRename={() => props.onRenameProject(project)}/>
+              onDeleted={() => props.onProjectDeleted(project)} 
+              onDetailsChanged={props.onDetailsChanged} 
+              onError={props.onError} />
           ))}
         </div>
       </section>

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -63,14 +63,8 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
   const onProjectCreated = (project: ExtendedProjectData) =>
     setProjects([...projects, project]);
 
-  const onRenameProject = (project: ExtendedProjectData) => {
-    setError({
-      icon: <Hammer size={16} className="text-bottom" />,
-      title: t['We\'re working on it!'],
-      description: t['This feature will become available soon.'],
-      type: 'info'
-    });
-  }
+  const onDetailsChanged = (project: ExtendedProjectData) =>
+    setProjects(projects => projects.map(p => p.id === project.id ? project : p));
     
   const onDeleteProject = (project: ExtendedProjectData) =>
     archiveProject(supabase, project.id)
@@ -122,8 +116,9 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           <ProjectsGrid 
             i18n={props.i18n} 
             projects={filteredProjects} 
-            onDeleteProject={onDeleteProject} 
-            onRenameProject={onRenameProject} />  
+            onProjectDeleted={onDeleteProject} 
+            onDetailsChanged={onDetailsChanged} 
+            onError={onError} />  
         )}
       </div>
 

--- a/src/apps/project-collaboration/InviteUser/InviteUser.css
+++ b/src/apps/project-collaboration/InviteUser/InviteUser.css
@@ -1,3 +1,0 @@
-.dialog-content.invite-users form .field {
-  font-size: var(--font-tiny);
-}

--- a/src/apps/project-collaboration/InviteUser/InviteUser.tsx
+++ b/src/apps/project-collaboration/InviteUser/InviteUser.tsx
@@ -8,8 +8,6 @@ import { Button } from '@components/Button';
 import type { ExtendedProjectData, Invitation, Translations, UserProfile } from 'src/Types';
 import type { PostgrestError } from '@supabase/supabase-js';
 
-import './InviteUser.css';
-
 interface InviteUserProps {
 
   i18n: Translations;

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -11,9 +11,11 @@ interface ProjectCardProps {
 
   project: ExtendedProjectData;
 
-  onDelete(): void;
+  onDeleted(): void;
 
-  onRename(): void;
+  onDetailsChanged(updated: ExtendedProjectData): void;
+
+  onError(error: string): void;
 
 }
 
@@ -82,10 +84,13 @@ export const ProjectCard = (props: ProjectCardProps) => {
               avatar={user.avatar_url} />
           ))}
         </div>
+
         <ProjectCardActions
           i18n={props.i18n}
-          onDelete={props.onDelete} 
-          onRename={props.onRename}/>
+          project={props.project}
+          onDeleted={props.onDeleted} 
+          onDetailsChanged={props.onDetailsChanged}
+          onError={props.onError} />
       </div>
     </div>
   )

--- a/src/components/ProjectCard/ProjectCardActions.tsx
+++ b/src/components/ProjectCard/ProjectCardActions.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { DotsThreeVertical, PencilSimple, Trash } from '@phosphor-icons/react';
-import type { Translations } from 'src/Types';
+import type { ExtendedProjectData, Translations } from 'src/Types';
+import { ProjectDetailsForm } from './ProjectDetailsForm';
 
 const { Content, Item, Portal, Root, Trigger } = Dropdown;
 
@@ -8,9 +10,13 @@ export interface ProjectCardActionsProps {
 
   i18n: Translations;
 
-  onDelete(): void;
+  project: ExtendedProjectData;
 
-  onRename(): void;
+  onDeleted(): void;
+
+  onDetailsChanged(updated: ExtendedProjectData): void;
+
+  onError(error: string): void;
 
 }
 
@@ -18,26 +24,48 @@ export const ProjectCardActions = (props: ProjectCardActionsProps) => {
 
   const { t } = props.i18n;
 
+  const [editing, setEditing] = useState(false);
+
+  const onDetailsSaved = (updated: ExtendedProjectData) => {
+    setEditing(false);
+    props.onDetailsChanged(updated);
+  }
+
+  const onDetailsError = (error: string) => {
+    setEditing(false);
+    props.onError(error);
+  }
+
   return (
-    <Root>
-      <Trigger asChild>
-        <button className="unstyled icon-only project-card-actions">
-          <DotsThreeVertical weight="bold" size={20}/>
-        </button>
-      </Trigger>
+    <>
+      <Root>
+        <Trigger asChild>
+          <button className="unstyled icon-only project-card-actions">
+            <DotsThreeVertical weight="bold" size={20}/>
+          </button>
+        </Trigger>
 
-      <Portal>
-        <Content className="dropdown-content no-icons" sideOffset={5} align="start">
-          <Item className="dropdown-item" onSelect={props.onDelete}>
-            <Trash size={16} /> <span>{t['Delete project']}</span>
-          </Item>
+        <Portal>
+          <Content className="dropdown-content no-icons" sideOffset={5} align="start">
+            <Item className="dropdown-item" onSelect={props.onDeleted}>
+              <Trash size={16} /> <span>{t['Delete project']}</span>
+            </Item>
 
-          <Item className="dropdown-item" onSelect={props.onRename}>
-            <PencilSimple size={16} /> <span>{t['Rename project']}</span>
-          </Item>
-        </Content>
-      </Portal>
-    </Root>
+            <Item className="dropdown-item" onSelect={() => setEditing(true)}>
+              <PencilSimple size={16} /> <span>{t['Edit project details']}</span>
+            </Item>
+          </Content>
+        </Portal>
+      </Root>
+
+      <ProjectDetailsForm 
+        i18n={props.i18n} 
+        project={props.project}
+        open={editing}
+        onSaved={onDetailsSaved} 
+        onCancel={() => setEditing(false)}
+        onError={onDetailsError} />
+    </>
   )
 
 }

--- a/src/components/ProjectCard/ProjectDetailsForm.tsx
+++ b/src/components/ProjectCard/ProjectDetailsForm.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import TextareaAutosize from 'react-textarea-autosize';
+import { useFormik } from 'formik';
+import { updateProject } from '@backend/crud';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { Button } from '@components/Button';
+import type { ExtendedProjectData, Translations } from 'src/Types';
+
+interface ProjectDetailsFormProps {
+
+  i18n: Translations;
+
+  open: boolean;
+
+  project: ExtendedProjectData;
+
+  onSaved(updated: ExtendedProjectData): void;
+
+  onCancel(): void;
+
+  onError(error: string): void;
+
+}
+
+export const ProjectDetailsForm = (props: ProjectDetailsFormProps) => {
+
+  const { t } = props.i18n;
+
+  const { project } = props;
+
+  const [busy, setBusy] = useState(false);
+
+  const onSubmit = (values: { name: string, description?: string }) => {
+    const { name, description } = values;
+
+    if (busy)
+      return;
+
+    setBusy(true);
+
+    updateProject(supabase, { 
+      id: project.id, 
+      name, 
+      description: description || null 
+    }).then(({ error }) => {
+      setBusy(false);
+
+      if (error)
+        props.onError('Error saving project details');
+      else
+        props.onSaved({ ...props.project, name, description });
+    });
+  }
+
+  const formik = useFormik({
+    initialValues: { 
+      name: project.name,
+      description: project.description
+    },
+    onSubmit
+  });
+
+  useEffect(() => {
+    formik.setValues({
+      name: props.project.name,
+      description: props.project.description
+    });
+  }, [props.open, props.project]);
+
+  return (
+    <Dialog.Root 
+      open={props.open} 
+      onOpenChange={() => !busy && props.onCancel()}>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialog-overlay" />
+
+        <Dialog.Content className="invite-users dialog-content">
+          <Dialog.Title className="dialog-title">
+            Project Details
+          </Dialog.Title>
+
+          <form onSubmit={formik.handleSubmit}>
+            <fieldset>
+              <div className="field">
+                <label>Name</label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  onChange={formik.handleChange}
+                  value={formik.values.name}
+                  placeholder="Project name..." 
+                  required />
+              </div>
+
+              <div className="field">
+                <label>Description</label>
+
+                <TextareaAutosize 
+                  id="description"
+                  name="description"
+                  rows={1} 
+                  maxRows={8}
+                  value={formik.values.description}
+                  onChange={formik.handleChange}
+                  placeholder="Project description..." />
+              </div>
+            </fieldset>
+
+            <Button 
+              busy={busy}
+              className="primary" 
+              type="submit">
+
+              <span>
+                Ok
+              </span>
+            </Button>
+
+            <button onClick={props.onCancel}>Cancel</button>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+
+}

--- a/src/i18n/de/dashboard-projects.json
+++ b/src/i18n/de/dashboard-projects.json
@@ -15,7 +15,7 @@
   "Sort": "Sortieren",
 
   "Delete project": "Projekt löschen",
-  "Rename project": "Projekt umbenennen",
+  "Edit project details": "Projektinformationen bearbeiten",
 
   "Something went wrong": "Etwas ist schiefgelaufen",
   "Could not create the project.": "Das Projekt konnte nicht erstellt werden.",

--- a/src/i18n/en/dashboard-projects.json
+++ b/src/i18n/en/dashboard-projects.json
@@ -15,7 +15,7 @@
   "Sort": "Sort",
 
   "Delete project": "Delete project",
-  "Rename project": "Rename project",
+  "Edit project details": "Edit project details",
 
   "Something went wrong": "Something went wrong",
   "Could not create the project.": "Could not create the project.",

--- a/src/themes/default/dialog/index.css
+++ b/src/themes/default/dialog/index.css
@@ -22,6 +22,10 @@
   padding: 25px;
 }
 
+.dialog-content form .field {
+  font-size: var(--font-tiny);
+}
+
 @keyframes dialogEnter {
   from {
     opacity: 0;

--- a/src/themes/default/form/index.css
+++ b/src/themes/default/form/index.css
@@ -2,12 +2,15 @@
 
 fieldset {
   border: none;
-  margin: 1.5em 0 2.5em 0;
+  margin: 2.5em 0 1.5em 0;
   padding: 0;
 }
 
 form .field {
-  margin: 1em 0;
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  margin: 0.5em 0 1.5em 0;
 }
 
 form .field label {
@@ -15,8 +18,13 @@ form .field label {
   width: 100px;
 }
 
-form .field input {
+form .field input,
+form .field textarea {
   width: 320px;
+}
+
+form .field textarea {
+  resize: none;
 }
 
 form select {


### PR DESCRIPTION
## In this PR

This PR implements missing functionality from the Project Card dropdown menu in the Dashboard. Instead of "Rename Project", the menu option now says "Edit project details". Selecting this option opens a dialog form for the project name and description text.

<img width="597" alt="Bildschirmfoto 2023-08-02 um 16 23 15" src="https://github.com/recogito/recogito-client/assets/470971/4ecaffea-fcb8-42f9-b38d-e628661b15b1">

<img width="674" alt="Bildschirmfoto 2023-08-02 um 16 23 33" src="https://github.com/recogito/recogito-client/assets/470971/4f5a8c2d-a46a-473d-8cb8-808277080715">

Note that the UI labels are not localized yet. (Coming tomorrow!)
