### PR TITLE
'All Projects' tab for non-admin users

### DIFF
--- a/src/apps/dashboard-projects/Header/Header.css
+++ b/src/apps/dashboard-projects/Header/Header.css
@@ -65,7 +65,7 @@
 }
 
 .dashboard-header-bottom li + li {
-  margin-left: 10px;
+  margin-left: 18px;
 }
 
 .dashboard-header-bottom li button {

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -99,18 +99,16 @@ export const Header = (props: HeaderProps) => {
 
       <section className="dashboard-header-bottom">
         <ul className="dashboard-header-tabs">
-          {props.me.isOrgAdmin && (
-            <li
-              className={filter === ProjectFilter.ALL ? 'active' : undefined}
-              onClick={() => onChangeFilter(ProjectFilter.ALL)}>
-              <button>{t['All']}</button>
-              
-              <span 
-                className={all === 0 ? 'badge disabled' : 'badge'}>
-                {all}
-              </span>
-            </li>
-          )}
+          <li
+            className={filter === ProjectFilter.ALL ? 'active' : undefined}
+            onClick={() => onChangeFilter(ProjectFilter.ALL)}>
+            <button>{t['All']}</button>
+            
+            <span 
+              className={all === 0 ? 'badge disabled' : 'badge'}>
+              {all}
+            </span>
+          </li>
 
           <li
             className={filter === ProjectFilter.MINE ? 'active' : undefined}

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -22,6 +22,8 @@ interface HeaderProps {
 
   filter: ProjectFilter;
 
+  counts: [number, number, number];
+
   onChangeFilter(f: ProjectFilter): void;
 
   onProjectCreated(project: ExtendedProjectData): void;
@@ -39,6 +41,8 @@ export const Header = (props: HeaderProps) => {
   const { t } = props.i18n;
   
   const { filter, onChangeFilter } = props;
+
+  const [all, mine, shared] = props.counts;
 
   // 'Create new project' button state
   const [creating, setCreating] = useState(false);
@@ -100,6 +104,11 @@ export const Header = (props: HeaderProps) => {
               className={filter === ProjectFilter.ALL ? 'active' : undefined}
               onClick={() => onChangeFilter(ProjectFilter.ALL)}>
               <button>{t['All']}</button>
+              
+              <span 
+                className={all === 0 ? 'badge disabled' : 'badge'}>
+                {all}
+              </span>
             </li>
           )}
 
@@ -107,12 +116,22 @@ export const Header = (props: HeaderProps) => {
             className={filter === ProjectFilter.MINE ? 'active' : undefined}
             onClick={() => onChangeFilter(ProjectFilter.MINE)}>
             <button>{t['My Projects']}</button>
+
+            <span 
+              className={mine === 0 ? 'badge disabled' : 'badge'}>
+              {mine}
+            </span>
           </li>
 
           <li
             className={filter === ProjectFilter.SHARED ? 'active' : undefined}
             onClick={() => onChangeFilter(ProjectFilter.SHARED)}>
             <button>{t['Shared with me']}</button>
+
+            <span 
+              className={shared === 0 ? 'badge disabled' : 'badge'}>
+              {shared}
+            </span>
           </li>
         </ul>
 

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -56,17 +56,23 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
       });
   }, []);
 
+  // Filtered projects
+  const myProjects = projects.filter(p => p.created_by?.id === me.id);
+
+  const sharedProjects = projects.filter(({ created_by, groups }) => 
+    groups.find(({ members }) => 
+      members.find(m => m.user.id === me.id) && me.id !== created_by?.id));
+
   const filteredProjects = 
     // All projects
     filter === ProjectFilter.ALL ?
       projects : 
     // Am I the creator?
     filter === ProjectFilter.MINE ? 
-      projects.filter(p => p.created_by?.id === me.id) : 
+      myProjects :
     // Am I one of the users in the groups?
     filter === ProjectFilter.SHARED ? 
-      projects.filter(({ created_by, groups }) => 
-        groups.find(({ members }) => members.find(m => m.user.id === me.id) && me.id !== created_by?.id)) : 
+      sharedProjects : 
     [];
 
   const onProjectCreated = (project: ExtendedProjectData) =>
@@ -132,6 +138,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           policies={policies}
           invitations={invitations} 
           filter={filter}
+          counts={[projects.length, myProjects.length, sharedProjects.length]}
           onChangeFilter={setFilter}
           onProjectCreated={onProjectCreated} 
           onInvitationAccepted={onInvitationAccepted}

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -63,10 +63,13 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
     groups.find(({ members }) => 
       members.find(m => m.user.id === me.id) && me.id !== created_by?.id));
 
+  // All projects are different for admins vs. mere mortals
+  const allProjects = me.isOrgAdmin ? projects : [...myProjects, ...sharedProjects];
+
   const filteredProjects = 
     // All projects
     filter === ProjectFilter.ALL ?
-      projects : 
+      allProjects :
     // Am I the creator?
     filter === ProjectFilter.MINE ? 
       myProjects :
@@ -138,7 +141,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           policies={policies}
           invitations={invitations} 
           filter={filter}
-          counts={[projects.length, myProjects.length, sharedProjects.length]}
+          counts={[allProjects.length, myProjects.length, sharedProjects.length]}
           onChangeFilter={setFilter}
           onProjectCreated={onProjectCreated} 
           onInvitationAccepted={onInvitationAccepted}

--- a/src/themes/default/badge/index.css
+++ b/src/themes/default/badge/index.css
@@ -9,6 +9,11 @@
   height: 2em;
   justify-content: center;
   margin: 0 7px;
-  min-width: 18px;
+  min-width: 8px;
   padding: 0 10px;
+}
+
+.badge.disabled {
+  color: var(--gray-400);
+  background-color: var(--gray-100);
 }


### PR DESCRIPTION
## In this PR

This is another PR in response to beta user feedback. People were confused when projects they joined didn't show up in the dashboard. (Because they'd only show up under "Shared with Me", and they might have been in "My Projects".)

This PR adds the "All Projects" back for non-admin users. If you are not an admin, the "All Projects" will simply display "Mine" + "Shared with Me" (rather than all projects actually returned from the backend, which may include additional projects you don't actually have access to.)

Here's a comparison of a what an Org Professor user will see vs. an Org Admin:

<img width="577" alt="Bildschirmfoto 2023-08-11 um 10 26 01" src="https://github.com/recogito/recogito-client/assets/470971/cc5b53c0-cf83-498b-9c71-5c4fddc8b9c3">


<img width="577" alt="Bildschirmfoto 2023-08-11 um 10 27 58" src="https://github.com/recogito/recogito-client/assets/470971/9a2eb5b0-f1c6-4d2f-a34a-54a2f764405f">
