### PR TITLE
Defining Tag Sets for Projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-46",
+        "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -53,6 +53,28 @@
         "@types/uuid": "^9.0.1"
       }
     },
+    "../../annotorious/annotorious-v3/packages/annotorious-react": {
+      "version": "3.0.0-pre-alpha-46",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "devDependencies": {
+        "@types/react-dom": "^18.0.11",
+        "@vitejs/plugin-react": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "typescript": "^4.7.4",
+        "vite": "^4.2.1",
+        "vite-plugin-dts": "^2.3.0",
+        "vite-tsconfig-paths": "^4.2.0"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.0.0 || ^4.0.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
+    },
     "../recogito/text-annotator/packages/text-annotator-react": {
       "extraneous": true
     },
@@ -78,17 +100,8 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-46",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-46.tgz",
-      "integrity": "sha512-CMtwsgs3kHWGXtNi3GLQs/DqQCFBYiWsuAitAr5VYKTWGjIyWSu+alcRp0YbKDhTDElBtKgjbzAq7GRN3XzHDA==",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3"
-      },
-      "peerDependencies": {
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
+      "resolved": "../../annotorious/annotorious-v3/packages/annotorious-react",
+      "link": true
     },
     "node_modules/@astrojs/compiler": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
+        "@annotorious/react": "^3.0.0-pre-alpha-46",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -53,28 +53,6 @@
         "@types/uuid": "^9.0.1"
       }
     },
-    "../../annotorious/annotorious-v3/packages/annotorious-react": {
-      "version": "3.0.0-pre-alpha-46",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@neodrag/react": "^2.0.3"
-      },
-      "devDependencies": {
-        "@types/react-dom": "^18.0.11",
-        "@vitejs/plugin-react": "^3.1.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "typescript": "^4.7.4",
-        "vite": "^4.2.1",
-        "vite-plugin-dts": "^2.3.0",
-        "vite-tsconfig-paths": "^4.2.0"
-      },
-      "peerDependencies": {
-        "openseadragon": "^3.0.0 || ^4.0.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
-      }
-    },
     "../recogito/text-annotator/packages/text-annotator-react": {
       "extraneous": true
     },
@@ -100,8 +78,17 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "resolved": "../../annotorious/annotorious-v3/packages/annotorious-react",
-      "link": true
+      "version": "3.0.0-pre-alpha-46",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-46.tgz",
+      "integrity": "sha512-CMtwsgs3kHWGXtNi3GLQs/DqQCFBYiWsuAitAr5VYKTWGjIyWSu+alcRp0YbKDhTDElBtKgjbzAq7GRN3XzHDA==",
+      "dependencies": {
+        "@neodrag/react": "^2.0.3"
+      },
+      "peerDependencies": {
+        "openseadragon": "^3.1.0",
+        "react": "16.8.0 || >=17.x",
+        "react-dom": "16.8.0 || >=17.x"
+      }
     },
     "node_modules/@astrojs/compiler": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "^3.0.0-pre-alpha-46",
+    "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "file:../../annotorious/annotorious-v3/packages/annotorious-react",
+    "@annotorious/react": "^3.0.0-pre-alpha-46",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -249,7 +249,7 @@ export interface TagDefinition {
 
   name: string;
 
-  target_type: 'context' | 'document' | 'group' | 'layer' | 'profile' | 'project';
+  target_type?: 'context' | 'document' | 'group' | 'layer' | 'profile' | 'project';
 
   scope: 'organization' | 'project' | 'system';
 

--- a/src/apps/annotation-image/ImageAnnotation.tsx
+++ b/src/apps/annotation-image/ImageAnnotation.tsx
@@ -1,0 +1,23 @@
+import { Annotorious } from '@annotorious/react';
+import type { DocumentInTaggedContext, Translations } from 'src/Types';
+import { ImageAnnotationDesktop } from './ImageAnnotationDesktop';
+
+export interface ImageAnnotationProps {
+
+  i18n: Translations;
+
+  document: DocumentInTaggedContext;
+
+  channelId: string;
+
+}
+
+export const ImageAnnotation = (props: ImageAnnotationProps) => {
+
+  return (
+    <Annotorious>
+      <ImageAnnotationDesktop {...props} />
+    </Annotorious>
+  )
+
+}

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { DocumentInTaggedContext, Layer, Translations } from 'src/Types';
 import { getAllDocumentLayersInProject, isDefaultContext } from '@backend/helpers';
-import { useLayerPolicies } from '@backend/hooks';
+import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Annotation } from '@components/Annotation';
 import { createAppearenceProvider, PresenceStack } from '@components/Presence';
@@ -58,6 +58,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
   const [layers, setLayers] = useState<Layer[] | undefined>();
 
   const appearance = useMemo(() => createAppearenceProvider(), []);
+
+  const vocabulary = useTagVocabulary(props.document.context.project_id);
 
   useEffect(() => {
     if (policies) {
@@ -159,9 +161,10 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
                 popup ={props => (
                   <Annotation.Popup 
                     {...props} 
+                    i18n={i18n}
                     policies={policies}
                     present={present} 
-                    i18n={i18n} /> )} />
+                    tagVocabulary={vocabulary} /> )} />
             )}
 
             <div className="anno-desktop-left">
@@ -179,6 +182,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationDesktopProps) => {
                 present={present} 
                 policies={policies}
                 layers={layers}
+                tagVocabulary={vocabulary}
                 onChangePanel={onChangeViewMenuPanel} 
                 onChangeFormatter={f => setFormatter(() => f)}
                 beforeSelectAnnotation={beforeSelectAnnotation} />

--- a/src/apps/annotation-image/index.ts
+++ b/src/apps/annotation-image/index.ts
@@ -1,1 +1,1 @@
-export * from './ImageAnnotationDesktop';
+export * from './ImageAnnotation';

--- a/src/apps/annotation-text/TextAnnotation.tsx
+++ b/src/apps/annotation-text/TextAnnotation.tsx
@@ -1,0 +1,24 @@
+import { Annotorious } from '@annotorious/react';
+import { TextAnnotationDesktop } from './TextAnnotationDesktop';
+import type { DocumentInTaggedContext, Translations } from 'src/Types';
+
+export interface TextAnnotationProps {
+
+  i18n: Translations;
+
+  document: DocumentInTaggedContext;
+
+  channelId: string;
+
+}
+
+/** Wraps the actual text annotation desktop, so we can access Annotorious context **/
+export const TextAnnotation = (props: TextAnnotationProps) => {
+
+  return (
+    <Annotorious>
+      <TextAnnotationDesktop {...props} />
+    </Annotorious>
+  )
+
+}

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -35,7 +35,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
   const contentType = props.document.content_type;
 
-  const anno = useAnnotator<RecogitoTextAnnotator>();;
+  const anno = useAnnotator<RecogitoTextAnnotator>();
 
   const policies = useLayerPolicies(props.document.layers[0].id);
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { Annotorious, SupabasePlugin } from '@annotorious/react';
+import { useEffect, useState } from 'react';
+import { SupabasePlugin, useAnnotator } from '@annotorious/react';
 import type { Annotation as Anno, Formatter, PresentUser } from '@annotorious/react';
 import { 
   TEIAnnotator, 
@@ -15,10 +15,11 @@ import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
 import { PresenceStack, createAppearenceProvider } from '@components/Presence';
 import { Annotation } from '@components/Annotation';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
+import type { TextAnnotationProps } from './TextAnnotation';
 import { Toolbar } from './Toolbar';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { useContent } from './useContent';
-import type { DocumentInTaggedContext, Translations, Layer } from 'src/Types';
+import type { Layer } from 'src/Types';
 
 import './TEI.css';
 import './TextAnnotationDesktop.css';
@@ -28,23 +29,13 @@ const SUPABASE = import.meta.env.PUBLIC_SUPABASE;
 
 const SUPABASE_API_KEY = import.meta.env.PUBLIC_SUPABASE_API_KEY;
 
-export interface TextAnnotationDesktopProps {
-
-  i18n: Translations;
-
-  document: DocumentInTaggedContext;
-
-  channelId: string;
-
-}
-
-export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
+export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
   const { i18n } = props;
 
   const contentType = props.document.content_type;
 
-  const anno = useRef<RecogitoTextAnnotator>();
+  const anno = useAnnotator<RecogitoTextAnnotator>();;
 
   const policies = useLayerPolicies(props.document.layers[0].id);
 
@@ -98,98 +89,96 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
   }
 
   const beforeSelectAnnotation = (a?: Anno) => {
-    if (a && !usePopup && anno.current) {
+    if (a && !usePopup && anno) {
       const t = a as TextAnnotation;
       // Don't fit the view if the annotation is already selected
-      if (anno.current.state.selection.isSelected(t))
+      if (anno.state.selection.isSelected(t))
         return;
 
-      anno.current.scrollIntoView(t);
+      anno.scrollIntoView(t);
     }
   }
 
   return (
     <div className={contentType === 'text/xml' ? 'content-wrapper tei' : 'content-wrapper text'}>
-      <Annotorious ref={anno}>
-        <main>
-          {contentType === 'text/xml' && text ? (
-            <TEIAnnotator
-              formatter={formatter}
-              presence={{
-                font: "500 12px Inter, Arial, Helvetica, sans-serif"
-              }}>
-              <CETEIcean tei={text} />
-            </TEIAnnotator>
-          ) : text && (
-            <TextAnnotator
-              formatter={formatter}
-              presence={{
-                font: "500 12px Inter, Arial, Helvetica, sans-serif"
-              }}>
-              <p className="plaintext">{text}</p>
-            </TextAnnotator>
-          )}
-        </main>
+      <main>
+        {contentType === 'text/xml' && text ? (
+          <TEIAnnotator
+            formatter={formatter}
+            presence={{
+              font: "500 12px Inter, Arial, Helvetica, sans-serif"
+            }}>
+            <CETEIcean tei={text} />
+          </TEIAnnotator>
+        ) : text && (
+          <TextAnnotator
+            formatter={formatter}
+            presence={{
+              font: "500 12px Inter, Arial, Helvetica, sans-serif"
+            }}>
+            <p className="plaintext">{text}</p>
+          </TextAnnotator>
+        )}
+      </main>
 
-        <div className="anno-desktop ta-desktop">
-          <AnnotationDesktop.UndoStack 
-            undoEmpty={true} />
+      <div className="anno-desktop ta-desktop">
+        <AnnotationDesktop.UndoStack 
+          undoEmpty={true} />
 
-          {layers && 
-            <SupabasePlugin 
-              supabaseUrl={SUPABASE}
-              apiKey={SUPABASE_API_KEY} 
-              channel={props.channelId}
-              defaultLayer={props.document.layers[0].id} 
-              layerIds={layers.map(layer => layer.id)}
-              appearanceProvider={createAppearenceProvider()}
-              onPresence={setPresent} 
-              privacyMode={privacy === 'PRIVATE'}/>
-          }
+        {layers && 
+          <SupabasePlugin 
+            supabaseUrl={SUPABASE}
+            apiKey={SUPABASE_API_KEY} 
+            channel={props.channelId}
+            defaultLayer={props.document.layers[0].id} 
+            layerIds={layers.map(layer => layer.id)}
+            appearanceProvider={createAppearenceProvider()}
+            onPresence={setPresent} 
+            privacyMode={privacy === 'PRIVATE'}/>
+        }
 
-          {usePopup && (
-            <TextAnnotatorPopup
-              popup={props => (
-                <Annotation.Popup 
-                  {...props} 
-                  i18n={i18n} 
-                  present={present} 
-                  policies={policies}
-                  tagVocabulary={vocabulary} />
-              )} />
-          )}
+        {usePopup && (
+          <TextAnnotatorPopup
+            popup={props => (
+              <Annotation.Popup 
+                {...props} 
+                i18n={i18n} 
+                present={present} 
+                policies={policies}
+                tagVocabulary={vocabulary} />
+            )} />
+        )}
 
-          <div className="anno-desktop-left">
-            <AnnotationDesktop.DocumentMenu
-              i18n={props.i18n}
-              document={props.document} />
-          </div>
-
-          <div className="anno-desktop-right not-annotatable">
-            <PresenceStack
-              present={present}
-              limit={limit} />
-
-            <AnnotationDesktop.ViewMenu 
-              i18n={i18n}
-              present={present} 
-              policies={policies}
-              layers={layers}
-              sorting={(a, b) => a.target.selector.start - b.target.selector.start}
-              tagVocabulary={vocabulary}
-              onChangePanel={onChangeViewMenuPanel}
-              onChangeFormatter={f => setFormatter(() => f)}
-              beforeSelectAnnotation={beforeSelectAnnotation} />
-          </div>
-
-          <div className="anno-desktop-bottom">
-            <Toolbar 
-              i18n={props.i18n}
-              privacy={privacy}
-              onChangePrivacy={setPrivacy} />
-          </div>
+        <div className="anno-desktop-left">
+          <AnnotationDesktop.DocumentMenu
+            i18n={props.i18n}
+            document={props.document} />
         </div>
-      </Annotorious>
+
+        <div className="anno-desktop-right not-annotatable">
+          <PresenceStack
+            present={present}
+            limit={limit} />
+
+          <AnnotationDesktop.ViewMenu 
+            i18n={i18n}
+            present={present} 
+            policies={policies}
+            layers={layers}
+            sorting={(a, b) => a.target.selector.start - b.target.selector.start}
+            tagVocabulary={vocabulary}
+            onChangePanel={onChangeViewMenuPanel}
+            onChangeFormatter={f => setFormatter(() => f)}
+            beforeSelectAnnotation={beforeSelectAnnotation} />
+        </div>
+
+        <div className="anno-desktop-bottom">
+          <Toolbar 
+            i18n={props.i18n}
+            privacy={privacy}
+            onChangePrivacy={setPrivacy} />
+        </div>
+      </div>
     </div>
   )
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -11,7 +11,7 @@ import {
 } from '@recogito/react-text-annotator';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { getAllDocumentLayersInProject, isDefaultContext } from '@backend/helpers';
-import { useLayerPolicies } from '@backend/hooks';
+import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
 import { PresenceStack, createAppearenceProvider } from '@components/Presence';
 import { Annotation } from '@components/Annotation';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
@@ -59,6 +59,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
   const [privacy, setPrivacy] = useState<PrivacyMode>('PUBLIC');
 
   const [layers, setLayers] = useState<Layer[] | undefined>();
+
+  const vocabulary = useTagVocabulary(props.document.context.project_id);
 
   useEffect(() => {
     if (policies) {
@@ -150,9 +152,10 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
               popup={props => (
                 <Annotation.Popup 
                   {...props} 
+                  i18n={i18n} 
                   present={present} 
                   policies={policies}
-                  i18n={i18n} />
+                  tagVocabulary={vocabulary} />
               )} />
           )}
 
@@ -173,6 +176,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationDesktopProps) => {
               policies={policies}
               layers={layers}
               sorting={(a, b) => a.target.selector.start - b.target.selector.start}
+              tagVocabulary={vocabulary}
               onChangePanel={onChangeViewMenuPanel}
               onChangeFormatter={f => setFormatter(() => f)}
               beforeSelectAnnotation={beforeSelectAnnotation} />

--- a/src/apps/annotation-text/index.ts
+++ b/src/apps/annotation-text/index.ts
@@ -1,1 +1,1 @@
-export * from './TextAnnotationDesktop';
+export * from './TextAnnotation';

--- a/src/apps/project-collaboration/ProjectCollaboration.tsx
+++ b/src/apps/project-collaboration/ProjectCollaboration.tsx
@@ -7,7 +7,7 @@ import type { ExtendedProjectData, Invitation, MyProfile, Group, Translations } 
 
 import './ProjectCollaboration.css';
 
-interface ManageUsersProps {
+interface ProjectCollaborationProps {
 
   i18n: Translations;
 
@@ -19,7 +19,7 @@ interface ManageUsersProps {
 
 };
 
-export const ProjectCollaboration = (props: ManageUsersProps) => {
+export const ProjectCollaboration = (props: ProjectCollaborationProps) => {
 
   const { t } = props.i18n;
 

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -2,3 +2,20 @@
   padding: 20px 40px;
   width: 100%;
 }
+
+.project-settings .tagging-vocabulary {
+  background-color: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--border-radius);
+  max-width: 65ch;
+  padding: 20px;
+}
+
+.project-settings .tagging-vocabulary h2 {
+  margin-top: 0.2em;
+}
+
+.project-settings .tagging-vocabulary p {
+  font-size: var(--font-small);
+  line-height: 160%;
+}

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -23,7 +23,7 @@
 .project-settings .tagging-vocabulary textarea {
   height: 12em;
   line-height: 150%;
-  margin-bottom: 0.5em;
+  margin: 0.5em 0;
   max-width: 65ch;
   min-width: 30ch;
   resize: none;

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -19,3 +19,19 @@
   font-size: var(--font-small);
   line-height: 160%;
 }
+
+.project-settings .tagging-vocabulary textarea {
+  height: 12em;
+  line-height: 150%;
+  margin-bottom: 0.5em;
+  max-width: 65ch;
+  min-width: 30ch;
+  resize: none;
+  width: 45ch;
+}
+
+.project-settings .tagging-vocabulary .buttons {
+  display: flex;
+  gap: 0.2em;
+  align-items: center;
+} 

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -1,0 +1,4 @@
+.project-settings {
+  padding: 20px 40px;
+  width: 100%;
+}

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getProjectTagVocabulary, setProjectTagVocabulary } from '@backend/helpers';
+import { clearProjectTagVocabulary, getProjectTagVocabulary, setProjectTagVocabulary } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Button } from '@components/Button';
 import { SaveState, TinySaveIndicator } from '@components/TinySaveIndicator';
@@ -47,7 +47,7 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
   }
 
   const saveVocabulary = () => {
-    setState('saving')
+    setState('saving');
 
     setProjectTagVocabulary(supabase, props.project.id, vocabulary)
       .then(() => { 
@@ -63,6 +63,31 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
         });
 
         setState('failed');
+      });
+  }
+
+  const clearVocabulary = () => {
+    setState('saving');
+
+    const prev = vocabulary;
+
+    setVocabulary([]);
+
+    clearProjectTagVocabulary(supabase, props.project.id)
+      .then(() => {
+        setState('success');
+      })
+      .catch(() => {
+        setToast({ 
+          title: t['Something went wrong'], 
+          description: t['Error saving tag vocabulary.'], 
+          type: 'error' 
+        });
+
+        setState('failed');
+
+        // Roll back
+        setVocabulary(prev);
       });
   }
 
@@ -90,7 +115,11 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
             value={vocabulary.join('\n')} 
             onChange={onChange} />
 
-          <div>
+          <div className="buttons">
+            <Button
+              onClick={clearVocabulary}>
+              <span>Clear</span>
+            </Button>
             <Button
               busy={state === 'saving'}
               className="primary"

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import type { Translations } from 'src/Types';
+
+import './ProjectSettings.css';
+
+interface ProjectSettingsProps {
+
+  i18n: Translations;
+
+};
+
+export const ProjectSettings = (props: ProjectSettingsProps) => {
+
+  const { t } = props.i18n;
+
+  const [vocabulary, setVocabulary] = useState<string[]>([]);
+
+  const onChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = evt.target;
+    setVocabulary(value.split('\n'));
+  }
+
+  return (
+    <div className="project-collaboration">
+      <h1>{t['Project Settings']}</h1>
+
+      <h2>Tagging Vocabulary</h2>
+      <p>
+        One per line...
+      </p>
+      <textarea 
+        value={vocabulary.join('\n')} 
+        onChange={onChange} />
+    </div>
+  )
+
+}

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -71,26 +71,38 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
       <ToastProvider>
         <h1>{t['Project Settings']}</h1>
 
-        <h2>Tagging Vocabulary</h2>
-        <p>
-          One per line...
-        </p>
-        <textarea 
-          value={vocabulary.join('\n')} 
-          onChange={onChange} />
+        <div className="tagging-vocabulary">
+          <h2>Tagging Vocabulary</h2>
 
-        <div>
-          <Button
-            busy={state === 'saving'}
-            className="primary"
-            onClick={saveVocabulary}>
-            <span>Save</span>
-          </Button>
+          <p>
+            You can pre-define a tagging vocabulary for this project 
+            by copying and pasting terms into the text area below,
+            one term per line.
+          </p>
 
-          <TinySaveIndicator 
-            resultOnly
-            state={state} 
-            fadeOut={2500} />
+          <p>
+            The terms will appear as autocomplete options when users
+            create new tags in the annotation interface. Please note that
+            users will still be able to add their own tags, too.
+          </p>
+
+          <textarea 
+            value={vocabulary.join('\n')} 
+            onChange={onChange} />
+
+          <div>
+            <Button
+              busy={state === 'saving'}
+              className="primary"
+              onClick={saveVocabulary}>
+              <span>Save</span>
+            </Button>
+
+            <TinySaveIndicator 
+              resultOnly
+              state={state} 
+              fadeOut={2500} />
+          </div>
         </div>
 
         <Toast

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -1,5 +1,10 @@
-import { useState } from 'react';
-import type { Translations } from 'src/Types';
+import { useEffect, useState } from 'react';
+import { getProjectTagVocabulary, setProjectTagVocabulary } from '@backend/helpers';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { Button } from '@components/Button';
+import { SaveState, TinySaveIndicator } from '@components/TinySaveIndicator';
+import { Toast, ToastContent, ToastProvider } from '@components/Toast';
+import type { ExtendedProjectData, Translations } from 'src/Types';
 
 import './ProjectSettings.css';
 
@@ -7,30 +12,91 @@ interface ProjectSettingsProps {
 
   i18n: Translations;
 
+  project: ExtendedProjectData;
+
 };
 
 export const ProjectSettings = (props: ProjectSettingsProps) => {
 
   const { t } = props.i18n;
 
+  const [toast, setToast] = useState<ToastContent | null>(null);
+
   const [vocabulary, setVocabulary] = useState<string[]>([]);
+
+  const [state, setState] = useState<SaveState>('idle');
+
+  useEffect(() => {
+    getProjectTagVocabulary(supabase, props.project.id)
+      .then(({ error, data }) => {
+        if (error) {
+          setToast({ 
+            title: t['Something went wrong'], 
+            description: t['Error loading tag vocabulary.'], 
+            type: 'error' 
+          });
+        } else {
+          setVocabulary(data.map(t => t.name));
+        }
+      });
+  }, []);
 
   const onChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = evt.target;
     setVocabulary(value.split('\n'));
   }
 
-  return (
-    <div className="project-collaboration">
-      <h1>{t['Project Settings']}</h1>
+  const saveVocabulary = () => {
+    setState('saving')
 
-      <h2>Tagging Vocabulary</h2>
-      <p>
-        One per line...
-      </p>
-      <textarea 
-        value={vocabulary.join('\n')} 
-        onChange={onChange} />
+    setProjectTagVocabulary(supabase, props.project.id, vocabulary)
+      .then(() => { 
+        setState('success');
+      })
+      .catch(error => {
+        console.error(error);
+
+        setToast({ 
+          title: t['Something went wrong'], 
+          description: t['Error saving tag vocabulary.'], 
+          type: 'error' 
+        });
+
+        setState('failed');
+      });
+  }
+
+  return (
+    <div className="project-settings">
+      <ToastProvider>
+        <h1>{t['Project Settings']}</h1>
+
+        <h2>Tagging Vocabulary</h2>
+        <p>
+          One per line...
+        </p>
+        <textarea 
+          value={vocabulary.join('\n')} 
+          onChange={onChange} />
+
+        <div>
+          <Button
+            busy={state === 'saving'}
+            className="primary"
+            onClick={saveVocabulary}>
+            <span>Save</span>
+          </Button>
+
+          <TinySaveIndicator 
+            resultOnly
+            state={state} 
+            fadeOut={2500} />
+        </div>
+
+        <Toast
+          content={toast}
+          onOpenChange={open => !open && setToast(null)} />
+      </ToastProvider>
     </div>
   )
 

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -97,18 +97,14 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
         <h1>{t['Project Settings']}</h1>
 
         <div className="tagging-vocabulary">
-          <h2>Tagging Vocabulary</h2>
+          <h2>{t['Tagging Vocabulary']}</h2>
 
           <p>
-            You can pre-define a tagging vocabulary for this project 
-            by copying and pasting terms into the text area below,
-            one term per line.
+            {t['You can pre-define a tagging vocabulary']}
           </p>
 
           <p>
-            The terms will appear as autocomplete options when users
-            create new tags in the annotation interface. Please note that
-            users will still be able to add their own tags, too.
+            {t['The terms will appear as autocomplete options']}
           </p>
 
           <textarea 
@@ -118,13 +114,13 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
           <div className="buttons">
             <Button
               onClick={clearVocabulary}>
-              <span>Clear</span>
+              <span>{t['Clear']}</span>
             </Button>
             <Button
               busy={state === 'saving'}
               className="primary"
               onClick={saveVocabulary}>
-              <span>Save</span>
+              <span>{t['Save']}</span>
             </Button>
 
             <TinySaveIndicator 

--- a/src/apps/project-settings/index.ts
+++ b/src/apps/project-settings/index.ts
@@ -1,0 +1,1 @@
+export * from './ProjectSettings';

--- a/src/backend/hooks/index.ts
+++ b/src/backend/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useAssignments';
 export * from './usePolicies';
+export * from './useTagVocabulary';

--- a/src/backend/hooks/useTagVocabulary.ts
+++ b/src/backend/hooks/useTagVocabulary.ts
@@ -1,0 +1,21 @@
+import { getProjectTagVocabulary } from '@backend/helpers';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { useEffect, useState } from 'react';
+
+export const useTagVocabulary = (projectId: string) => {
+
+  const [vocabulary, setVocabulary] = useState<string[]>([]);
+
+  useEffect(() => {
+    getProjectTagVocabulary(supabase, projectId)
+      .then(({ error, data }) => {
+        if (error)
+          console.error(error)
+        else
+          setVocabulary(data.map(t => t.name));
+      });
+  }, []);
+
+  return vocabulary;
+
+}

--- a/src/backend/hooks/useTagVocabulary.ts
+++ b/src/backend/hooks/useTagVocabulary.ts
@@ -1,3 +1,4 @@
+import { Annotation, StoreChangeEvent, useAnnotationStore } from '@annotorious/react';
 import { getProjectTagVocabulary } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { useEffect, useState } from 'react';
@@ -5,6 +6,8 @@ import { useEffect, useState } from 'react';
 export const useTagVocabulary = (projectId: string) => {
 
   const [vocabulary, setVocabulary] = useState<string[]>([]);
+
+  const store = useAnnotationStore();
 
   useEffect(() => {
     getProjectTagVocabulary(supabase, projectId)
@@ -15,6 +18,22 @@ export const useTagVocabulary = (projectId: string) => {
           setVocabulary(data.map(t => t.name));
       });
   }, []);
+
+  useEffect(() => {
+    if (store) {
+      const onChange = (event: StoreChangeEvent<Annotation>) => {
+        // TODO observe store changes and update the tag set dynamically!
+        console.log(event);
+      }
+
+      store.observe(onChange);
+
+      return () => {
+        store.unobserve(onChange);
+      }
+    }
+  }, [store]);
+
 
   return vocabulary;
 

--- a/src/components/Annotation/Card/BaseCard.tsx
+++ b/src/components/Annotation/Card/BaseCard.tsx
@@ -87,7 +87,8 @@ export const BaseCard = (props: BaseCardProps) => {
       <TagsWidget 
         i18n={props.i18n}
         annotation={props.annotation} 
-        me={me} />
+        me={me} 
+        vocabulary={props.tagVocabulary} />
 
       {comments.length > 0 && (
         <ul className="annotation-card-comments-container">

--- a/src/components/Annotation/Card/CardProps.ts
+++ b/src/components/Annotation/Card/CardProps.ts
@@ -15,6 +15,8 @@ export interface CardProps {
 
   showReplyForm?: boolean;
 
+  tagVocabulary?: string[];
+
   onReply?(body: AnnotationBody): void;
 
 }

--- a/src/components/Annotation/Popup/Popup.tsx
+++ b/src/components/Annotation/Popup/Popup.tsx
@@ -15,6 +15,8 @@ interface PopupProps {
 
   policies?: Policies;
 
+  tagVocabulary?: string[];
+
 }
 
 export const Popup = (props: PopupProps) => {

--- a/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
@@ -78,21 +78,20 @@ export const Autocomplete = (props: AutocompleteProps) => {
     if (evt.key === 'Enter') {
       onSubmit();
     } else if (evt.key === 'Escape') {
+      setSuggestions([]);
+      setHighlightedIndex(undefined);
       props.onCancel && props.onCancel();
     } else {
       // Neither enter nor cancel
-      console.log('key', evt.key);
       if (suggestions.length > 0) {
-        if (evt.which === 38) {
-          // Key up
+        if (evt.key === 'ArrowUp') {
           if (highlightedIndex === undefined) {
             setHighlightedIndex(0);
           } else {
             const prev = Math.max(0, highlightedIndex - 1);
             setHighlightedIndex(prev);
           }
-        } else if (evt.which === 40) {
-          // Key down
+        } else if (evt.key === 'ArrowDown') {
           if (highlightedIndex === undefined) {
             setHighlightedIndex(0);
           } else {
@@ -103,9 +102,8 @@ export const Autocomplete = (props: AutocompleteProps) => {
       } else {
         // No suggestions: key down shows all vocab 
         // options (only for hard-wired vocabs!)
-        if (evt.which === 40) {
-          if (Array.isArray(props.vocabulary))
-            setSuggestions(props.vocabulary);
+        if (evt.key === 'ArrowDown') {
+          setSuggestions(props.vocabulary);
         }
       }
     }

--- a/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
@@ -41,6 +41,10 @@ export const Autocomplete = (props: AutocompleteProps) => {
     props.onChange && props.onChange(value);
   }, [value]);
 
+  useEffect(() => {
+    element.current?.querySelector('.selected')?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
   const getSuggestions = (value: string) => {
     const suggestions = getVocabSuggestions(value, props.vocabulary);
     setSuggestions(suggestions);

--- a/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
@@ -142,11 +142,7 @@ export const Autocomplete = (props: AutocompleteProps) => {
             key={`${item}-${index}`}
             onClick={onSubmit}
             onMouseEnter={() => setHighlightedIndex(index)}
-            style={
-                highlightedIndex === index
-                  ? { backgroundColor: '#bde4ff' }
-                  : {}
-              }>
+            className={highlightedIndex === index ? 'selected' : undefined}>
             {item}
           </li>
         ))}

--- a/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/Autocomplete.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react';
+
+const getVocabSuggestions = (query: string, vocabulary: string[]) =>
+  vocabulary.filter(item =>
+    item.toLowerCase().startsWith(query.toLowerCase()));
+
+interface AutocompleteProps {
+
+  focus?: boolean;
+
+  placeholder?: string;
+
+  initialValue?: string;
+
+  vocabulary: string[];
+
+  onChange?(value: string): void;
+
+  onSubmit(value: string): void;
+
+  onCancel?(): void;
+
+}
+
+export const Autocomplete = (props: AutocompleteProps) => {
+
+  const element = useRef<HTMLDivElement>(null);
+
+  const [value, setValue] = useState(props.initialValue || '');
+
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  const [highlightedIndex, setHighlightedIndex] = useState<number | undefined>();
+
+  useEffect(() => {
+    if (props.focus)
+      element.current?.querySelector('input')?.focus({ preventScroll: true });
+  }, []);
+
+  useEffect(() => {
+    props.onChange && props.onChange(value);
+  }, [value]);
+
+  const getSuggestions = (value: string) => {
+    const suggestions = getVocabSuggestions(value, props.vocabulary);
+    setSuggestions(suggestions);
+  }
+
+  const onSubmit = () => {
+    if (highlightedIndex !== undefined) {
+      // Submit highligted suggestion
+      props.onSubmit(suggestions[highlightedIndex]);
+    } else {
+      // Submit input value
+      const trimmed = value.trim();
+
+      if (trimmed) {
+        // If there is a vocabulary with the same label, use that
+        const matchingTerm = Array.isArray(props.vocabulary) ?
+          props.vocabulary.find(term =>
+            term.toLowerCase() === trimmed.toLowerCase()) : null;
+
+        if (matchingTerm) {
+          props.onSubmit(matchingTerm);
+        } else {
+          // Otherwise, just use as a freetext tag
+          props.onSubmit(trimmed);
+        }
+      }
+    }
+
+    setValue('');
+    setSuggestions([]);
+    setHighlightedIndex(undefined);
+  }
+
+  const onKeyDown = (evt: React.KeyboardEvent) => {
+    if (evt.key === 'Enter') {
+      onSubmit();
+    } else if (evt.key === 'Escape') {
+      props.onCancel && props.onCancel();
+    } else {
+      // Neither enter nor cancel
+      console.log('key', evt.key);
+      if (suggestions.length > 0) {
+        if (evt.which === 38) {
+          // Key up
+          if (highlightedIndex === undefined) {
+            setHighlightedIndex(0);
+          } else {
+            const prev = Math.max(0, highlightedIndex - 1);
+            setHighlightedIndex(prev);
+          }
+        } else if (evt.which === 40) {
+          // Key down
+          if (highlightedIndex === undefined) {
+            setHighlightedIndex(0);
+          } else {
+            const next = Math.min(suggestions.length - 1, highlightedIndex + 1);
+            setHighlightedIndex(next);
+          }
+        }
+      } else {
+        // No suggestions: key down shows all vocab 
+        // options (only for hard-wired vocabs!)
+        if (evt.which === 40) {
+          if (Array.isArray(props.vocabulary))
+            setSuggestions(props.vocabulary);
+        }
+      }
+    }
+  }
+
+  const onChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = evt.target;
+    setValue(value);
+
+    // Typing on the input resets the highlight
+    setHighlightedIndex(undefined);
+
+    if (value)
+      getSuggestions(value);
+    else
+      setSuggestions([]);
+  }
+
+  return (
+    <div
+      ref={element}  
+      className="tag-autocomplete">
+      <div>
+        <input
+          onKeyDown={onKeyDown}
+          onChange={onChange}
+          value={value}
+          placeholder={props.placeholder} />
+      </div>
+      
+      <ul>
+        {suggestions.length > 0 && suggestions.map((item, index) => (
+          <li 
+            key={`${item}-${index}`}
+            onClick={onSubmit}
+            onMouseEnter={() => setHighlightedIndex(index)}
+            style={
+                highlightedIndex === index
+                  ? { backgroundColor: '#bde4ff' }
+                  : {}
+              }>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.css
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.css
@@ -1,7 +1,10 @@
+.tag-autocomplete {
+  position: relative;
+  z-index: 1;
+}
 
 .annotation-tagswidget .tag-autocomplete {
   display: inline;
-  position: relative;
 }
 
 .annotation-tagswidget .tag-autocomplete input {
@@ -14,29 +17,29 @@
   transition: all 180ms;
 }
 
-.annotation-tagswidget .tag-autocomplete input:focus {
+.tag-autocomplete input:focus {
   box-shadow: none;
 }
 
-.annotation-tagswidget .tag-autocomplete ul {
+.tag-autocomplete ul {
   background-color: #fff;
   border-radius: 3px;
   box-shadow: 0 0 20px rgba(0,0,0,0.25);
   list-style-type: none;
   margin: 0;
   max-height: 200px;
-  min-width: 180px;
+  min-width: 172px;
   overflow-y: auto;
   padding: 0;
   position: absolute;
   z-index: 9999;
 }
 
-.annotation-tagswidget .tag-autocomplete ul:empty {
+.tag-autocomplete ul:empty {
   display: none;
 }
 
-.annotation-tagswidget .tag-autocomplete li {
+.tag-autocomplete li {
   box-sizing: border-box;
   cursor: pointer;
   display: block;
@@ -45,14 +48,18 @@
   width: 100%;
 }
 
-.annotation-tagswidget .tag-autocomplete li.selected {
+.annotation-tagswidget .tag-autocomplete li {
+  display: block;
+}
+
+.tag-autocomplete li.selected {
   background-color: var(--button-focus-outline-color);
 }
 
-.annotation-tagswidget .tag-autocomplete li:first-child {
+.tag-autocomplete li:first-child {
   border-radius: 3px 3px 0 0;
 }
 
-.annotation-tagswidget .tag-autocomplete li:last-child {
+.tag-autocomplete li:last-child {
   border-radius: 0 0 3px 3px;
 }

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.css
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.css
@@ -1,54 +1,55 @@
 
-form.annotation-tag-input-form input {
+.annotation-tagswidget .tag-autocomplete {
+  display: inline;
+  position: relative;
+}
+
+.annotation-tagswidget .tag-autocomplete input {
   background-color: transparent;
   border: none;
   border-radius: 3px;
   font-size: 12px;
   padding: 4px;
+  outline: none;
   transition: all 180ms;
 }
 
-form.annotation-tag-input-form input:focus {
-  background-color: var(--gray-300);
+.annotation-tagswidget .tag-autocomplete input:focus {
   box-shadow: none;
 }
 
-.tag-autocomplete {
-  display:inline;
-  position:relative;
+.annotation-tagswidget .tag-autocomplete ul {
+  background-color: #fff;
+  border-radius: 3px;
+  box-shadow: 0 0 20px rgba(0,0,0,0.25);
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  z-index: 9999;
 }
 
-.tag-autocomplete input {
-  outline:none;
-  border:none;
-  width:80px;
-  height:100%;
-  line-height:14px;
-  white-space:pre;
-  box-sizing:border-box;
-  background-color:transparent;
-  font-size:14px;
+.annotation-tagswidget .tag-autocomplete ul:empty {
+  display: none;
 }
 
-.tag-autocomplete ul {
-  position:absolute;
-  margin:0;
-  padding:0;
-  list-style-type:none;
-  background-color:#fff;
-  border-radius:3px;
-  border:1px solid #d6d7d9;
-  box-sizing:border-box;
-  box-shadow:0 0 20px rgba(0,0,0,0.25);
+.annotation-tagswidget .tag-autocomplete li {
+  box-sizing: border-box;
+  cursor: pointer;
+  display: block;
+  font-size: 12px;
+  padding: 8px 12px;
+  width: 100%;
 }
 
-.tag-autocomplete ul:empty {
-  display:none;
+.annotation-tagswidget .tag-autocomplete li.selected {
+  background-color: var(--button-focus-outline-color);
 }
 
-.tag-autocomplete li {
-  box-sizing:border-box;
-  padding:2px 12px;
-  width:100%;
-  cursor:pointer;
+.annotation-tagswidget .tag-autocomplete li:first-child {
+  border-radius: 3px 3px 0 0;
+}
+
+.annotation-tagswidget .tag-autocomplete li:last-child {
+  border-radius: 0 0 3px 3px;
 }

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.css
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.css
@@ -1,6 +1,3 @@
-form.annotation-tag-input-form {
-  display: inline;
-}
 
 form.annotation-tag-input-form input {
   background-color: transparent;
@@ -14,4 +11,44 @@ form.annotation-tag-input-form input {
 form.annotation-tag-input-form input:focus {
   background-color: var(--gray-300);
   box-shadow: none;
+}
+
+.tag-autocomplete {
+  display:inline;
+  position:relative;
+}
+
+.tag-autocomplete input {
+  outline:none;
+  border:none;
+  width:80px;
+  height:100%;
+  line-height:14px;
+  white-space:pre;
+  box-sizing:border-box;
+  background-color:transparent;
+  font-size:14px;
+}
+
+.tag-autocomplete ul {
+  position:absolute;
+  margin:0;
+  padding:0;
+  list-style-type:none;
+  background-color:#fff;
+  border-radius:3px;
+  border:1px solid #d6d7d9;
+  box-sizing:border-box;
+  box-shadow:0 0 20px rgba(0,0,0,0.25);
+}
+
+.tag-autocomplete ul:empty {
+  display:none;
+}
+
+.tag-autocomplete li {
+  box-sizing:border-box;
+  padding:2px 12px;
+  width:100%;
+  cursor:pointer;
 }

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.css
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.css
@@ -24,6 +24,9 @@
   box-shadow: 0 0 20px rgba(0,0,0,0.25);
   list-style-type: none;
   margin: 0;
+  max-height: 200px;
+  min-width: 180px;
+  overflow-y: auto;
   padding: 0;
   position: absolute;
   z-index: 9999;

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.tsx
@@ -1,7 +1,7 @@
-import { ChangeEvent, FormEvent, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import type { Annotation, AnnotationBody, PresentUser, User } from '@annotorious/react';
 import type { Translations } from 'src/Types';
+import { Autocomplete } from './Autocomplete';
 
 import './TagInput.css';
 
@@ -23,14 +23,7 @@ export const TagInput = (props: TagInputProps) => {
 
   const { me } = props;
   
-  const [value, setValue] = useState('');
-
-  const onChange = (event: ChangeEvent<HTMLInputElement>) =>
-    setValue(event.target.value)
-
-  const onSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
+  const onSubmit = (value: string) => {
     const tag: AnnotationBody = {
       id: uuidv4(),
       annotation: props.annotation.id,
@@ -44,18 +37,14 @@ export const TagInput = (props: TagInputProps) => {
       value
     };
 
-    setValue('');
-
     props.onCreate(tag);
   }
 
   return (
-    <form className="annotation-tag-input-form" onSubmit={onSubmit}>
-      <input 
-        placeholder={props.i18n.t['Add a tag...']}
-        value={value} 
-        onChange={onChange} />
-    </form>
+    <Autocomplete
+      placeholder={props.i18n.t['Add a tag...']} 
+      onSubmit={onSubmit}
+      vocabulary={props.vocabulary || []} />
   )
 
 }

--- a/src/components/Annotation/TagsWidget/TagInput/TagInput.tsx
+++ b/src/components/Annotation/TagsWidget/TagInput/TagInput.tsx
@@ -13,6 +13,8 @@ export interface TagInputProps {
 
   annotation: Annotation;
 
+  vocabulary?: string[];
+
   onCreate(tag: AnnotationBody): void;
 
 }

--- a/src/components/Annotation/TagsWidget/TagsWidget.css
+++ b/src/components/Annotation/TagsWidget/TagsWidget.css
@@ -5,6 +5,7 @@
   line-height: 100%;
   padding: 10px;
   position: relative;
+  z-index: 999;
 }
 
 .annotation-tagswidget .tags {

--- a/src/components/Annotation/TagsWidget/TagsWidget.tsx
+++ b/src/components/Annotation/TagsWidget/TagsWidget.tsx
@@ -16,6 +16,8 @@ interface TagsWidgetProps {
 
   me: PresentUser | User;
 
+  vocabulary?: string[];
+
 }
 
 export const TagsWidget = (props: TagsWidgetProps) => {
@@ -58,6 +60,7 @@ export const TagsWidget = (props: TagsWidgetProps) => {
             i18n={props.i18n} 
             annotation={props.annotation}
             me={props.me}
+            vocabulary={props.vocabulary}
             onCreate={onCreate} />
         ) : more > 0 && (
           <MoreTags 

--- a/src/components/Annotation/TagsWidget/TagsWidget.tsx
+++ b/src/components/Annotation/TagsWidget/TagsWidget.tsx
@@ -76,6 +76,7 @@ export const TagsWidget = (props: TagsWidgetProps) => {
           i18n={props.i18n} 
           annotation={props.annotation} 
           me={props.me} 
+          vocabulary={props.vocabulary}
           onCreate={onCreate} />
       )}
     </div>

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.css
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.css
@@ -4,7 +4,7 @@
   scroll-padding: 20px;
 }
 
-.anno-sidepanel.annotation-list ul {
+.anno-sidepanel.annotation-list > ul {
   height: 100%;
   list-style-type: none;  
   margin: 0;

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -30,6 +30,8 @@ interface AnnotationListProps {
 
   sorting?: ((a: Anno, b: Anno) => number);
 
+  tagVocabulary?: string[];
+
   beforeSelect(a: SupabaseAnnotation | undefined): void;
 
 }
@@ -160,7 +162,8 @@ export const AnnotationList = (props: AnnotationListProps) => {
                   showReplyForm={isSelected(a)}
                   i18n={props.i18n}
                   annotation={a} 
-                  present={props.present} />
+                  present={props.present}
+                  tagVocabulary={props.tagVocabulary} />
               ) : (
                 <Annotation.PublicCard 
                   className={isSelected(a) ? 'selected' : undefined}
@@ -168,7 +171,8 @@ export const AnnotationList = (props: AnnotationListProps) => {
                   i18n={props.i18n}
                   annotation={a} 
                   present={props.present}
-                  policies={props.policies} />  
+                  policies={props.policies} 
+                  tagVocabulary={props.tagVocabulary} />  
               )
             )}
           </li>

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
@@ -23,6 +23,8 @@ interface ViewMenuProps {
 
   sorting?: ((a: Annotation, b: Annotation) => number);
 
+  tagVocabulary?: string[];
+
   onChangePanel(panel: ViewMenuPanel | undefined): void;
 
   beforeSelectAnnotation(a?: Annotation): void;
@@ -115,6 +117,7 @@ export const ViewMenu = (props: ViewMenuProps) => {
               me={me}
               policies={props.policies}
               sorting={props.sorting}
+              tagVocabulary={props.tagVocabulary}
               beforeSelect={props.beforeSelectAnnotation} />
           ) : panel === ViewMenuPanel.LAYERS ? (
             <LayersPanel

--- a/src/components/TinySaveIndicator/TinySaveIndicator.tsx
+++ b/src/components/TinySaveIndicator/TinySaveIndicator.tsx
@@ -7,6 +7,8 @@ import './TinySaveIndicator.css';
 export type SaveState = 'saving' | 'success' | 'failed' | 'idle';
 
 interface TinySaveIndicatorProps {
+
+  resultOnly?: boolean;
   
   state: SaveState;
 
@@ -46,7 +48,7 @@ export const TinySaveIndicator = (props: TinySaveIndicatorProps) => {
         <Check size={16} weight="bold" />
       ) : state === 'failed' ? (
         <X size={16} weight="bold" />
-      ) : (
+      ) : !props.resultOnly && (
         <Spinner className="button-busy-spinner" size={16} />
       )}
     </div>

--- a/src/i18n/de/index.ts
+++ b/src/i18n/de/index.ts
@@ -13,6 +13,7 @@ import projectAssignmentDetails from './project-assignment-details.json';
 import projectAssignments from './project-assignments.json';
 import projectCollaboration from './project-collaboration.json';
 import projectHome from './project-home.json';
+import projectSettings from './project-settings.json';
 import projectSidedbar from './project-sidebar.json';
 
 export default {
@@ -28,5 +29,6 @@ export default {
   'project-assignments': projectAssignments,
   'project-collaboration': projectCollaboration,
   'project-home': projectHome,
+  'project-settings': projectSettings,
   'project-sidebar': { ...projectSidedbar, ...accountMenu }
 }

--- a/src/i18n/de/project-settings.json
+++ b/src/i18n/de/project-settings.json
@@ -1,0 +1,3 @@
+{
+  "Project Settings": "Projekteinstellungen"
+}

--- a/src/i18n/de/project-settings.json
+++ b/src/i18n/de/project-settings.json
@@ -1,3 +1,13 @@
 {
-  "Project Settings": "Projekteinstellungen"
+  "Project Settings": "Projekteinstellungen",
+
+  "Tagging Vocabulary": "Tag-Vokabular",
+  "You can pre-define a tagging vocabulary": "Füge Begriffe in das Textfeld ein, um ein Tag-Vokabular für dieses Projekt festzulegen (ein Begriff pro Zeile).",
+  "The terms will appear as autocomplete options": "In der Annotations-Ansicht werden die Begriffe als Autocomplete-Optionen vorgeschlagen, wenn Benutzer neue Tags anlegen. Beachte dass Benutzer nach wie vor auch eigene Tags verwenden können.",
+  "Clear": "Löschen",
+  "Save": "Speichern",
+  "Error loading tag vocabulary.": "Fehler beim Laden des Tag-Vokabulars.",
+  "Error saving tag vocabulary.": "Fehler beim Speichern des Tag-Vokabulars.",
+
+  "Something went wrong": "Etwas ist schiefgelaufen"
 }

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -13,6 +13,7 @@ import projectAssignmentDetails from './project-assignment-details.json';
 import projectAssignments from './project-assignments.json';
 import projectCollaboration from './project-collaboration.json';
 import projectHome from './project-home.json';
+import projectSettings from './project-settings.json';
 import projectSidedbar from './project-sidebar.json';
 
 export default {
@@ -28,5 +29,6 @@ export default {
   'project-assignments': projectAssignments,
   'project-collaboration': projectCollaboration,
   'project-home': projectHome,
+  'project-settings': projectSettings,
   'project-sidebar': { ...projectSidedbar, ...accountMenu }
 }

--- a/src/i18n/en/project-settings.json
+++ b/src/i18n/en/project-settings.json
@@ -1,0 +1,3 @@
+{
+  "Project Settings": "Project Settings"
+}

--- a/src/i18n/en/project-settings.json
+++ b/src/i18n/en/project-settings.json
@@ -1,3 +1,13 @@
 {
-  "Project Settings": "Project Settings"
+  "Project Settings": "Project Settings",
+
+  "Tagging Vocabulary": "Tagging Vocabulary",
+  "You can pre-define a tagging vocabulary": "You can pre-define a tagging vocabulary for this project by copying and pasting terms into the text area below, one term per line.",
+  "The terms will appear as autocomplete options": "The terms will appear as autocomplete options when users create new tags in the annotation interface. Please note that users will still be able to add their own tags, too.",
+  "Clear": "Clear",
+  "Save": "Save",
+  "Error loading tag vocabulary.": "Error loading tag vocabulary.",
+  "Error saving tag vocabulary.": "Error saving tag vocabulary.",
+
+  "Something went wrong": "Something went wrong"
 }

--- a/src/layouts/project/ProjectSidebar.tsx
+++ b/src/layouts/project/ProjectSidebar.tsx
@@ -106,13 +106,13 @@ export const ProjectSidebar = (props: ProjectSidebarProps) => {
                 label={t['Add Ons']}
               link={link('addons')} /> */}
               
-              {/* isAdmin && (
+              {isAdmin && (
                 <NavItem
                   active={active === 'Settings'}
                   icon={Sliders}
                   label={t['Settings']}
                   link={link('settings')} />
-              ) */}
+              )}
             </ul>
           </li>
         </ul>

--- a/src/pages/[lang]/annotate/[context]/[document]/index.astro
+++ b/src/pages/[lang]/annotate/[context]/[document]/index.astro
@@ -57,13 +57,11 @@ if (document.data.content_type === 'text/plain') {
 ---
 <BaseLayout title="Annotation">
   {viewer === 'OPENSEADRAGON' ? (
-    <div class="container image">
-      <ImageAnnotation 
-        client:only
-        i18n={getTranslations(Astro.request, 'annotation-image')}
-        document={document.data}
-        channelId={channelId} />
-    </div>
+    <ImageAnnotation 
+      client:only
+      i18n={getTranslations(Astro.request, 'annotation-image')}
+      document={document.data}
+      channelId={channelId} />
   ) : (
     <TextAnnotation 
       client:only

--- a/src/pages/[lang]/annotate/[context]/[document]/index.astro
+++ b/src/pages/[lang]/annotate/[context]/[document]/index.astro
@@ -3,8 +3,8 @@ import crypto from 'crypto';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import { ImageAnnotationDesktop } from '@apps/annotation-image';
-import { TextAnnotationDesktop } from '@apps/annotation-text';
+import { ImageAnnotation } from '@apps/annotation-image';
+import { TextAnnotation } from '@apps/annotation-text';
 import { getDocumentInContext } from '@backend/helpers';
 
 const lang = getLangFromUrl(Astro.url);
@@ -58,14 +58,14 @@ if (document.data.content_type === 'text/plain') {
 <BaseLayout title="Annotation">
   {viewer === 'OPENSEADRAGON' ? (
     <div class="container image">
-      <ImageAnnotationDesktop 
+      <ImageAnnotation 
         client:only
         i18n={getTranslations(Astro.request, 'annotation-image')}
         document={document.data}
         channelId={channelId} />
     </div>
   ) : (
-    <TextAnnotationDesktop 
+    <TextAnnotation 
       client:only
       i18n={getTranslations(Astro.request, 'annotation-text')} 
       document={document.data}

--- a/src/pages/[lang]/projects/[project]/collaboration.astro
+++ b/src/pages/[lang]/projects/[project]/collaboration.astro
@@ -4,7 +4,7 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { listPendingInvitations, getMyProfile } from '@backend/crud';
 import { getProjectExtended } from '@backend/helpers';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import { ProjectCollaboration } from '@apps/project-collaboration/ProjectCollaboration';
+import { ProjectCollaboration } from '@apps/project-collaboration';
 
 const lang = getLangFromUrl(Astro.url);
 

--- a/src/pages/[lang]/projects/[project]/settings.astro
+++ b/src/pages/[lang]/projects/[project]/settings.astro
@@ -2,10 +2,13 @@
 import ProjectLayout from '@layouts/project/ProjectLayout.astro';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getMyProfile } from '@backend/crud';
-import { getLangFromUrl } from '@i18n';
+import { getLangFromUrl, getTranslations } from '@i18n';
 import { getProjectExtended } from '@backend/helpers';
+import { ProjectSettings } from '@apps/project-settings';
 
 const lang = getLangFromUrl(Astro.url);
+
+const i18n = getTranslations(Astro.request, 'project-settings');
 
 const supabase = await createSupabaseServerClient(Astro.request, Astro.cookies);
 if (!supabase)
@@ -30,7 +33,9 @@ if (project.error || !project.data) {
 }
 ---
 <ProjectLayout active="Settings" user={profile.data} project={project.data}>
-  <h1>Settings</h1>
+  <ProjectSettings 
+    client:load 
+    i18n={i18n} />
 </ProjectLayout>
 
 <style>

--- a/src/pages/[lang]/projects/[project]/settings.astro
+++ b/src/pages/[lang]/projects/[project]/settings.astro
@@ -35,7 +35,8 @@ if (project.error || !project.data) {
 <ProjectLayout active="Settings" user={profile.data} project={project.data}>
   <ProjectSettings 
     client:load 
-    i18n={i18n} />
+    i18n={i18n} 
+    project={project.data} />
 </ProjectLayout>
 
 <style>


### PR DESCRIPTION
## In this PR

This PR adds functionality for defining a tag set for a project. 

- The editing form is part of the __Settings__ page
- The __Settings__ sidebar nav option is shown to all project admin users
- Tags are stored in the backend in the `tag_definitions` table, with a project scope. (Note: I don't know whether there are any policy restrictions to inserting tags. In theory, I guess everyone could just go to the /settings page manually, and change the tag sets? CC @lwjameson)
- In the annotation interface, tags are used to drive a new autocomplete dropdown. 

Note: users are still able to user their own tags, too. I.e. a tag set will simply add to the available auto-suggest options, but not limit users to _just_ those tags. I assume clients may want different approaches under different circumstances. But for now, this is basically a 1:1 emulation of the behavior that old Recogito used to offer.

<img width="918" alt="Bildschirmfoto 2023-09-29 um 13 21 09" src="https://github.com/recogito/recogito-client/assets/470971/daa1d3e7-5cbe-40b1-b096-943ba274a3bf">

<img width="558" alt="Bildschirmfoto 2023-09-29 um 13 21 51" src="https://github.com/recogito/recogito-client/assets/470971/8992b50e-4d65-4755-8230-d308d7ef4ee9">
