### PR TITLE
Counter badges for dashboard filter tabs

### DIFF
--- a/src/apps/dashboard-projects/Header/Header.css
+++ b/src/apps/dashboard-projects/Header/Header.css
@@ -65,7 +65,7 @@
 }
 
 .dashboard-header-bottom li + li {
-  margin-left: 10px;
+  margin-left: 18px;
 }
 
 .dashboard-header-bottom li button {

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -22,6 +22,8 @@ interface HeaderProps {
 
   filter: ProjectFilter;
 
+  counts: [number, number, number];
+
   onChangeFilter(f: ProjectFilter): void;
 
   onProjectCreated(project: ExtendedProjectData): void;
@@ -39,6 +41,8 @@ export const Header = (props: HeaderProps) => {
   const { t } = props.i18n;
   
   const { filter, onChangeFilter } = props;
+
+  const [all, mine, shared] = props.counts;
 
   // 'Create new project' button state
   const [creating, setCreating] = useState(false);
@@ -100,6 +104,11 @@ export const Header = (props: HeaderProps) => {
               className={filter === ProjectFilter.ALL ? 'active' : undefined}
               onClick={() => onChangeFilter(ProjectFilter.ALL)}>
               <button>{t['All']}</button>
+              
+              <span 
+                className={all === 0 ? 'badge disabled' : 'badge'}>
+                {all}
+              </span>
             </li>
           )}
 
@@ -107,12 +116,22 @@ export const Header = (props: HeaderProps) => {
             className={filter === ProjectFilter.MINE ? 'active' : undefined}
             onClick={() => onChangeFilter(ProjectFilter.MINE)}>
             <button>{t['My Projects']}</button>
+
+            <span 
+              className={mine === 0 ? 'badge disabled' : 'badge'}>
+              {mine}
+            </span>
           </li>
 
           <li
             className={filter === ProjectFilter.SHARED ? 'active' : undefined}
             onClick={() => onChangeFilter(ProjectFilter.SHARED)}>
             <button>{t['Shared with me']}</button>
+
+            <span 
+              className={shared === 0 ? 'badge disabled' : 'badge'}>
+              {shared}
+            </span>
           </li>
         </ul>
 

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -56,17 +56,23 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
       });
   }, []);
 
+  // Filtered projects
+  const myProjects = projects.filter(p => p.created_by?.id === me.id);
+
+  const sharedProjects = projects.filter(({ created_by, groups }) => 
+    groups.find(({ members }) => 
+      members.find(m => m.user.id === me.id) && me.id !== created_by?.id));
+
   const filteredProjects = 
     // All projects
     filter === ProjectFilter.ALL ?
       projects : 
     // Am I the creator?
     filter === ProjectFilter.MINE ? 
-      projects.filter(p => p.created_by?.id === me.id) : 
+      myProjects :
     // Am I one of the users in the groups?
     filter === ProjectFilter.SHARED ? 
-      projects.filter(({ created_by, groups }) => 
-        groups.find(({ members }) => members.find(m => m.user.id === me.id) && me.id !== created_by?.id)) : 
+      sharedProjects : 
     [];
 
   const onProjectCreated = (project: ExtendedProjectData) =>
@@ -132,6 +138,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           policies={policies}
           invitations={invitations} 
           filter={filter}
+          counts={[projects.length, myProjects.length, sharedProjects.length]}
           onChangeFilter={setFilter}
           onProjectCreated={onProjectCreated} 
           onInvitationAccepted={onInvitationAccepted}

--- a/src/themes/default/badge/index.css
+++ b/src/themes/default/badge/index.css
@@ -9,6 +9,11 @@
   height: 2em;
   justify-content: center;
   margin: 0 7px;
-  min-width: 18px;
+  min-width: 8px;
   padding: 0 10px;
+}
+
+.badge.disabled {
+  color: var(--gray-400);
+  background-color: var(--gray-100);
 }


### PR DESCRIPTION
## In this PR

This PR adds counter badges to the filter tabs in the Dashboard. 

<img width="577" alt="Bildschirmfoto 2023-08-11 um 09 42 39" src="https://github.com/recogito/recogito-client/assets/470971/e8248cb6-f1f5-4031-8bfc-40efe555f4b1">

Beta users had repeatedly reported that a project they had joined did not appear in their dashboard. This is (almost certainly) confusion over the tab filtering, caused by bad UX. 
- If you join a project it will, by design, only appear in your 'Shared with Me' tab.
- The default tab setting is 'My Projects'
- If a user has the filter set to 'My Projects' and joins a project, nothing will change. This makes it look like joining didn't work.

With this PR, joining a project will affect the counter value instantly. Badges are also in a "disabled" style while the count is 0. This means that a first-time user will see both a change in the counter value, as a well as a change in the color shade, which should provide slightly better feedback.

__Additional note:__ unlike admin  users, normal (Professor/Student) users do __not__ have an 'All Projects' filter setting! It was also commented by a beta user that this would be desirable. I removed the tab briefly before the beta test, because it's default behavior was to list all projects that SELECT query returned from the DB. 

This was fine for an Org Admin (who should see everything in the system). But not for a professor, who should not see projects they can't enter (but only "Mine" + "Shared" combined). This view is now made easier by @lwjameson recent RPC function. I will add this to the UI in a separate PR.