### PR TITLE
Auto-discarding of duplicate invites

### DIFF
--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -18,11 +18,11 @@ interface HeaderProps {
 
   policies?: Policies;
 
+  projects: ExtendedProjectData[][];
+
   invitations: Invitation[];
 
   filter: ProjectFilter;
-
-  counts: [number, number, number];
 
   onChangeFilter(f: ProjectFilter): void;
 
@@ -42,7 +42,7 @@ export const Header = (props: HeaderProps) => {
   
   const { filter, onChangeFilter } = props;
 
-  const [all, mine, shared] = props.counts;
+  const [all, mine, shared] = props.projects;
 
   // 'Create new project' button state
   const [creating, setCreating] = useState(false);
@@ -88,6 +88,7 @@ export const Header = (props: HeaderProps) => {
 
           <Notifications 
             i18n={props.i18n} 
+            myProjects={[...mine, ...shared]}
             invitations={props.invitations} 
             onInvitationAccepted={props.onInvitationAccepted}
             onInvitationDeclined={props.onInvitationDeclined} 
@@ -105,8 +106,8 @@ export const Header = (props: HeaderProps) => {
             <button>{t['All']}</button>
             
             <span 
-              className={all === 0 ? 'badge disabled' : 'badge'}>
-              {all}
+              className={all.length === 0 ? 'badge disabled' : 'badge'}>
+              {all.length}
             </span>
           </li>
 
@@ -116,8 +117,8 @@ export const Header = (props: HeaderProps) => {
             <button>{t['My Projects']}</button>
 
             <span 
-              className={mine === 0 ? 'badge disabled' : 'badge'}>
-              {mine}
+              className={mine.length === 0 ? 'badge disabled' : 'badge'}>
+              {mine.length}
             </span>
           </li>
 
@@ -127,8 +128,8 @@ export const Header = (props: HeaderProps) => {
             <button>{t['Shared with me']}</button>
 
             <span 
-              className={shared === 0 ? 'badge disabled' : 'badge'}>
-              {shared}
+              className={shared.length === 0 ? 'badge disabled' : 'badge'}>
+              {shared.length}
             </span>
           </li>
         </ul>

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -134,9 +134,9 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           i18n={props.i18n} 
           me={me}
           policies={policies}
+          projects={[allProjects, myProjects, sharedProjects]}
           invitations={invitations} 
           filter={filter}
-          counts={[allProjects.length, myProjects.length, sharedProjects.length]}
           onChangeFilter={setFilter}
           onProjectCreated={onProjectCreated} 
           onInvitationAccepted={onInvitationAccepted}

--- a/src/backend/helpers/invitationHelpers.ts
+++ b/src/backend/helpers/invitationHelpers.ts
@@ -25,6 +25,27 @@ export const joinProject = (
     });
 });
 
+/** 
+ * This method joins a project without retrieving follow-up project data.
+ * We only use this to silently "discard" invitations for project we are
+ * already a member of.
+ */
+export const silentlyJoinProject = (
+  supabase: SupabaseClient,
+  invitation: Invitation
+): Promise<void> => new Promise((resolve, reject) => {
+  supabase
+    .from('invites')
+    .update({ accepted: true })
+    .eq('id', invitation.id)
+    .then(({ error }) => {
+      if (error)
+        reject(error)
+      else
+        resolve();
+    })
+});
+
 export const declineInvitation = (supabase: SupabaseClient, invitation: Invitation) =>
   supabase
     .from('invites')


### PR DESCRIPTION
## In this PR

This PR adds a workaround concerning issue 110:
https://github.com/performant-software/vico/issues/110

We can't prevent project admins from sending an invitation to an email of a user who's already a project member. This PR adds a workaround, where the dashboard will check on startup if any invites for the user are for projects they are already a member of. If so, the dashboard hides the invites from the user, and instead consumes them silently in the background (by accepting). The DB trigger makes sure no change is made to the user's actual role in the project.  