### PR TITLE
contentEditable Text Field Fixes

### DIFF
--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -7,7 +7,21 @@
 }
 
 .project-home h1 {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.4em;
+}
+
+.project-home h1 > span {
+  display: inline-block;
+  border: 1px dashed transparent;
+  border-radius: var(--border-radius);
+  margin: 0 -8px;
+  padding: 2px 8px;
+}
+
+.project-home h1 > span:hover {
+  background-color: #e6eaf1;
+  border-color: var(--gray-400);
+  cursor: pointer;
 }
 
 .project-home-grid-wrapper {

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -4,11 +4,11 @@ import type { FileRejection } from 'react-dropzone';
 import type { PostgrestError } from '@supabase/supabase-js';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { getProjectPolicies } from '@backend/helpers';
-import { archiveLayer, renameDocument, updateProject } from '@backend/crud';
+import { archiveLayer, renameDocument } from '@backend/crud';
 import { DocumentCard } from '@components/DocumentCard';
-import { EditableText } from '@components/EditableText';
 import { Toast, ToastContent, ToastProvider } from '@components/Toast';
 import { UploadActions, UploadFormat, UploadTracker, useUpload, useDragAndDrop } from './upload';
+import { ProjectTitle } from './ProjectTitle';
 import { ProjectDescription } from './ProjectDescription';
 import type { Policies, DocumentInProject, ExtendedProjectData, Translations } from 'src/Types';
 
@@ -100,13 +100,6 @@ export const ProjectHome = (props: ProjectHomeProps) => {
     }]);
   }
 
-  const onRenameProject = (name: string) => {
-    updateProject(supabase, { id: project.id, name })
-      .then(response => {
-        console.log(response);
-      });
-  }
-
   /**
    * When 'deleting a document' we're actually just archiving
    * all the layers on this document in this project!
@@ -178,11 +171,7 @@ export const ProjectHome = (props: ProjectHomeProps) => {
     <div className="project-home">
       <ToastProvider>
         <div>
-          <h1>
-            <EditableText 
-              value={project.name} 
-              onSubmit={onRenameProject} />
-          </h1>
+          <ProjectTitle project={project} />
 
           <ProjectDescription 
             i18n={props.i18n}

--- a/src/apps/project-home/ProjectTitle/ProjectTitle.css
+++ b/src/apps/project-home/ProjectTitle/ProjectTitle.css
@@ -1,0 +1,8 @@
+.project-title .tiny-save-indicator {
+  margin-left: 0;
+  vertical-align: text-bottom;
+}
+
+.project-title:hover .tiny-save-indicator {
+  margin-left: 5px;
+}

--- a/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
+++ b/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { updateProject } from '@backend/crud';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { EditableText } from '@components/EditableText';
+import { SaveState, TinySaveIndicator } from '@components/TinySaveIndicator';
+import type { ExtendedProjectData } from 'src/Types';
+
+import './ProjectTitle.css';
+
+interface ProjectTitleProps {
+
+  project: ExtendedProjectData;
+
+  onChanged?(title: string): void;
+
+}
+
+export const ProjectTitle = (props: ProjectTitleProps) => {
+
+  const { project } = props;
+
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+
+  const onRenameProject = (name: string) => {
+    setSaveState('saving');
+
+    updateProject(supabase, { id: project.id, name })
+      .then(({ error }) => {
+        if (error) {
+          setSaveState('failed');
+        } else {
+          setSaveState('success');
+        }
+      })
+  }
+
+  return (
+    <h1 className="project-title">
+      <EditableText 
+        value={project.name} 
+        onSubmit={onRenameProject} />
+
+      {saveState !== 'idle' && (
+        <TinySaveIndicator 
+          state={saveState} 
+          fadeOut={1500}/>
+      )}
+    </h1>
+  )
+
+}

--- a/src/apps/project-home/ProjectTitle/index.ts
+++ b/src/apps/project-home/ProjectTitle/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectTitle';

--- a/src/components/DocumentCard/DocumentCard.css
+++ b/src/components/DocumentCard/DocumentCard.css
@@ -42,7 +42,7 @@
   display: block;
   display: -webkit-box;
   font-weight: 400;
-  height: 3.2em;
+  max-height: 3.2em;
   line-clamp: 2;
   overflow: hidden;
   overflow-wrap: anywhere;

--- a/src/components/EditableText/EditableText.css
+++ b/src/components/EditableText/EditableText.css
@@ -1,0 +1,3 @@
+.editable-text {
+  display: inline-block;
+}

--- a/src/layouts/project/ProjectLayout.astro
+++ b/src/layouts/project/ProjectLayout.astro
@@ -40,7 +40,9 @@ const cookie = Astro.cookies.get('x-project-sidebar-collapsed');
           </li>
 
           <li>
-            <a href=`/${lang}/projects/${project.id}`>{project.name}</a>
+            <a href=`/${lang}/projects/${project.id}`>
+              {project.name.length > 30 ? `${project.name.slice(0, 30)}...` : project.name}
+            </a>
           </li>
 
           <li>

--- a/src/themes/default/index.css
+++ b/src/themes/default/index.css
@@ -193,6 +193,7 @@ h1 {
   font-size: 1.6em;
   font-weight: 600;
   letter-spacing: 0.02ch;
+  line-height: 140%;
   margin: 0.8em 0;
   padding: 0;
 }


### PR DESCRIPTION
## In this PR

This PR fixes several UX/display issues with editable text labels which we, so far, have in two places:

- Project Title
- Document name (underneath the document cards, in the project document overview page)

The following fixes were made:

- Pasting text will remove the formatting (see also Usersnap report https://app.usersnap.com/#/projects/87c2a0f6-75c8-45e1-bc11-d7fce92ea6eb/list?date_desc&state_open).
- A length limit is applied when pasting (currently defaults to 256 characters) to prevent users from pasting excessively long texts as titles.
- In the breadcrumb, a 30-character length limit is applied to the project title. Longer titles will be truncated with an ellipsis.
- The project title now has a hover emphasis that matches that of the project description, to to indicate edit-ability.
- The `TinySaveIndicator` icon was added, to show save status after editing the project title.
- Minor CSS tweaks were made to the document name labels.

<img width="666" alt="Bildschirmfoto 2023-08-14 um 11 28 49" src="https://github.com/recogito/recogito-client/assets/470971/42b7ddee-f3d4-4804-9345-d438e8c1c00d">

