### PR TITLE
Students can no longer edit project titles (issue #157)

### DIFF
--- a/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
+++ b/src/apps/project-home/ProjectDescription/ProjectDescription.tsx
@@ -13,9 +13,9 @@ interface ProjectDescriptionProps {
 
   i18n: Translations;
 
-  project: ExtendedProjectData;
+  editable?: boolean;
 
-  policies?: Policies;
+  project: ExtendedProjectData;
 
   onChanged(project: ExtendedProjectData): void;
 
@@ -26,8 +26,6 @@ interface ProjectDescriptionProps {
 export const ProjectDescription = (props: ProjectDescriptionProps) => {
 
   const { t } = props.i18n;
-
-  const canEdit = props.policies?.get('projects').has('UPDATE');
 
   const el = useRef<HTMLTextAreaElement>(null);
 
@@ -115,8 +113,8 @@ export const ProjectDescription = (props: ProjectDescriptionProps) => {
         </>
       ) : description ? (
         <p 
-          className={canEdit ? 'editable' : undefined}
-          onClick={canEdit ? () => setEditable(true) : undefined}>
+          className={props.editable ? 'editable' : undefined}
+          onClick={props.editable ? () => setEditable(true) : undefined}>
           {description}
           {saveState !== 'idle' && (
             <TinySaveIndicator 
@@ -124,7 +122,7 @@ export const ProjectDescription = (props: ProjectDescriptionProps) => {
               fadeOut={1500} />
           )}
         </p>
-      ) : canEdit && (
+      ) : props.editable && (
         <button className="minimal" onClick={() => setEditable(true)}>
           <PlusCircle size={16} /> <span>{t['Add a project description']}</span>
         </button>

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -37,6 +37,8 @@ export const ProjectHome = (props: ProjectHomeProps) => {
 
   const policies = useProjectPolicies(project.id);
 
+  const canEdit = policies?.get('projects').has('UPDATE');
+
   const [toast, setToast] = useState<ToastContent | null>(null);
 
   const [showUploads, setShowUploads] = useState(false);
@@ -164,12 +166,14 @@ export const ProjectHome = (props: ProjectHomeProps) => {
     <div className="project-home">
       <ToastProvider>
         <div>
-          <ProjectTitle project={project} />
+          <ProjectTitle 
+            editable={canEdit}
+            project={project} />
 
           <ProjectDescription 
             i18n={props.i18n}
+            editable={canEdit}
             project={project} 
-            policies={policies}
             onChanged={setProject} 
             onError={error => onError(error, 'Error updating project description.')} />
           

--- a/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
+++ b/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
@@ -19,25 +19,30 @@ export const ProjectTitle = (props: ProjectTitleProps) => {
 
   const { project } = props;
 
+  const [title, setTitle] = useState(project.name);
+
   const [saveState, setSaveState] = useState<SaveState>('idle');
 
   const onRenameProject = (name: string) => {
+    setTitle(name);
     setSaveState('saving');
 
     updateProject(supabase, { id: project.id, name })
       .then(({ error }) => {
         if (error) {
+          setTitle(project.name);
           setSaveState('failed');
         } else {
           setSaveState('success');
+
         }
-      })
+      });
   }
 
   return (
     <h1 className="project-title">
       <EditableText 
-        value={project.name} 
+        value={title} 
         onSubmit={onRenameProject} />
 
       {saveState !== 'idle' && (

--- a/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
+++ b/src/apps/project-home/ProjectTitle/ProjectTitle.tsx
@@ -9,6 +9,8 @@ import './ProjectTitle.css';
 
 interface ProjectTitleProps {
 
+  editable?: boolean;
+
   project: ExtendedProjectData;
 
   onChanged?(title: string): void;
@@ -34,16 +36,19 @@ export const ProjectTitle = (props: ProjectTitleProps) => {
           setSaveState('failed');
         } else {
           setSaveState('success');
-
         }
       });
   }
 
   return (
     <h1 className="project-title">
-      <EditableText 
-        value={title} 
-        onSubmit={onRenameProject} />
+      {props.editable ? (
+        <EditableText
+          value={title} 
+          onSubmit={onRenameProject} />
+      ) : (
+        title
+      )}
 
       {saveState !== 'idle' && (
         <TinySaveIndicator 

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -34,8 +34,6 @@ export const EditableText = (props: EditableTextProps) => {
 
   const el = useRef<HTMLElement>(null);
 
-  // const [value, setValue] = useState(props.value);
-
   useEffect(() => {
     if (props.focus && el.current)
       setTimeout(() => el.current?.focus(), 1);

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
 import ContentEditable from 'react-contenteditable';
 
@@ -11,6 +11,8 @@ interface EditableTextProps {
   maxLength?: number;
 
   value: string;
+
+  onChange?(value: string): void;
 
   onSubmit(value: string): void;
 
@@ -32,7 +34,7 @@ export const EditableText = (props: EditableTextProps) => {
 
   const el = useRef<HTMLElement>(null);
 
-  const [value, setValue] = useState(props.value);
+  // const [value, setValue] = useState(props.value);
 
   useEffect(() => {
     if (props.focus && el.current)
@@ -55,13 +57,9 @@ export const EditableText = (props: EditableTextProps) => {
   // Submit change on blur
   const onBlur = () => { 
     clearSelection();
-
     const currentValue = el.current?.innerText;
-    if (currentValue && currentValue !== props.value) {
+    if (currentValue && currentValue !== props.value)
       props.onSubmit(currentValue);
-    } else {
-      setValue(() => value);
-    }
   }
 
   // Enter key will blur the element (and submit)
@@ -71,11 +69,14 @@ export const EditableText = (props: EditableTextProps) => {
       (evt.target as HTMLElement).blur();
     }
   }
+
+  const onChange = (value: string) =>
+    props.onChange && props.onChange(value);
   
   // Paste without formatting
   const onPaste = (evt: React.ClipboardEvent) => {
     evt.preventDefault();
-    navigator.clipboard.readText().then(text => setValue(text.slice(0, maxLength)));
+    navigator.clipboard.readText().then(text => onChange(text.slice(0, maxLength)));
   }
 
   return (
@@ -83,11 +84,11 @@ export const EditableText = (props: EditableTextProps) => {
       className="editable-text"
       innerRef={el}
       spellCheck={false}
-      html={value} 
+      html={props.value} 
       tagName="span"
       onKeyDown={onKeyDown}
       onBlur={onBlur}
-      onChange={evt => setValue(evt.target.value)}
+      onChange={evt => onChange(evt.target.value)}
       onFocus={onFocus} 
       onPaste={onPaste} />
   )


### PR DESCRIPTION
## In this PR

This PR addresses [Issue #157](https://github.com/performant-software/vico/issues/157): as a student I should not see the interface to rename a project.

- Title is no longer editable unless the user has UPDATE privileges on the `projects` table. (This rule has already been applied for the description - but wasn't enforced for the title.)
- `EditableText` was changed to a controlled component & edits are reverted in case saving failed.