### PR TITLE
implemented limit of five on displayed avatars

### DIFF
--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -16,6 +16,7 @@ import {
 import './TextAnnotationDesktop.css';
 
 import '@recogito/react-text-annotator/dist/react-text-annotator.css';
+import { PresenceViewMoreButton } from '@components/Presence/PresenceViewMoreButton';
 
 const SUPABASE = import.meta.env.PUBLIC_SUPABASE;
 
@@ -42,6 +43,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
   const [usePopup, setUsePopup] = useState(true);
 
   const [privacy, setPrivacy] = useState<PrivacyMode>('PUBLIC');
+
+  //max number of avatars displayed in the top right
+  const limit = 5;
 
   const onChangeViewMenuPanel = (panel: ViewMenuPanel | undefined) => {
     if (panel === ViewMenuPanel.ANNOTATIONS) {
@@ -92,8 +96,17 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
         )}
 
         <div className="anno-desktop-right not-annotatable">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '50px', zIndex: 3 }}>
           <PresenceStack
-            present={present} />
+            present={present}
+            limit={limit} />
+
+          { present.length > limit+1 && (
+            <PresenceViewMoreButton
+              present={present}
+              limit={limit} />
+          )}
+          </div>
 
           <AnnotationDesktop.ViewMenu 
             i18n={i18n}

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -96,17 +96,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
         )}
 
         <div className="anno-desktop-right not-annotatable">
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '50px', zIndex: 3 }}>
           <PresenceStack
             present={present}
             limit={limit} />
-
-          { present.length > limit+1 && (
-            <PresenceViewMoreButton
-              present={present}
-              limit={limit} />
-          )}
-          </div>
 
           <AnnotationDesktop.ViewMenu 
             i18n={i18n}

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -3,6 +3,7 @@ import { animated, useTransition } from '@react-spring/web';
 import { Avatar } from '@components/Avatar';
 
 import './PresenceStack.css';
+import { PresenceViewMoreButton } from './PresenceViewMoreButton';
 
 interface PresenceStackProps {
 
@@ -31,23 +32,26 @@ export const PresenceStack = (props: PresenceStackProps) => {
   });
 
   return (
-    <div className="presence-stack">
-      <ul>
-        {transition((style, presentUser) => (
-          <animated.li 
-            style={{ 
-              ...style, 
-              ...{'--presence-color': presentUser.appearance.color }
-            }} 
-            key={presentUser.presenceKey}>
-            <Avatar 
-              id={presentUser.id}
-              name={presentUser.appearance.label}
-              color={presentUser.appearance.color} 
-              avatar={presentUser.appearance.avatar} />
-          </animated.li>
-        ))}
-      </ul>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '50px' }}>
+      <div className="presence-stack">
+        <ul>
+          {transition((style, presentUser) => (
+            <animated.li 
+              style={{ 
+                ...style, 
+                ...{'--presence-color': presentUser.appearance.color }
+              }} 
+              key={presentUser.presenceKey}>
+              <Avatar 
+                id={presentUser.id}
+                name={presentUser.appearance.label}
+                color={presentUser.appearance.color} 
+                avatar={presentUser.appearance.avatar} />
+            </animated.li>
+          ))}
+        </ul>
+      </div>
+      { present.length > limit && <PresenceViewMoreButton limit={limit} present={present} /> }
     </div>
   )
 

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -15,16 +15,13 @@ interface PresenceStackProps {
 }
 
 export const PresenceStack = (props: PresenceStackProps) => {
-  console.log(props.present);
 
-  const { limit = 3 } = props;
+  const { limit = 5 } = props;
 
   const present = props.showMe ? 
     props.present : props.present.filter(u => !isMe(u));
 
-  const displayList = present.length <= limit ? present : [ ...present.slice(0, limit), { presenceKey: '0', presentList: present.slice(limit+1, undefined), appearance: { label: `+ ${present.length - limit} more`, color: 'white' } }];
-  console.log(displayList);
-  const transition = useTransition(displayList, {
+  const transition = useTransition(present.slice(0, limit), {
     from: { opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 }, 
@@ -43,11 +40,11 @@ export const PresenceStack = (props: PresenceStackProps) => {
               ...{'--presence-color': presentUser.appearance.color }
             }} 
             key={presentUser.presenceKey}>
-            {presentUser.presenceKey != '0' ? <Avatar 
+            <Avatar 
               id={presentUser.id}
               name={presentUser.appearance.label}
               color={presentUser.appearance.color} 
-              avatar={presentUser.appearance.avatar} /> : <></>}
+              avatar={presentUser.appearance.avatar} />
           </animated.li>
         ))}
       </ul>

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -10,14 +10,21 @@ interface PresenceStackProps {
 
   present: PresentUser[];
 
+  limit?: number;
+
 }
 
 export const PresenceStack = (props: PresenceStackProps) => {
+  console.log(props.present);
+
+  const { limit = 3 } = props;
 
   const present = props.showMe ? 
     props.present : props.present.filter(u => !isMe(u));
 
-  const transition = useTransition(present, {
+  const displayList = present.length <= limit ? present : [ ...present.slice(0, limit), { presenceKey: '0', presentList: present.slice(limit+1, undefined), appearance: { label: `+ ${present.length - limit} more`, color: 'white' } }];
+  console.log(displayList);
+  const transition = useTransition(displayList, {
     from: { opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 }, 
@@ -36,11 +43,11 @@ export const PresenceStack = (props: PresenceStackProps) => {
               ...{'--presence-color': presentUser.appearance.color }
             }} 
             key={presentUser.presenceKey}>
-            <Avatar 
+            {presentUser.presenceKey != '0' ? <Avatar 
               id={presentUser.id}
               name={presentUser.appearance.label}
               color={presentUser.appearance.color} 
-              avatar={presentUser.appearance.avatar} />
+              avatar={presentUser.appearance.avatar} /> : <></>}
           </animated.li>
         ))}
       </ul>

--- a/src/components/Presence/PresenceViewMoreButton.css
+++ b/src/components/Presence/PresenceViewMoreButton.css
@@ -12,7 +12,7 @@
 }
 
 .presence-view-more-content {
-    min-width: 220px;
+    min-width: 150px;
     background-color: white;
     border-radius: 6px;
     padding: 5px;
@@ -21,9 +21,11 @@
     animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
     will-change: transform, opacity;  
     cursor: default;
+    max-height: 50vh;
+    overflow-y: scroll;
 }
 
-.presence-view-more-item {
+.presence-view-more-content li {
     display: flex;
     align-items: center;
     padding: 5px;
@@ -31,7 +33,6 @@
     border-radius: 5px;
 }
 
-.presence-view-more-item[data-highlighted] {
-    border-style: none;
-    background-color: rgb(226, 226, 226)
+.presence-view-more-content ul {
+    padding-left: 0;
 }

--- a/src/components/Presence/PresenceViewMoreButton.css
+++ b/src/components/Presence/PresenceViewMoreButton.css
@@ -8,4 +8,30 @@
     padding: 0 12px;
     width: auto;
     margin-right: 8px;
+    pointer-events: all;
+}
+
+.presence-view-more-content {
+    min-width: 220px;
+    background-color: white;
+    border-radius: 6px;
+    padding: 5px;
+    box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35), 0px 10px 20px -15px rgba(22, 23, 24, 0.2);
+    animation-duration: 400ms;
+    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: transform, opacity;  
+    cursor: default;
+}
+
+.presence-view-more-item {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+    border-style: none;
+    border-radius: 5px;
+}
+
+.presence-view-more-item[data-highlighted] {
+    border-style: none;
+    background-color: rgb(226, 226, 226)
 }

--- a/src/components/Presence/PresenceViewMoreButton.css
+++ b/src/components/Presence/PresenceViewMoreButton.css
@@ -1,0 +1,11 @@
+.presence-view-more-trigger {
+    background-color: white;
+    border-radius: 9999px;
+    box-sizing: border-box;
+    font-size: var(--font-tiny);
+    font-weight: 500;
+    height: 38px;
+    padding: 0 12px;
+    width: auto;
+    margin-right: 8px;
+}

--- a/src/components/Presence/PresenceViewMoreButton.tsx
+++ b/src/components/Presence/PresenceViewMoreButton.tsx
@@ -1,0 +1,46 @@
+import { isMe, type PresentUser } from '@annotorious/react';
+import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import { Avatar } from '@components/Avatar';
+import './PresenceViewMoreButton.css';
+import { CaretDown, Check } from '@phosphor-icons/react';
+
+const { Content, Item, Portal, Root, Trigger, RadioGroup, RadioItem, ItemIndicator } = Dropdown;
+
+
+interface PresenceViewMoreButtonProps {
+
+    present: PresentUser[];
+
+    limit?: number;
+
+    showMe?: boolean;
+
+}
+
+export const PresenceViewMoreButton = (props: PresenceViewMoreButtonProps) => {
+  const { limit = 3 } = props;
+    
+  const present = props.showMe ? 
+    props.present : props.present.filter(u => !isMe(u));
+
+    return (
+    <Root>
+      <Trigger asChild>
+        <button
+          className="presence-view-more-trigger">
+          <span>
+            +{present.length - limit} more
+          </span>   
+          <CaretDown size={10} weight="bold" />
+        </button>
+      </Trigger>
+
+
+        <Content>
+          <Item>hi</Item>
+          <Item>bye</Item>
+        </Content>
+
+    </Root>
+    );
+};

--- a/src/components/Presence/PresenceViewMoreButton.tsx
+++ b/src/components/Presence/PresenceViewMoreButton.tsx
@@ -9,7 +9,7 @@ const { Content, Item, Portal, Root, Trigger, RadioGroup, RadioItem, ItemIndicat
 
 interface PresenceViewMoreButtonProps {
 
-    present: PresentUser[];
+    present?: PresentUser[];
 
     limit?: number;
 
@@ -21,7 +21,7 @@ export const PresenceViewMoreButton = (props: PresenceViewMoreButtonProps) => {
   const { limit = 3 } = props;
     
   const present = props.showMe ? 
-    props.present : props.present.filter(u => !isMe(u));
+    props.present : props.present?.filter(u => !isMe(u));
 
     return (
     <Root>
@@ -29,18 +29,30 @@ export const PresenceViewMoreButton = (props: PresenceViewMoreButtonProps) => {
         <button
           className="presence-view-more-trigger">
           <span>
-            +{present.length - limit} more
+            +{present ? present.length - limit : '0'} more
           </span>   
           <CaretDown size={10} weight="bold" />
         </button>
       </Trigger>
 
-
-        <Content>
-          <Item>hi</Item>
-          <Item>bye</Item>
+      <Portal>
+        <Content align="start" className="presence-view-more-content">
+            {present?.slice(limit, undefined).map((presentUser) => (
+                <Item className="presence-view-more-item">
+                    
+                    <Avatar 
+                    id={presentUser.id}
+                    name={presentUser.appearance.label}
+                    color={presentUser.appearance.color} 
+                    avatar={presentUser.appearance.avatar} />
+                    <span style={{ paddingLeft: '15px' }}>
+                        {presentUser.name}
+                    </span>
+                    
+                </Item>
+            ))}
         </Content>
-
+      </Portal>
     </Root>
     );
 };

--- a/src/components/Presence/PresenceViewMoreButton.tsx
+++ b/src/components/Presence/PresenceViewMoreButton.tsx
@@ -1,10 +1,10 @@
 import { isMe, type PresentUser } from '@annotorious/react';
-import * as Dropdown from '@radix-ui/react-dropdown-menu';
+import * as Popover from '@radix-ui/react-popover';
 import { Avatar } from '@components/Avatar';
 import './PresenceViewMoreButton.css';
 import { CaretDown, Check } from '@phosphor-icons/react';
 
-const { Content, Item, Portal, Root, Trigger, RadioGroup, RadioItem, ItemIndicator } = Dropdown;
+const { Content, Portal, Root, Trigger } = Popover;
 
 
 interface PresenceViewMoreButtonProps {
@@ -37,8 +37,9 @@ export const PresenceViewMoreButton = (props: PresenceViewMoreButtonProps) => {
 
       <Portal>
         <Content align="start" className="presence-view-more-content">
-            {present?.slice(limit, undefined).map((presentUser) => (
-                <Item className="presence-view-more-item">
+          <ul>
+            {present?.map((presentUser) => (
+                <li className="presence-view-more-item">
                     
                     <Avatar 
                     id={presentUser.id}
@@ -49,8 +50,9 @@ export const PresenceViewMoreButton = (props: PresenceViewMoreButtonProps) => {
                         {presentUser.name}
                     </span>
                     
-                </Item>
+                </li>
             ))}
+            </ul>
         </Content>
       </Portal>
     </Root>


### PR DESCRIPTION
### In this PR
This PR implements a limit (currently set to five but can be changed pretty easily) to the number of avatars displayed in the top right of a document, putting the remaining ones in a dropdown.
![image](https://github.com/recogito/recogito-client/assets/110847635/7fa90f97-8faa-4a67-8006-1ad8bfe83763)

### Notes and further work needed
- Currently only implemented in desktop text annotations, not images. Once completed it will need to be added to image annotation component as well.
- Max height of dropdown not implemented yet
- Currently dropdown only shows the users that were left off the list, but also it shows names and not just avatars, which is a little weird because that means you can only see the names of people other than the first five.... Could be changed so that the dropdown shows all users, or maybe have a tooltip over the existing avatars that displays the name? Open to suggestions.
- "+n more" language needs to be localized; currently hard-coded in English

I would recommend *not merging* this PR until some of these tweaks are made, but I'm putting it here now for review/suggestions and to generate the netlify preview.