### PR TITLE
Adds the Tag Widget to popup + card for newly created annotations

### DIFF
--- a/src/components/Annotation/Popup/Popup.tsx
+++ b/src/components/Annotation/Popup/Popup.tsx
@@ -2,6 +2,7 @@ import { Annotation } from '@components/Annotation';
 import { useAnnotator, useAnnotatorUser } from '@annotorious/react';
 import type { Annotation as Anno, PresentUser, User } from '@annotorious/react';
 import { SupabaseAnnotation, Visibility } from '@recogito/annotorious-supabase';
+import { TagsWidget } from '../TagsWidget';
 import type { Policies, Translations } from 'src/Types';
 
 import './Popup.css';
@@ -64,6 +65,12 @@ export const Popup = (props: PopupProps) => {
       ) : isMine ? (
         isPrivate ? (
           <div className="annotation-card private">
+            <TagsWidget 
+              i18n={props.i18n} 
+              me={me} 
+              annotation={selected}
+              vocabulary={props.tagVocabulary} />
+
             <Annotation.ReplyForm 
               {...props}
               autofocus
@@ -74,6 +81,12 @@ export const Popup = (props: PopupProps) => {
           </div>
         ) : (
           <div className="annotation-card">
+            <TagsWidget 
+              i18n={props.i18n} 
+              me={me} 
+              annotation={selected}
+              vocabulary={props.tagVocabulary} />
+
             <Annotation.ReplyForm 
               {...props}
               autofocus

--- a/src/components/Annotation/TagsWidget/TagsWidget.css
+++ b/src/components/Annotation/TagsWidget/TagsWidget.css
@@ -8,6 +8,19 @@
   z-index: 999;
 }
 
+.private .annotation-tagswidget {
+  background-color: var(--private-bg-light);
+  color: var(--font-dark);
+}
+
+.private .annotation-tagswidget input {
+  color: var(--font-dark);
+}
+
+.private .annotation-tagswidget input::placeholder {
+  color: var(--font-light);
+}
+
 .annotation-tagswidget .tags {
   display: flex;
 }
@@ -17,6 +30,14 @@
   line-height: 100%;
 }
 
+.private .annotation-tagswidget ul {
+  background-color: var(--private-bg-light);
+}
+
 .annotation-tagswidget li {
   display: inline;
+}
+
+.annotation-tagswidget + .annotation-reply-form {
+  border-top: none;
 }

--- a/src/components/Annotation/index.ts
+++ b/src/components/Annotation/index.ts
@@ -3,6 +3,7 @@ import { EmptyCard, PrivateCard, PublicCard } from './Card';
 import { LifecycleLogger } from './LifecycleLogger';
 import { Popup } from './Popup';
 import { ReplyForm } from './ReplyForm';
+import { TagsWidget } from './TagsWidget';
 
 export const Annotation = {
   
@@ -18,6 +19,8 @@ export const Annotation = {
 
   Popup,
 
-  ReplyForm
+  ReplyForm,
+
+  TagsWidget
 
 }

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -12,10 +12,10 @@ import {
   User,
   useViewportState
 } from '@annotorious/react';
+import type { Annotator } from '@annotorious/react';
 import { Filter, FilterSelector } from './FilterSelector';
 
 import './AnnotationList.css';
-import type { Annotator } from '@annotorious/react';
 
 interface AnnotationListProps {
 
@@ -132,6 +132,12 @@ export const AnnotationList = (props: AnnotationListProps) => {
               isMine(a) ? (              
                 isSelected(a) ? (
                   <div className={getReplyFormClass(a)}>
+                    <Annotation.TagsWidget 
+                      i18n={props.i18n} 
+                      me={me} 
+                      annotation={a}
+                      vocabulary={props.tagVocabulary} />
+
                     <Annotation.ReplyForm
                       autofocus={autofocus}
                       scrollIntoView


### PR DESCRIPTION
## In this PR

So far, it was not possible to create a new annotation with __just a tag__. The initial popup (or sidebar card) only showed the comment box. After you added a comment, and then re-selected the annotation, the popup configuration was such that it would show
- the comment
- the reply field
- the tag widget

I.e. to create an annotation with only a tag, users effectively had to add a comment, re-open the annotation, add a tag, delete the comment...

This PR adds the Tag Widget to the initial popup (and sidebar card) for newly created annotations.