### PR TITLE
Sidebar: sorting annotations + debounced state updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-40",
+        "@annotorious/react": "^3.0.0-pre-alpha-41",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -23,7 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
-        "@recogito/react-text-annotator": "^3.0.0-pre-alpha-46",
+        "@recogito/react-text-annotator": "^3.0.0-pre-alpha-47",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
         "@uppy/core": "^3.2.1",
@@ -51,11 +51,61 @@
         "@types/uuid": "^9.0.1"
       }
     },
+    "../../annotorious/annotorious-v3/packages/annotorious-react": {
+      "name": "@annotorious/react",
+      "version": "3.0.0-pre-alpha-41",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
+    },
     "../recogito/text-annotator/packages/text-annotator-react": {
       "extraneous": true
     },
     "../text-annotator-js/packages/text-annotator": {
       "extraneous": true
+    },
+    "../text-annotator/packages/text-annotator-react": {
+      "name": "@recogito/react-text-annotator",
+      "version": "3.0.0-pre-alpha-47",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3",
+        "CETEIcean": "^1.8.0"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@annotorious/react": "^3.0.0-pre-alpha-41",
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
     },
     "../text-annotator/packages/text-annotator/react": {
       "extraneous": true
@@ -76,9 +126,9 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-40",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-40.tgz",
-      "integrity": "sha512-aIPc00LyZwfDPAXptdHYErIBjg1ksHf3KztHqHszpKfjpvsjTf5zRRe1iIDP9ffPlCJNxQV/g/FV0SjRCZ1laQ==",
+      "version": "3.0.0-pre-alpha-41",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-41.tgz",
+      "integrity": "sha512-Snsy4tQdYDcJMJnMkKuWpN0vVeLNg8lxyTGZL04IoY49bryxoJeULm7CCpgMYd4sf4XVnGBGP2ATKEQqv4hEmg==",
       "dependencies": {
         "@neodrag/react": "^2.0.3"
       },
@@ -2091,15 +2141,15 @@
       }
     },
     "node_modules/@recogito/react-text-annotator": {
-      "version": "3.0.0-pre-alpha-46",
-      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-46.tgz",
-      "integrity": "sha512-rryizOItArYQYm2glORAXTHPLTKyoK4bygt7D+SeH4VGL1Ofog/MAWw+nGdnXmleibQPTDkhNuLnmuJ9UqYi4A==",
+      "version": "3.0.0-pre-alpha-47",
+      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-47.tgz",
+      "integrity": "sha512-a//UeNRqQF92D+h4mON+IgXN10bHxwXxfFQ/ociqARJIvaxaBWxoYDf+yimjr8Y+wo02KNVPLsTFPdyxKK39cg==",
       "dependencies": {
         "@neodrag/react": "^2.0.3",
         "CETEIcean": "^1.8.0"
       },
       "peerDependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-40",
+        "@annotorious/react": "^3.0.0-pre-alpha-41",
         "openseadragon": "^3.1.0",
         "react": "16.8.0 || >=17.x",
         "react-dom": "16.8.0 || >=17.x"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "^3.0.0-pre-alpha-40",
+    "@annotorious/react": "^3.0.0-pre-alpha-41",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",
@@ -26,7 +26,7 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
-    "@recogito/react-text-annotator": "^3.0.0-pre-alpha-46",
+    "@recogito/react-text-annotator": "^3.0.0-pre-alpha-47",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",
     "@uppy/core": "^3.2.1",

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -171,6 +171,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
               present={present} 
               policies={policies}
               layers={layers}
+              sorting={(a, b) => a.target.selector.start - b.target.selector.start}
               onChangePanel={onChangeViewMenuPanel}
               onChangeFormatter={f => setFormatter(() => f)}
               beforeSelectAnnotation={beforeSelectAnnotation} />

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -11,7 +11,8 @@ import {
   useAnnotatorUser,
   useSelection,
   User,
-  Visibility, 
+  Visibility,
+  useViewportState, 
 } from '@annotorious/react';
 
 import './AnnotationList.css';
@@ -34,7 +35,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
 
   const el = useRef<HTMLUListElement>(null);
 
-  const annotations = useAnnotations();
+  const annotations = useAnnotations(250);
 
   const sorted = props.sorting ? [...annotations].sort(props.sorting) : annotations;
 

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Annotation } from '@components/Annotation';
 import type { Policies, Translations } from 'src/Types';
 import { 
+  Annotation as Anno,
   AnnotoriousOpenSeadragonAnnotator,
   PresentUser, 
   SupabaseAnnotation,
@@ -23,6 +24,8 @@ interface AnnotationListProps {
 
   policies?: Policies;
 
+  sorting?: ((a: Anno, b: Anno) => number);
+
   beforeSelect(a: SupabaseAnnotation | undefined): void;
 
 }
@@ -32,6 +35,8 @@ export const AnnotationList = (props: AnnotationListProps) => {
   const el = useRef<HTMLUListElement>(null);
 
   const annotations = useAnnotations();
+
+  const sorted = props.sorting ? [...annotations].sort(props.sorting) : annotations;
 
   const user = useAnnotatorUser();
 
@@ -88,7 +93,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
       ref={el}
       className="anno-sidepanel annotation-list" 
       onClick={onClick}>
-      {annotations.map(a => (
+      {sorted.map(a => (
         <li 
           key={a.id}
           onClick={event => onClick(event, a)}>

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
@@ -21,6 +21,8 @@ interface ViewMenuProps {
 
   layers?: Layer[];
 
+  sorting?: ((a: Annotation, b: Annotation) => number);
+
   onChangePanel(panel: ViewMenuPanel | undefined): void;
 
   beforeSelectAnnotation(a?: Annotation): void;
@@ -111,6 +113,7 @@ export const ViewMenu = (props: ViewMenuProps) => {
               i18n={props.i18n}
               present={props.present} 
               policies={props.policies}
+              sorting={props.sorting}
               beforeSelect={props.beforeSelectAnnotation} />
           ) : panel === ViewMenuPanel.LAYERS ? (
             <LayersPanel


### PR DESCRIPTION
## In this PR

This PR adds
- annotation sorting for the sidebar
- various smaller performance enhancements, by debouncing events that lead to lots of React re-renders

Note that most of the work for this PR has actually happened in the `@annotorious/*` and `@recogito/text-annotator` base packages.

__Caveat:__ sorting TEI annotations by text sequence is a non-trivial challenge. I therefore modified the data format of the TEI selectors to retain the character offset. This means __new TEI annotations will be sorted correctly__. Annotations already in the system which don't have the character offset stored will not be sorted.
