### PR TITLE
Auto-deleting empty annotations

### DIFF
--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -81,6 +81,10 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
           adapter={null}
           tool={tool} 
           keepEnabled={true}>
+          
+          <AnnotationDesktop.UndoStack 
+            undoEmpty={true} />
+
           <SupabasePlugin
             base={SUPABASE}
             apiKey={SUPABASE_API_KEY} 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -16,7 +16,6 @@ import type { PrivacyMode } from '@components/PrivacySelector';
 import { TEIContent, PlaintextContent } from './content';
 
 import './TextAnnotationDesktop.css';
-
 import '@recogito/react-text-annotator/dist/react-text-annotator.css';
 
 const SUPABASE = import.meta.env.PUBLIC_SUPABASE;
@@ -97,6 +96,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
             appearanceProvider={createAppearenceProvider()}
             onPresence={setPresent} 
             privacyMode={privacy === 'PRIVATE'}/>
+
+          <AnnotationDesktop.UndoStack 
+            undoEmpty={true} />
 
           {usePopup && (
             <TextAnnotatorPopup

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -88,6 +88,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
         </main>
 
         <div className="anno-desktop ta-desktop">
+          <AnnotationDesktop.UndoStack 
+            undoEmpty={true} />
+            
           <SupabasePlugin 
             base={SUPABASE}
             apiKey={SUPABASE_API_KEY} 
@@ -96,9 +99,6 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
             appearanceProvider={createAppearenceProvider()}
             onPresence={setPresent} 
             privacyMode={privacy === 'PRIVATE'}/>
-
-          <AnnotationDesktop.UndoStack 
-            undoEmpty={true} />
 
           {usePopup && (
             <TextAnnotatorPopup

--- a/src/components/AnnotationDesktop/UndoStack/UndoStack.tsx
+++ b/src/components/AnnotationDesktop/UndoStack/UndoStack.tsx
@@ -1,0 +1,65 @@
+/**
+ * Experimental code to a) prevent creation of empty annotations
+ * and b) think about how we can implement undo functionality in 
+ * the future.
+ */
+import { useEffect, useState } from 'react';
+import { Annotation, useAnnotationStore, useAnnotations, useAnnotator, useSelection } from '@annotorious/react';
+
+interface UndoStackProps {
+
+  undoEmpty?: boolean;
+
+}
+
+export const UndoStack = (props: UndoStackProps) => {
+
+  const { undoEmpty } = props;
+
+  const anno = useAnnotator();
+
+  const store = useAnnotationStore();
+
+  const [created, setCreated] = useState<Annotation | undefined>();
+
+  const { selected } = useSelection();
+  
+  useEffect(() => {
+    if (anno && undoEmpty) {
+      const onCreate = (annotation: Annotation) =>
+        setCreated(annotation);
+
+      const onDelete = () =>
+        setCreated(undefined);
+
+      anno.on('createAnnotation', onCreate);
+      anno.on('deleteAnnotation', onDelete);
+
+      return () => {
+        anno.off('createAnnotation', onCreate);
+        anno.off('deleteAnnotation', onDelete);
+      }
+    }
+  }, [anno]);
+
+  useEffect(() => {
+    if (selected.length === 0 && undoEmpty && created) {
+      // Check if the create annotation is still empty
+      const lastCreated = store.getAnnotation(created.id);
+
+      if (lastCreated.bodies.length === 0) {
+        if (created.bodies.length === 0) {
+          // The problem: deselect will store the latest target update.
+          // We want to delete the annotation instead. How to best avoid
+          // race conditions?
+          setTimeout(() => store.deleteAnnotation(lastCreated), 100);
+        }
+      }
+
+      setCreated(undefined);
+    }
+  }, [selected, created]);
+
+  return null;
+
+}

--- a/src/components/AnnotationDesktop/UndoStack/UndoStack.tsx
+++ b/src/components/AnnotationDesktop/UndoStack/UndoStack.tsx
@@ -28,7 +28,7 @@ export const UndoStack = (props: UndoStackProps) => {
     if (anno && undoEmpty) {
       const onCreate = (annotation: Annotation) =>
         setCreated(annotation);
-
+      
       const onDelete = () =>
         setCreated(undefined);
 
@@ -49,10 +49,38 @@ export const UndoStack = (props: UndoStackProps) => {
 
       if (lastCreated.bodies.length === 0) {
         if (created.bodies.length === 0) {
-          // The problem: deselect will store the latest target update.
-          // We want to delete the annotation instead. How to best avoid
-          // race conditions?
-          setTimeout(() => store.deleteAnnotation(lastCreated), 100);
+          // The problem: deselect will cause the SupabasePlugin 
+          // to store the annotation in the backend, if it changed.
+          // 
+          // In text mode, the annotation is first created (and stored 
+          // in Supabase), then modified as the user drags the selection.
+          // When de-selecting, this change will cause the Supabase 
+          // plugin to trigger a save request.
+          // 
+          // If we delete the annotation in this useEffect handler, this
+          // will lead to the following sequence of events:
+          // 
+          // - The user de-selects
+          // - The @annotorious/core Lifecycle handler is always the first listener on the selection,
+          //   which means that `updateAnnotation` will fire first
+          // - The Supabase plugin starts updating with a preflight OPTION request
+          // - UndoStack gets notfied of the selection change, causing this effect to run
+          // - UndoStack deletes the annotation
+          // - The Supabase plugin's store listener archive-deletes the annotation via the RPC
+          // - The update OPTIONS request returns
+          // - The Supabase plugin sends the PATCH request to update the annotation
+          // - The PATCH request fails because the target was alread archived on Supabase
+          //
+          // The question is how to avoid this situation. One possibility would be to
+          // tweak the Lifcycle handler, to emit the `updateAnnotation` after the event loop
+          // is done. In this case, the sequence will (hopefully...) change to:
+          // 
+          // - The user de-selects
+          // - Undo stack deletes the annotation
+          // - SupabasePlugin archives the annotation
+          // - @annotorious/core lifecycle handler executes, but does not emit a change, 
+          //   because the annotation is already deleted from the store
+          store.deleteAnnotation(lastCreated);
         }
       }
 

--- a/src/components/AnnotationDesktop/UndoStack/index.ts
+++ b/src/components/AnnotationDesktop/UndoStack/index.ts
@@ -1,0 +1,1 @@
+export * from './UndoStack';

--- a/src/components/AnnotationDesktop/index.ts
+++ b/src/components/AnnotationDesktop/index.ts
@@ -1,12 +1,15 @@
 import { DocumentMenu } from './DocumentMenu';
+import { UndoStack } from './UndoStack';
 import { ViewMenu } from './ViewMenu';
-
-export { ViewMenuPanel } from './ViewMenu'
 
 export const AnnotationDesktop = {
 
   DocumentMenu, 
+
+  UndoStack,
   
   ViewMenu
 
 }
+
+export { ViewMenuPanel } from './ViewMenu'


### PR DESCRIPTION
## In this PR

This PR attempts to fix the the current problem of __empty annotations__. If a user creates an annotations without a body, it will appear as "busy" (with a "user is typing" animation) to other users. Unless the creator of the annotation opens the annotation later, and adds an annotation body, the annotation will remain "busy" for all eternity.

One solution to this problem is to simply not allow empty annotations: if a user creates an annotation, and de-selects without adding a body, the annotation is deleted. (Note that GoogleDocs applies exactly the same pattern!)

This PR implements this functionality. There are currently two open issues:
- We might want to think about an alert popup that explains that the annotation is auto-removed because empty annotations are not allowed. Not 100% this is necessary. It might be self-explanatory enough, especially given the GDocs works the same way.
- Because of the way __text annotation__  works, there is currently a bit of a race condition that causes the Supabase plugin to attempt an update to the annotation target in the backend, after the annotation was already archived. This doesn't cause any visible problems right now, simply causes a sequence of 5 (=preset) update requests which, obviously, fail in the backend. I wrote a note about this into the code as a comment. The solution will have to be implemented in the `@annotorious/core` library.