### PR TITLE
TEI annotation rendering fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
-        "@recogito/react-text-annotator": "3.0.0-pre-alpha-35",
+        "@recogito/react-text-annotator": "3.0.0-pre-alpha-36",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
         "@uppy/core": "^3.2.1",
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@recogito/react-text-annotator": {
-      "version": "3.0.0-pre-alpha-35",
-      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-35.tgz",
-      "integrity": "sha512-Hs46HWKyPJlkclrBzJ9R69Np8Vmiv9HycYsHCgKi8tQ2ZoSIBpviARvPi7IbbZ+4alaaPTIqrtuh+oueb/EQjg==",
+      "version": "3.0.0-pre-alpha-36",
+      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-36.tgz",
+      "integrity": "sha512-hdgoIecA2Ls6/XiDHhlqDa9iu1eSCwxaSJMaZ62/+DuAzCRQ7Q/Urv8XMbsQJ2TtYEeWqlTzpOZrRlSiBeTb+Q==",
       "dependencies": {
         "@neodrag/react": "^2.0.3",
         "CETEIcean": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
-    "@recogito/react-text-annotator": "3.0.0-pre-alpha-35",
+    "@recogito/react-text-annotator": "3.0.0-pre-alpha-36",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",
     "@uppy/core": "^3.2.1",

--- a/src/apps/annotation-text/content/TEIContent.css
+++ b/src/apps/annotation-text/content/TEIContent.css
@@ -134,7 +134,7 @@ tei-anchor {
 tei-app {
   /* Empty Rule Set */
 }
-tei-app tei-note {
+tei-note {
   display: none;
 }
 tei-appInfo {


### PR DESCRIPTION
## In this PR

I'm making this PR mostly for documentation purposes, since the actual fix has happend in the `text-annotator` package, in this commit:

https://github.com/recogito/text-annotator-js/commit/7c3860f559c4693e0cc8396440fecdd0c790452e

The commit in this repository just updates to the latest, bugfixed `text-annotator` package. 

The fix solves [the previously reported issue](https://github.com/recogito/recogito-client/pull/39) of a single annotation being rendered as if it were multiple overlapping annotations, because the `range.getClientRects()` method will return `DOMRect`s for each nested markup element.

__Before the fix:__

<img width="691" alt="Bildschirmfoto 2023-08-23 um 09 20 51" src="https://github.com/recogito/recogito-client/assets/470971/0eab75dd-33ed-4f82-b7ed-35e94afc2a37">

__After the fix:__

<img width="691" alt="Bildschirmfoto 2023-08-23 um 09 21 50" src="https://github.com/recogito/recogito-client/assets/470971/fd5501de-ae14-4a89-a659-69a48b8a5952">
