### PR TITLE
Update to Annotorious 3.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recogito-client",
       "version": "0.0.1",
       "dependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-46",
+        "@annotorious/react": "^3.0.0-pre-alpha-49",
         "@astrojs/netlify": "^2.2.3",
         "@astrojs/node": "^5.3.3",
         "@astrojs/react": "^2.2.0",
@@ -23,7 +23,8 @@
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
-        "@recogito/react-text-annotator": "^3.0.0-pre-alpha-59",
+        "@recogito/annotorious-supabase": "^3.0.0-pre-alpha-49",
+        "@recogito/react-text-annotator": "^3.0.0-pre-alpha-60",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
         "@uppy/core": "^3.2.1",
@@ -77,17 +78,53 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@annotorious/core": {
+      "version": "3.0.0-pre-alpha-49",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-pre-alpha-49.tgz",
+      "integrity": "sha512-71e6eOjXyoeQL2xBxVsfOXYRazWN4udpZUehC/5xEfTzBqnGMjPqBKQJSaAEmi8Cg460sEZNNfqie854gE+Nzg==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "nanoevents": "^8.0.0",
+        "nanoid": "^5.0.1",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@annotorious/core/node_modules/nanoevents": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-8.0.0.tgz",
+      "integrity": "sha512-bYYwNCdNc5ea6/Lwh1uioU1/7aaKa3EPmNQ2weTm8PWSpbWrsaWHePe0Zq4SF+D3F3JX3cn+QdktOPCf1meOqw==",
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@annotorious/core/node_modules/nanoid": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.1.tgz",
+      "integrity": "sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-pre-alpha-46",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-46.tgz",
-      "integrity": "sha512-CMtwsgs3kHWGXtNi3GLQs/DqQCFBYiWsuAitAr5VYKTWGjIyWSu+alcRp0YbKDhTDElBtKgjbzAq7GRN3XzHDA==",
+      "version": "3.0.0-pre-alpha-49",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-pre-alpha-49.tgz",
+      "integrity": "sha512-55xdm9zmuhKP0io+CSEJMBh7RijII6H0aJlfn3ts4SuQgdcRfW/vCsGhMTyB+Gglfs4EyEecFHn++rv4fdsXkQ==",
       "dependencies": {
         "@neodrag/react": "^2.0.3"
       },
       "peerDependencies": {
-        "openseadragon": "^3.1.0",
-        "react": "16.8.0 || >=17.x",
-        "react-dom": "16.8.0 || >=17.x"
+        "openseadragon": "^3.0.0 || ^4.0.0",
+        "react": "16.8.0 || >=17.x || >=18.x",
+        "react-dom": "16.8.0 || >=17.x || >=18.x"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -2092,16 +2129,26 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@recogito/annotorious-supabase": {
+      "version": "3.0.0-pre-alpha-49",
+      "resolved": "https://registry.npmjs.org/@recogito/annotorious-supabase/-/annotorious-supabase-3.0.0-pre-alpha-49.tgz",
+      "integrity": "sha512-k4oR18zRXfYV9Fs9TaPz7bA0+UN5ZDVN/TOhuYZ6TC93hDxYqIJR0qiZpIKjbhCULnFVG92d0e5MdhJZO9RAuw==",
+      "dependencies": {
+        "@annotorious/core": "^3.0.0-pre-alpha-49",
+        "@supabase/supabase-js": "^2.20.0",
+        "nanoevents": "^7.0.1"
+      }
+    },
     "node_modules/@recogito/react-text-annotator": {
-      "version": "3.0.0-pre-alpha-59",
-      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-59.tgz",
-      "integrity": "sha512-OSSLWuMCBW+4wWgFDJ0Tl2Ew1G9A6tG7sK8EWYDyCQgcOyGQuHo2eGKD/NrzxFPQhOYN3/hWnBxTjcawprlzcw==",
+      "version": "3.0.0-pre-alpha-60",
+      "resolved": "https://registry.npmjs.org/@recogito/react-text-annotator/-/react-text-annotator-3.0.0-pre-alpha-60.tgz",
+      "integrity": "sha512-EsXdzE469xv4iP/ZcNV+8Jj/10XJamoEuSsQaySsrpyoWz3FDwxzDDlOX3F9MTzllrXtWCWxcIvx0fMySqHL6A==",
       "dependencies": {
         "@neodrag/react": "^2.0.3",
         "CETEIcean": "^1.8.0"
       },
       "peerDependencies": {
-        "@annotorious/react": "^3.0.0-pre-alpha-44",
+        "@annotorious/react": "^3.0.0-pre-alpha-49",
         "openseadragon": "^3.1.0",
         "react": "16.8.0 || >=17.x",
         "react-dom": "16.8.0 || >=17.x"
@@ -5724,6 +5771,14 @@
       "resolved": "https://registry.npmjs.org/namespace-emitter/-/namespace-emitter-2.0.1.tgz",
       "integrity": "sha512-N/sMKHniSDJBjfrkbS/tpkPj4RAbvW3mr8UAzvlMHyun93XEm83IAvhWtJVHo+RHn/oO8Job5YN4b+wRjSVp5g=="
     },
+    "node_modules/nanoevents": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/nanoevents/-/nanoevents-7.0.1.tgz",
+      "integrity": "sha512-o6lpKiCxLeijK4hgsqfR6CNToPyRU3keKyyI6uwuHRvpRTbZ0wXw51WRgyldVugZqoJfkGFrjrIenYH3bfEO3Q==",
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
@@ -6155,9 +6210,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7678,9 +7733,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8432,9 +8491,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@annotorious/react": "3.0.0-pre-alpha-46",
+    "@annotorious/react": "^3.0.0-pre-alpha-49",
     "@astrojs/netlify": "^2.2.3",
     "@astrojs/node": "^5.3.3",
     "@astrojs/react": "^2.2.0",
@@ -26,7 +26,8 @@
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
-    "@recogito/react-text-annotator": "3.0.0-pre-alpha-59",
+    "@recogito/annotorious-supabase": "^3.0.0-pre-alpha-49",
+    "@recogito/react-text-annotator": "^3.0.0-pre-alpha-60",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",
     "@uppy/core": "^3.2.1",

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -7,6 +7,7 @@ import { Annotation } from '@components/Annotation';
 import { createAppearenceProvider, PresenceStack } from '@components/Presence';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
 import type { PrivacyMode } from '@components/PrivacySelector';
+import { SupabasePlugin } from '@components/SupabasePlugin';
 import { Toolbar } from './Toolbar';
 import type { ImageAnnotationProps } from './ImageAnnotation';
 import { 
@@ -18,7 +19,6 @@ import {
   OpenSeadragonViewer,
   PointerSelectAction,
   PresentUser,
-  SupabasePlugin,
   useAnnotator
 } from '@annotorious/react';
 
@@ -32,6 +32,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
   const { i18n } = props;
 
+  // @ts-ignore
   const anno = useAnnotator<AnnotoriousOpenSeadragonAnnotator>();
 
   const policies = useLayerPolicies(props.document.layers[0].id);
@@ -113,7 +114,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     <div className="anno-desktop ia-desktop">
       {policies && (
         <OpenSeadragonAnnotator 
-          adapter={null}
           pointerSelectAction={selectAction}
           tool={tool} 
           keepEnabled={true}
@@ -135,6 +135,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               privacyMode={privacy === 'PRIVATE'} />
           }
 
+          {/* @ts-ignore */}
           <OpenSeadragonViewer
             className="ia-osd-container"
             options={{

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SupabasePlugin, useAnnotator } from '@annotorious/react';
+import { useAnnotator } from '@annotorious/react';
 import type { Annotation as Anno, Formatter, PresentUser } from '@annotorious/react';
 import { 
   TEIAnnotator, 
@@ -18,6 +18,7 @@ import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop'
 import type { TextAnnotationProps } from './TextAnnotation';
 import { Toolbar } from './Toolbar';
 import type { PrivacyMode } from '@components/PrivacySelector';
+import { SupabasePlugin } from '@components/SupabasePlugin';
 import { useContent } from './useContent';
 import type { Layer } from 'src/Types';
 
@@ -165,7 +166,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
             present={present} 
             policies={policies}
             layers={layers}
-            sorting={(a, b) => a.target.selector.start - b.target.selector.start}
+            sorting={(a, b) => 
+              // @ts-ignore
+              a.target.selector.start - b.target.selector.start}
             tagVocabulary={vocabulary}
             onChangePanel={onChangeViewMenuPanel}
             onChangeFormatter={f => setFormatter(() => f)}

--- a/src/components/Annotation/Popup/Popup.tsx
+++ b/src/components/Annotation/Popup/Popup.tsx
@@ -1,6 +1,7 @@
 import { Annotation } from '@components/Annotation';
-import { useAnnotator, useAnnotatorUser, Visibility } from '@annotorious/react';
+import { useAnnotator, useAnnotatorUser } from '@annotorious/react';
 import type { Annotation as Anno, PresentUser, User } from '@annotorious/react';
+import { SupabaseAnnotation, Visibility } from '@recogito/annotorious-supabase';
 import type { Policies, Translations } from 'src/Types';
 
 import './Popup.css';
@@ -28,7 +29,7 @@ export const Popup = (props: PopupProps) => {
   const me: PresentUser | User = props.present.find(p => p.id === user.id) || user;
 
   // Popup only supports a single selected annotation for now
-  const selected = props.selected[0].annotation;
+  const selected = props.selected[0].annotation as SupabaseAnnotation;
 
   const isPrivate = selected.visibility === Visibility.PRIVATE;
 

--- a/src/components/Annotation/ReplyForm/ReplyForm.tsx
+++ b/src/components/Annotation/ReplyForm/ReplyForm.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ArrowRight, Detective } from '@phosphor-icons/react';
 import TextareaAutosize from 'react-textarea-autosize';
-import { Visibility, useAnnotationStore } from '@annotorious/react';
-import type { AnnotationBody, PresentUser, SupabaseAnnotation, User } from '@annotorious/react';
+import { useAnnotationStore } from '@annotorious/react';
+import type { AnnotationBody, PresentUser, User } from '@annotorious/react';
+import { Visibility, SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { Avatar } from '../../Avatar';
 
 import './ReplyForm.css';

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -1,22 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Annotation } from '@components/Annotation';
 import type { Policies, Translations } from 'src/Types';
+import { SupabaseAnnotation, Visibility } from '@recogito/annotorious-supabase';
 import { 
   Annotation as Anno,
-  AnnotoriousOpenSeadragonAnnotator,
   PresentUser, 
-  SupabaseAnnotation,
   useAnnotations,
   useAnnotator,
   useAnnotatorUser,
   useSelection,
   User,
-  Visibility,
   useViewportState
 } from '@annotorious/react';
 import { Filter, FilterSelector } from './FilterSelector';
 
 import './AnnotationList.css';
+import type { Annotator } from '@annotorious/react';
 
 interface AnnotationListProps {
 
@@ -67,7 +66,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
 
   const me: PresentUser | User = props.present.find(p => p.id === user.id) || user;
 
-  const anno = useAnnotator<AnnotoriousOpenSeadragonAnnotator>();
+  const anno = useAnnotator<Annotator>();
 
   const { selected, pointerEvent } = useSelection();
 

--- a/src/components/AnnotationDesktop/LayersPanel/colorCodings/colorByPrivacy.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/colorCodings/colorByPrivacy.ts
@@ -1,5 +1,5 @@
-import { Visibility } from '@annotorious/react';
-import type { Formatter, SupabaseAnnotation } from '@annotorious/react';
+import { Visibility, SupabaseAnnotation } from '@recogito/annotorious-supabase';
+import type { Formatter } from '@annotorious/react';
 import type { ColorCoding, ColorLegendValue } from '../ColorCoding';
 import { CarbonCategoricalDark14 } from '../ColorPalettes';
 

--- a/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
+++ b/src/components/AnnotationDesktop/ViewMenu/ViewMenu.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Chats, StackSimple, X } from '@phosphor-icons/react';
 import { useTransition, animated } from '@react-spring/web'
 import { Avatar } from '@components/Avatar';
-import { isMe } from '@annotorious/react';
+import { isMe } from '@recogito/annotorious-supabase';
 import type { Annotation, Formatter, PresentUser } from '@annotorious/react';
 import type { Layer, Policies, Translations } from 'src/Types';
 import { LayersPanel } from '../LayersPanel';
@@ -35,7 +35,7 @@ interface ViewMenuProps {
 
 export const ViewMenu = (props: ViewMenuProps) => {
 
-  const me = props.present.find(isMe);
+  const me = props.present.find(isMe)!;
 
   const [panel, _setPanel] = useState<ViewMenuPanel | undefined>();
 

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -1,4 +1,4 @@
-import { isMe } from '@annotorious/react';
+import { isMe } from '@recogito/annotorious-supabase';
 import type { PresentUser } from '@annotorious/react';
 import { animated, useTransition } from '@react-spring/web';
 import { Avatar } from '@components/Avatar';

--- a/src/components/Presence/PresenceViewMoreButton.tsx
+++ b/src/components/Presence/PresenceViewMoreButton.tsx
@@ -1,4 +1,4 @@
-import { isMe } from '@annotorious/react';
+import { isMe } from '@recogito/annotorious-supabase';
 import type { PresentUser } from '@annotorious/react';
 import * as Popover from '@radix-ui/react-popover';
 import { Avatar } from '@components/Avatar';

--- a/src/components/SupabasePlugin/SupabasePlugin.ts
+++ b/src/components/SupabasePlugin/SupabasePlugin.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useAnnotator, Annotation, Annotator, PresentUser, User } from '@annotorious/react';
+import { type SupabasePluginConfig, SupabasePlugin as Supabase } from '@recogito/annotorious-supabase';
+import type { PostgrestError } from '@supabase/supabase-js';
+
+// Re-export isMe utility
+export { isMe } from '@recogito/annotorious-supabase';
+
+export type SupabasePluginProps = SupabasePluginConfig & {
+
+  privacyMode: boolean,
+
+  onConnected?(user: User): void,
+
+  onConnectError?(error: string): void,
+
+  onInitialLoad?(annotations: Annotation[]): void,
+
+  onInitialLoadError?(error: PostgrestError): void,
+
+  onIntegrityError?(message: string): void,
+
+  onPresence?(users: PresentUser[]): void,
+
+  onSaveError?(error: PostgrestError): void,
+
+  onSelectionChange?(user: PresentUser): void
+
+}
+
+export const SupabasePlugin = (props: SupabasePluginProps) => {
+
+  const anno = useAnnotator<Annotator<Annotation, Annotation>>();
+
+  const [plugin, setPlugin] = useState<ReturnType<typeof Supabase>>();
+
+  useEffect(() => {
+    if (anno) {
+      const supabase = Supabase(anno, props);
+      
+      supabase
+        .connect()
+        .then(user => props.onConnected && props.onConnected(user))
+        .catch(error => props.onConnectError && props.onConnectError(error));
+
+      supabase.on('initialLoad', annotations => props.onInitialLoad && props.onInitialLoad(annotations));
+      supabase.on('initialLoadError', error => props.onInitialLoadError && props.onInitialLoadError(error));
+      supabase.on('integrityError', message => props.onIntegrityError && props.onIntegrityError(message));
+      supabase.on('presence', users => props.onPresence && props.onPresence(users));
+      supabase.on('saveError', error => props.onSaveError && props.onSaveError(error));
+      supabase.on('selectionChange', user => props.onSelectionChange && props.onSelectionChange(user));
+
+      setPlugin(supabase);
+
+      return () => {
+        supabase.destroy();
+      }
+    }
+  }, [
+    anno, 
+    props.onInitialLoad,
+    props.onInitialLoadError,
+    props.onIntegrityError,
+    props.onPresence,
+    props.onSaveError,
+    props.onSelectionChange
+  ]);
+
+  useEffect(() => {
+    if (plugin)
+      plugin.privacyMode = props.privacyMode;
+  }, [props.privacyMode, plugin])
+
+  return null;
+
+}

--- a/src/components/SupabasePlugin/index.ts
+++ b/src/components/SupabasePlugin/index.ts
@@ -1,0 +1,1 @@
+export * from './SupabasePlugin';


### PR DESCRIPTION
## In this PR

This PR brings the Recogito client up to date with the latest API changes that were recently introduced to the Annotorious base library, on the path to the first official release (3.0.0-rc.1). The main change is that the Supabase plugin, which is entirely specific to our own implementation, is no longer part of the Annotorious monorepo, but now [published as a separate package here](https://github.com/recogito/annotorious-supabase).