### PR TITLE
Annotorious + TextAnnotatorJS upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
+        "@annotorious/react": "^3.0.0-pre-alpha-35",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -23,7 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
-        "@recogito/react-text-annotator": "file:../text-annotator/packages/text-annotator-react",
+        "@recogito/react-text-annotator": "^3.0.0-pre-alpha-38",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
         "@uppy/core": "^3.2.1",
@@ -51,56 +51,8 @@
         "@types/uuid": "^9.0.1"
       }
     },
-    "../../annotorious/annotorious-v3/packages/annotorious-react": {
-      "name": "@annotorious/react",
-      "version": "3.0.0-pre-alpha-34",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3"
-      },
-      "devDependencies": {
-        "@types/react-dom": "^18.0.11",
-        "@vitejs/plugin-react": "^3.1.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "typescript": "^4.7.4",
-        "vite": "^4.2.1",
-        "vite-plugin-dts": "^2.3.0",
-        "vite-tsconfig-paths": "^4.2.0"
-      },
-      "peerDependencies": {
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
-    },
     "../text-annotator-js/packages/text-annotator": {
       "extraneous": true
-    },
-    "../text-annotator/packages/text-annotator-react": {
-      "name": "@recogito/react-text-annotator",
-      "version": "3.0.0-pre-alpha-37",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3",
-        "CETEIcean": "^1.8.0"
-      },
-      "devDependencies": {
-        "@types/react-dom": "^18.0.11",
-        "@vitejs/plugin-react": "^3.1.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "typescript": "^4.7.4",
-        "vite": "^4.2.1",
-        "vite-plugin-dts": "^2.3.0",
-        "vite-tsconfig-paths": "^4.2.0"
-      },
-      "peerDependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-34",
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
     },
     "../text-annotator/packages/text-annotator/react": {
       "extraneous": true
@@ -121,8 +73,17 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "resolved": "../../annotorious/annotorious-v3/packages/annotorious-react",
-      "link": true
+      "version": "3.0.0-pre-alpha-35",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-35.tgz",
+      "integrity": "sha512-6Ek2dGlit01xN26IQMd+fKyj+2WtNyRPoK87T3+GmdhfXQP0EUtIUF6gERovH/qwlIGuGQKq0g7Fev0zihVK/A==",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
     },
     "node_modules/@astrojs/compiler": {
       "version": "1.8.0",
@@ -1150,6 +1111,11 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
+    "node_modules/@neodrag/react": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@neodrag/react/-/react-2.0.3.tgz",
+      "integrity": "sha512-VtubEZzyB+mmi6bZYKay/UmMuWsG2rsiAV7+O7iLN4YXKOOa7TxJT3alnLRqkntII8X48h2Hs7jSjosqxuAxDQ=="
+    },
     "node_modules/@netlify/functions": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-1.6.0.tgz",
@@ -2122,8 +2088,19 @@
       }
     },
     "node_modules/@recogito/react-text-annotator": {
-      "resolved": "../text-annotator/packages/text-annotator-react",
-      "link": true
+      "version": "3.0.0-pre-alpha-38",
+      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-38.tgz",
+      "integrity": "sha512-OTUZ6Y1iJnMPGPQoQwgswAgNQxXYTjgyaooGE5fsbudAYSzaWEqpxqhmzOffsaqeBpkjgec9QwgzeAmJS1yWjA==",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3",
+        "CETEIcean": "^1.8.0"
+      },
+      "peerDependencies": {
+        "@annotorious/react": "^3.0.0-pre-alpha-35",
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
     },
     "node_modules/@supabase/auth-helpers-shared": {
       "version": "0.3.4",
@@ -3069,6 +3046,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/CETEIcean": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/CETEIcean/-/CETEIcean-1.8.0.tgz",
+      "integrity": "sha512-x0kEFFKpO21hkemPt5w8/IezQEL3suUfEeYpLbw98Y/0WH5wlbDKEpmpQLR02/2dTL2kFE+sHUCmeAVDD816YA=="
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-34",
+        "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -51,6 +51,29 @@
         "@types/uuid": "^9.0.1"
       }
     },
+    "../../annotorious/annotorious-v3/packages/annotorious-react": {
+      "name": "@annotorious/react",
+      "version": "3.0.0-pre-alpha-34",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
+    },
     "../text-annotator-js/packages/text-annotator": {
       "extraneous": true
     },
@@ -73,7 +96,7 @@
         "vite-tsconfig-paths": "^4.2.0"
       },
       "peerDependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-33",
+        "@annotorious/react": "^3.0.0-pre-alpha-34",
         "openseadragon": "^3.1.0",
         "react": "16.8.0 || >=17.x",
         "react-dom": "16.8.0 || >=17.x"
@@ -98,17 +121,8 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-34",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-34.tgz",
-      "integrity": "sha512-j0KDIb/f7txDihWQr/omNUGrf8CgBEhXfQF5HjZ1M8ce531Vnc2Vaq0uudsSLLJ6fTIV/uh/Pm1TXpMcAmgUAA==",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3"
-      },
-      "peerDependencies": {
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
+      "resolved": "../../annotorious/annotorious-v3/packages/annotorious-react",
+      "link": true
     },
     "node_modules/@astrojs/compiler": {
       "version": "1.8.0",
@@ -1135,11 +1149,6 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
-    "node_modules/@neodrag/react": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@neodrag/react/-/react-2.0.3.tgz",
-      "integrity": "sha512-VtubEZzyB+mmi6bZYKay/UmMuWsG2rsiAV7+O7iLN4YXKOOa7TxJT3alnLRqkntII8X48h2Hs7jSjosqxuAxDQ=="
     },
     "node_modules/@netlify/functions": {
       "version": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "3.0.0-pre-alpha-32",
+        "@annotorious/react": "^3.0.0-pre-alpha-34",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -23,7 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
-        "@recogito/react-text-annotator": "3.0.0-pre-alpha-36",
+        "@recogito/react-text-annotator": "file:../text-annotator/packages/text-annotator-react",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
         "@uppy/core": "^3.2.1",
@@ -51,6 +51,34 @@
         "@types/uuid": "^9.0.1"
       }
     },
+    "../text-annotator-js/packages/text-annotator": {
+      "extraneous": true
+    },
+    "../text-annotator/packages/text-annotator-react": {
+      "name": "@recogito/react-text-annotator",
+      "version": "3.0.0-pre-alpha-37",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3",
+        "CETEIcean": "^1.8.0"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@annotorious/react": "^3.0.0-pre-alpha-33",
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
+    },
     "../text-annotator/packages/text-annotator/react": {
       "extraneous": true
     },
@@ -70,9 +98,9 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-32",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-32.tgz",
-      "integrity": "sha512-+21DMYoSdOtYXeVBGyPhk7C3IiypgoP0udO9zyQkUU7tdTkzLvGO8onZj4sxXwotyAQ0XGC/GqRm1DPX1cwnlg==",
+      "version": "3.0.0-pre-alpha-34",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-34.tgz",
+      "integrity": "sha512-j0KDIb/f7txDihWQr/omNUGrf8CgBEhXfQF5HjZ1M8ce531Vnc2Vaq0uudsSLLJ6fTIV/uh/Pm1TXpMcAmgUAA==",
       "dependencies": {
         "@neodrag/react": "^2.0.3"
       },
@@ -2085,19 +2113,8 @@
       }
     },
     "node_modules/@recogito/react-text-annotator": {
-      "version": "3.0.0-pre-alpha-36",
-      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-36.tgz",
-      "integrity": "sha512-hdgoIecA2Ls6/XiDHhlqDa9iu1eSCwxaSJMaZ62/+DuAzCRQ7Q/Urv8XMbsQJ2TtYEeWqlTzpOZrRlSiBeTb+Q==",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3",
-        "CETEIcean": "^1.8.0"
-      },
-      "peerDependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-32",
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
+      "resolved": "../text-annotator/packages/text-annotator-react",
+      "link": true
     },
     "node_modules/@supabase/auth-helpers-shared": {
       "version": "0.3.4",
@@ -3043,11 +3060,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/CETEIcean": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/CETEIcean/-/CETEIcean-1.8.0.tgz",
-      "integrity": "sha512-x0kEFFKpO21hkemPt5w8/IezQEL3suUfEeYpLbw98Y/0WH5wlbDKEpmpQLR02/2dTL2kFE+sHUCmeAVDD816YA=="
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
+    "@annotorious/react": "^3.0.0-pre-alpha-35",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",
@@ -26,7 +26,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
-    "@recogito/react-text-annotator": "file:../text-annotator/packages/text-annotator-react",
+    "@recogito/react-text-annotator": "^3.0.0-pre-alpha-38",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",
     "@uppy/core": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "^3.0.0-pre-alpha-34",
+    "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "3.0.0-pre-alpha-32",
+    "@annotorious/react": "^3.0.0-pre-alpha-34",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",
@@ -26,7 +26,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
-    "@recogito/react-text-annotator": "3.0.0-pre-alpha-36",
+    "@recogito/react-text-annotator": "file:../text-annotator/packages/text-annotator-react",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",
     "@uppy/core": "^3.2.1",

--- a/src/apps/annotation-image/ImageAnnotationDesktop.css
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.css
@@ -1,4 +1,4 @@
-@import '@annotorious/react/dist/annotorious-react.css';
+@import '@annotorious/react/annotorious-react.css';
 
 .ia-osd-container {
   height: 100%;

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -6,10 +6,10 @@ import { createAppearenceProvider, PresenceStack } from '@components/Presence';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { Toolbar } from './Toolbar';
-import {
+import { 
   Annotorious, 
-  AnnotoriousOpenSeadragonAnnotator, 
-  ImageAnnotation,
+  AnnotoriousOpenSeadragonAnnotator,
+  ImageAnnotation, 
   OpenSeadragonAnnotator,
   OpenSeadragonPopup,
   OpenSeadragonViewer,

--- a/src/apps/annotation-image/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-image/Toolbar/Toolbar.tsx
@@ -64,8 +64,8 @@ export const Toolbar = (props: ToolbarProps) => {
           </button>
 
           <button 
-            className={tool === 'box' ? 'active' : undefined}
-            onClick={() => onChangeTool('box')}>
+            className={tool === 'rectangle' ? 'active' : undefined}
+            onClick={() => onChangeTool('rectangle')}>
             <Rectangle />
           </button>
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -4,8 +4,9 @@ import type { Annotation as Anno, PresentUser } from '@annotorious/react';
 import { 
   TEIAnnotator, 
   TextAnnotator, 
-  TextAnnotatorRef, 
-  TextAnnotatorPopup 
+  RecogitoTextAnnotator, 
+  TextAnnotatorPopup, 
+  TextAnnotation
 } from '@recogito/react-text-annotator';
 import { useLayerPolicies } from '@backend/hooks';
 import { PresenceStack, createAppearenceProvider } from '@components/Presence';
@@ -17,7 +18,7 @@ import type { PrivacyMode } from '@components/PrivacySelector';
 import { TEIContent, PlaintextContent } from './content';
 
 import './TextAnnotationDesktop.css';
-import '@recogito/react-text-annotator/dist/react-text-annotator.css';
+import '@recogito/react-text-annotator/react-text-annotator.css';
 
 const SUPABASE = import.meta.env.PUBLIC_SUPABASE;
 
@@ -39,7 +40,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
 
   const contentType = props.document.content_type;
 
-  const anno = useRef<TextAnnotatorRef>();
+  const anno = useRef<RecogitoTextAnnotator>();
 
   const policies = useLayerPolicies(props.document.layers[0].id);
 
@@ -64,11 +65,12 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
 
   const beforeSelectAnnotation = (a?: Anno) => {
     if (a && !usePopup && anno.current) {
+      const t = a as TextAnnotation;
       // Don't fit the view if the annotation is already selected
-      if (anno.current.state.selection.isSelected(a))
+      if (anno.current.state.selection.isSelected(t))
         return;
 
-      anno.current.scrollIntoView(a);
+      anno.current.scrollIntoView(t);
     }
   }
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -1,12 +1,12 @@
 import { useRef, useState } from 'react';
 import { Annotorious, SupabasePlugin } from '@annotorious/react';
+import type { Annotation as Anno, PresentUser } from '@annotorious/react';
 import { 
   TEIAnnotator, 
   TextAnnotator, 
   TextAnnotatorRef, 
   TextAnnotatorPopup 
 } from '@recogito/react-text-annotator';
-import type { Annotation as Anno, PresentUser } from '@annotorious/react';
 import { useLayerPolicies } from '@backend/hooks';
 import { PresenceStack, createAppearenceProvider } from '@components/Presence';
 import { Annotation } from '@components/Annotation';

--- a/src/components/Annotation/ReplyForm/ReplyForm.tsx
+++ b/src/components/Annotation/ReplyForm/ReplyForm.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ArrowRight, Detective } from '@phosphor-icons/react';
 import TextareaAutosize from 'react-textarea-autosize';
-import { Visibility, useAnnotationStore, useAnnotatorUser } from '@annotorious/react';
+import { Visibility, useAnnotationStore } from '@annotorious/react';
 import type { Annotation, AnnotationBody, PresentUser, User } from '@annotorious/react';
 import { Avatar } from '../../Avatar';
 

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -1,4 +1,5 @@
-import { isMe, type PresentUser } from '@annotorious/react';
+import { isMe } from '@annotorious/react';
+import type { PresentUser } from '@annotorious/react';
 import { animated, useTransition } from '@react-spring/web';
 import { Avatar } from '@components/Avatar';
 

--- a/src/components/Presence/PresenceViewMoreButton.tsx
+++ b/src/components/Presence/PresenceViewMoreButton.tsx
@@ -1,11 +1,11 @@
-import { isMe, type PresentUser } from '@annotorious/react';
+import { isMe } from '@annotorious/react';
+import type { PresentUser } from '@annotorious/react';
 import * as Popover from '@radix-ui/react-popover';
 import { Avatar } from '@components/Avatar';
 import './PresenceViewMoreButton.css';
 import { CaretDown } from '@phosphor-icons/react';
 
 const { Content, Portal, Root, Trigger } = Popover;
-
 
 interface PresenceViewMoreButtonProps {
 


### PR DESCRIPTION
## In this PR

This PR upgrades the client to the latest published Annotorious & TextAnnotatorJS versions. Annotorious has undergone some major changes (with the introduction of annotation for standard, non-OpenSeadragon images), plus, I redesigned the build process to allow for tree-shaking in the `@annotorious/react` package.