### PR TITLE
Enabled 'sign-in with SSO' button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ PUBLIC_SUPABASE_API_KEY="your-anonymous-key"
 PUBLIC_USERSNAP_GLOBAL_API_KEY="usersnap-global-api-key"
 PUBLIC_USERSNAP_PROJECT_API_KEY="usersnap-project-api-key"
 
+# SSO domain
+PUBLIC_SSO_DOMAIN="example.com"
+
 ###
 # Non-public vars stay on the server
 ###

--- a/src/apps/auth-login/Login.tsx
+++ b/src/apps/auth-login/Login.tsx
@@ -7,6 +7,8 @@ import { StateChecking, StateLoginForm, StateMagicLink } from './states';
 
 import './Login.css';
 
+const SSO_DOMAIN = import.meta.env.PUBLIC_SSO_DOMAIN;
+
 const setCookies = (session: Session | null) => {
   if (!session)
     throw 'SIGNED_IN event without session - should never happen';
@@ -51,6 +53,18 @@ export const Login = (props: { i18n: Translations }) => {
     });
   }, []);
 
+  const signInWithSSO = () => {
+    supabase.auth.signInWithSSO({
+      domain: SSO_DOMAIN
+    }).then(({ data, error }) => {
+      if (data?.url) {
+        window.location.href= data.url;
+      } else {
+        console.error(error);
+      }
+    });
+  }
+
   if (isChecking) {
     return (
       <StateChecking />
@@ -63,7 +77,8 @@ export const Login = (props: { i18n: Translations }) => {
     return (
       <StateLoginForm 
         i18n={props.i18n}
-        onSendLink={() => setSendLink(true)} />
+        onSendLink={() => setSendLink(true)} 
+        onSignInWithSSO={signInWithSSO}/>
     )
   }
 

--- a/src/apps/auth-login/states/StateLoginForm.tsx
+++ b/src/apps/auth-login/states/StateLoginForm.tsx
@@ -12,6 +12,8 @@ export interface StateSignInFormProps {
 
   onSendLink(): void;
 
+  onSignInWithSSO(): void;
+
 }
 
 export const StateLoginForm = (props: StateSignInFormProps) => {
@@ -105,7 +107,7 @@ export const StateLoginForm = (props: StateSignInFormProps) => {
             <MagicWand size={19} /> {t['Continue with Magic Link']}
           </button>
 
-          <button className="lg w-full">
+          <button className="lg w-full" onClick={props.onSignInWithSSO}>
             <Lock size={19} /> {t['Continue with SSO']}
           </button>
         </div>


### PR DESCRIPTION
## In this PR

This PR wires up the 'Sign in with SSO' button on the login form with the [corresponding Supabase auth method](https://supabase.com/docs/reference/javascript/auth-signinwithsso).

The domain can be configured via a new environment variable `PUBLIC_SSO_DOMAIN'.