### PR TITLE
Editable Assignments

### DIFF
--- a/src/apps/project-assignments/Grid/AssignmentsGrid.tsx
+++ b/src/apps/project-assignments/Grid/AssignmentsGrid.tsx
@@ -11,8 +11,9 @@ interface AssignmentsGridProps {
 
   project: ExtendedProjectData;
 
-  // Just temporary, for hacking/testing
   assignments: Context[];
+
+  onEditAssignment(assignment: Context): void;
 
   onDeleteAssignment(assignment: Context): void;
 
@@ -29,6 +30,7 @@ export const AssignmentsGrid = (props: AssignmentsGridProps) => {
           canUpdate={props.canUpdate}
           project={props.project}
           assignment={assignment} 
+          onEdit={() => props.onEditAssignment(assignment)}
           onDelete={() => props.onDeleteAssignment(assignment)} />
       ))}
     </div>

--- a/src/apps/project-assignments/ProjectAssignments.tsx
+++ b/src/apps/project-assignments/ProjectAssignments.tsx
@@ -44,8 +44,14 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
 
   const { assignments, setAssignments } = useAssignments(project);
 
-  const onAssignmentCreated = (assignment: Context) =>
-    setAssignments(assignments => ([...(assignments || []), assignment]));
+  const onAssignmentSaved = (assignment: Context) =>
+    setAssignments(assignments => {
+      const isUpdate = assignments?.find(a => a.id === assignment.id);
+
+      return isUpdate ? 
+        assignments!.map(a => a.id === assignment.id ? assignment : a) :
+        [...(assignments || []), assignment];
+    });
 
   const onEditAssignment = (assignment: Context) =>
     getAssignment(supabase, assignment.id).then(({ data, error }) => {
@@ -125,7 +131,7 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
                 project={props.project}
                 documents={props.documents}
                 assignment={editing}
-                onCreated={onAssignmentCreated}
+                onSaved={onAssignmentSaved}
                 onClose={() => setEditing(undefined)} />
             )}
           </>

--- a/src/apps/project-assignments/ProjectAssignments.tsx
+++ b/src/apps/project-assignments/ProjectAssignments.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { GraduationCap } from '@phosphor-icons/react';
-import { archiveAssignment, getAllLayersInContext } from '@backend/helpers';
+import { archiveAssignment, getAllLayersInContext, getAssignment } from '@backend/helpers';
 import { archiveLayer } from '@backend/crud';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { useAssignments, useProjectPolicies } from '@backend/hooks';
@@ -11,6 +11,7 @@ import type { Context, DocumentInContext, ExtendedProjectData, MyProfile, Transl
 import { AssignmentsGrid } from './Grid';
 
 import './ProjectAssignments.css';
+import { AssignmentSpec } from './Wizard/AssignmentSpec';
 
 interface ProjectAssignmentsProps {
 
@@ -47,6 +48,20 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
   const onAssignmentCreated = (assignment: Context) =>
     setAssignments(assignments => ([...(assignments || []), assignment]));
 
+  const onEditAssignment = (assignment: Context) =>
+    getAssignment(supabase, assignment.id).then(({ data, error }) => {
+      if (error) {
+        setToast({
+          title: t['Something went wrong'],
+          description: t['Could not open the assignment.'],
+          type: 'error'
+        });
+      } else {
+        // TODO compile an AssignmentSpec object for the wizard
+        console.log('editing', data);
+      }
+    });
+
   const onDeleteAssignment = (assignment: Context) => {
     // Optimistic update: remove assignment from the list
     setAssignments(assignments => (assignments || []).filter(a => a.id !== assignment.id));
@@ -57,8 +72,8 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
         setAssignments(assignments => ([...(assignments || []), assignment]));
 
         setToast({
-          title: 'Something went wrong',
-          description: 'Could not delete the document.',
+          title: t['Something went wrong'],
+          description: t['Could not delete the assignment.'],
           type: 'error'
         });
       } else {
@@ -72,8 +87,8 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
           .then(() => archiveAssignment(supabase, assignment.id))
           .then(() => {
             setToast({
-              title: 'Deleted',
-              description: 'Document deleted successfully.',
+              title: t['Deleted'],
+              description: t['Assignment deleted successfully.'],
               type: 'success'
             });
           })
@@ -82,8 +97,8 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
             setAssignments(assignments => ([...(assignments || []), assignment]));
 
             setToast({
-              title: 'Something went wrong',
-              description: 'Could not delete the document.',
+              title: t['Something went wrong'],
+              description: t['Could not delete the assignment.'],
               type: 'error'
             });
           });
@@ -124,6 +139,7 @@ export const ProjectAssignments = (props: ProjectAssignmentsProps) => {
             canUpdate={canCreate}
             project={project}
             assignments={assignments} 
+            onEditAssignment={onEditAssignment}
             onDeleteAssignment={onDeleteAssignment} />
         ) : (
           <div />

--- a/src/apps/project-assignments/Wizard/AssignmentSpec.ts
+++ b/src/apps/project-assignments/Wizard/AssignmentSpec.ts
@@ -1,4 +1,4 @@
-import type { DocumentInContext, UserProfile } from 'src/Types';
+import type { DocumentInContext, ExtendedAssignmentData, UserProfile } from 'src/Types';
 
 export interface AssignmentSpec {
 
@@ -11,3 +11,43 @@ export interface AssignmentSpec {
   description?: string;
 
 }
+
+// Utility crosswalk between ExtendedAssignmentData and AssignmentSpec
+export const toAssignmentSpec = (data: ExtendedAssignmentData): AssignmentSpec => ({
+  name: data.name,
+  description: data.description,
+  documents: data.layers.map(layer => ({
+    id: layer.document.id,
+    name: layer.document.name,
+    created_at: layer.document.created_at,
+    created_by: layer.document.created_by,
+    updated_at: layer.document.updated_at,
+    updated_by: layer.document.updated_by,
+    bucket_id: layer.document.bucket_id,
+    content_type: layer.document.content_type,
+    meta_data: layer.document.meta_data,
+    layers: [{
+      id: layer.id,
+      document_id: layer.document.id,
+      project_id: data.project_id,
+      name: layer.name,
+      description: layer.description,
+      context: {
+        id: data.id,
+        name: data.name,
+        description: data.description,
+        project_id: data.project_id
+      }
+    }]
+  })),
+  team: data.layers[0].groups.reduce((allUsers, { members }) => {
+    const usersInThisGroup = members.map(m => m.user);
+
+    const toAdd = usersInThisGroup.filter(u => {
+      const exists = allUsers.find(x => x.id === u.id);
+      return !exists;
+    });
+
+    return [...allUsers, ...toAdd];
+  }, [] as UserProfile[])          
+});

--- a/src/apps/project-assignments/Wizard/AssignmentSpec.ts
+++ b/src/apps/project-assignments/Wizard/AssignmentSpec.ts
@@ -2,6 +2,8 @@ import type { DocumentInContext, ExtendedAssignmentData, UserProfile } from 'src
 
 export interface AssignmentSpec {
 
+  id?: string;
+
   name?: string;
 
   documents: DocumentInContext[];
@@ -14,6 +16,7 @@ export interface AssignmentSpec {
 
 // Utility crosswalk between ExtendedAssignmentData and AssignmentSpec
 export const toAssignmentSpec = (data: ExtendedAssignmentData): AssignmentSpec => ({
+  id: data.id,
   name: data.name,
   description: data.description,
   documents: data.layers.map(layer => ({
@@ -40,14 +43,5 @@ export const toAssignmentSpec = (data: ExtendedAssignmentData): AssignmentSpec =
       }
     }]
   })),
-  team: data.layers[0].groups.reduce((allUsers, { members }) => {
-    const usersInThisGroup = members.map(m => m.user);
-
-    const toAdd = usersInThisGroup.filter(u => {
-      const exists = allUsers.find(x => x.id === u.id);
-      return !exists;
-    });
-
-    return [...allUsers, ...toAdd];
-  }, [] as UserProfile[])          
+  team: data.layers[0].groups.find(g => g.name === 'Layer Student')?.members.map(m => m.user) || []
 });

--- a/src/apps/project-assignments/Wizard/AssignmentWizard.tsx
+++ b/src/apps/project-assignments/Wizard/AssignmentWizard.tsx
@@ -27,7 +27,7 @@ interface AssignmentWizardProps {
 
   onClose(): void;
 
-  onCreated(assignment: Context): void;
+  onSaved(assignment: Context): void;
 
 }
 
@@ -86,9 +86,9 @@ export const AssignmentWizard = (props: AssignmentWizardProps) => {
     setAssignment(assignment => ({ ...assignment, description })) :
     setAssignment(assignment => ({ ...assignment, description: undefined }));
   
-  const onCreated = (assignment: Context) => {
+  const onSaved = (assignment: Context) => {
     setComplete(true);
-    props.onCreated(assignment);
+    props.onSaved(assignment);
   }
 
   // Don't close this dialog when the user clicks outside!
@@ -112,14 +112,15 @@ export const AssignmentWizard = (props: AssignmentWizardProps) => {
                 i18n={props.i18n} 
                 project={props.project}
                 assignment={assignment} 
-                onCreated={onCreated}
+                previous={props.assignment}
+                onSaved={onSaved}
                 onError={() => setComplete(true)} />
             ) : (
               <ProgressCreating
                 i18n={props.i18n} 
                 project={props.project}
                 assignment={assignment} 
-                onCreated={onCreated}
+                onSaved={onSaved}
                 onError={() => setComplete(true)} />
             )
           ) : (

--- a/src/apps/project-assignments/Wizard/AssignmentWizard.tsx
+++ b/src/apps/project-assignments/Wizard/AssignmentWizard.tsx
@@ -9,13 +9,15 @@ import { Documents } from './Documents';
 import { Team } from './Team';
 import { Instructions } from './Instructions';
 import { Verify } from './Verify';
-import { Progress } from './Progress';
 
 import './AssignmentWizard.css';
+import { ProgressCreating, ProgressUpdating } from './Progress';
 
 interface AssignmentWizardProps {
 
   i18n: Translations;
+
+  assignment: AssignmentSpec;
 
   me: UserProfile;
 
@@ -28,6 +30,11 @@ interface AssignmentWizardProps {
   onCreated(assignment: Context): void;
 
 }
+
+export const NEW_ASSIGNMENT = {
+  documents: [],
+  team: []
+};
 
 const STEPS = [
   'documents',
@@ -42,14 +49,16 @@ export const AssignmentWizard = (props: AssignmentWizardProps) => {
 
   const [step, setStep] = useState(0);
 
-  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   const [complete, setComplete] = useState(false);
 
-  const [assignment, setAssignment] = useState<AssignmentSpec>({
-    documents: [],
-    team: []
-  });
+  const [assignment, setAssignment] = useState(props.assignment);
+
+  // Flag indicating whether this is creating a new assignment
+  // or updating an existing one
+  const isUpdate = 
+    !(props.assignment.documents.length === 0 && props.assignment.team.length === 0);
 
   const validityScore = [
     assignment.name,
@@ -97,13 +106,22 @@ export const AssignmentWizard = (props: AssignmentWizardProps) => {
           className="dialog-content assignment-wizard"
           onPointerDownOutside={onPointerDownOutside}>
 
-          {creating ? (
-            <Progress 
-              i18n={props.i18n} 
-              project={props.project}
-              assignment={assignment} 
-              onCreated={onCreated}
-              onError={() => setComplete(true)} />
+          {saving ? (
+            isUpdate ? (
+              <ProgressUpdating
+                i18n={props.i18n} 
+                project={props.project}
+                assignment={assignment} 
+                onCreated={onCreated}
+                onError={() => setComplete(true)} />
+            ) : (
+              <ProgressCreating
+                i18n={props.i18n} 
+                project={props.project}
+                assignment={assignment} 
+                onCreated={onCreated}
+                onError={() => setComplete(true)} />
+            )
           ) : (
             <>
               <h1>
@@ -179,9 +197,10 @@ export const AssignmentWizard = (props: AssignmentWizardProps) => {
                   <Verify 
                     i18n={props.i18n}
                     assignment={assignment}
+                    isUpdate={isUpdate}
                     onCancel={props.onClose}
                     onBack={onBack} 
-                    onCreateAssignment={() => setCreating(true)} />
+                    onSaveAssignment={() => setSaving(true)} />
                 </Tabs.Content>
               </Tabs.Root>
             </>

--- a/src/apps/project-assignments/Wizard/Progress/Progress.css
+++ b/src/apps/project-assignments/Wizard/Progress/Progress.css
@@ -1,4 +1,4 @@
-.creating-assignment {
+.saving-assignment {
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -9,11 +9,11 @@
   padding: 30px;
 }
 
-.creating-assignment .spinner {
+.saving-assignment .spinner {
   color: var(--bright-blue);
 }
 
-.creating-assignment p {
+.saving-assignment p {
   max-width: 50ch;
   text-align: center;
 }

--- a/src/apps/project-assignments/Wizard/Progress/Progress.ts
+++ b/src/apps/project-assignments/Wizard/Progress/Progress.ts
@@ -1,0 +1,18 @@
+import type { Context, ExtendedProjectData, Translations } from 'src/Types';
+import type { AssignmentSpec } from '../AssignmentSpec';
+
+export interface ProgressProps {
+
+  i18n: Translations;
+
+  project: ExtendedProjectData;
+
+  assignment: AssignmentSpec;
+
+  onCreated(assignment: Context): void;
+
+  onError(error: string): void;
+
+}
+
+export type ProgressState = 'idle' | 'creating_assignment' | 'updating_assignment' | 'success' | 'failed';

--- a/src/apps/project-assignments/Wizard/Progress/Progress.ts
+++ b/src/apps/project-assignments/Wizard/Progress/Progress.ts
@@ -9,7 +9,7 @@ export interface ProgressProps {
 
   assignment: AssignmentSpec;
 
-  onCreated(assignment: Context): void;
+  onSaved(assignment: Context): void;
 
   onError(error: string): void;
 

--- a/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
@@ -46,7 +46,7 @@ export const ProgressCreating = (props: ProgressProps) => {
                 addUsersToLayer(supabase, layer.id, 'Layer Student', team));
             }, Promise.resolve<void>(undefined)).then(() => {
               setState('success');
-              props.onCreated(context);
+              props.onSaved(context);
             })            
           }).catch(error => {
             console.error(error);

--- a/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
@@ -3,28 +3,12 @@ import { addUsersToLayer, createAssignmentContext, createLayerInContext } from '
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Spinner } from '@components/Spinner';
 import { AnimatedCheck } from '@components/AnimatedIcons';
-import type { Layer, ExtendedProjectData, Translations, Context } from 'src/Types';
-import type { AssignmentSpec } from '../AssignmentSpec';
+import type { Layer } from 'src/Types';
+import type { ProgressProps, ProgressState } from './Progress';
 
 import './Progress.css';
 
-interface ProgressProps {
-
-  i18n: Translations;
-
-  project: ExtendedProjectData;
-
-  assignment: AssignmentSpec;
-
-  onCreated(assignment: Context): void;
-
-  onError(error: string): void;
-
-}
-
-type ProgressState = 'idle' | 'creating_assignment' | 'success' | 'failed';
-
-export const Progress = (props: ProgressProps) => {
+export const ProgressCreating = (props: ProgressProps) => {
 
   const { t } = props.i18n;
 
@@ -75,7 +59,7 @@ export const Progress = (props: ProgressProps) => {
   }, []);
 
   return (
-    <div className="creating-assignment">
+    <div className="saving-assignment">
       {state === 'idle' || state === 'creating_assignment' ? (
         <Spinner />
       ) : state === 'success' ? (
@@ -86,7 +70,7 @@ export const Progress = (props: ProgressProps) => {
           </p>
         </>
       ) : (
-        <p>Something went wrong</p>
+        <p>{t['Something went wrong']}</p>
       )}
     </div>
   )

--- a/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
@@ -1,66 +1,137 @@
 import { useEffect, useState } from 'react';
-import { addUsersToLayer, createAssignmentContext, createLayerInContext } from '@backend/helpers';
+import { archiveLayer } from '@backend/crud';
+import { addUsersToLayer, createLayerInContext, removeUsersFromLayer, updateAssignmentContext } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Spinner } from '@components/Spinner';
 import { AnimatedCheck } from '@components/AnimatedIcons';
-import type { Layer } from 'src/Types';
+import type { Context, Layer } from 'src/Types';
 import type { ProgressProps, ProgressState } from './Progress';
+import type { AssignmentSpec } from '../AssignmentSpec';
 
 import './Progress.css';
 
-export const ProgressUpdating = (props: ProgressProps) => {
+interface ProgressUpdatingProps extends ProgressProps {
+
+  previous: AssignmentSpec;
+
+}
+
+/**
+ * Helper to determine which items in ys were added and removed, compared to xs.
+ */
+const diff = <T extends { id: string }>(xs: T[], ys: T[]): { added: T[], removed: T[], unchanged: T[] } => {
+  const added = [];
+  const removed = [];
+  const unchanged = [];
+
+  const xsIdSet = new Set(xs.map(item => item.id));
+  const ysIdSet = new Set(ys.map(item => item.id));
+
+  for (const item of xs) {
+    if (ysIdSet.has(item.id)) {
+      // Item is in both arrays - unchanged
+      unchanged.push(item);
+    } else {
+      // Item is in the first array but not in the second - removed
+      removed.push(item);
+    }
+  }
+
+  for (const item of ys) {
+    if (!xsIdSet.has(item.id)) {
+      // Item is in the second array but not in the first - added
+      added.push(item);
+    }
+  }
+
+  return { added, removed, unchanged };
+}
+
+export const ProgressUpdating = (props: ProgressUpdatingProps) => {
 
   const { t } = props.i18n;
+
+  const { previous } = props;
 
   const { name, description, documents, team } = props.assignment;
 
   const [state, setState] = useState<ProgressState>('idle');
+
+  const context: Context = {
+    id:  previous.id!,
+    name: name!,
+    description,
+    project_id: props.project.id
+  };
   
   useEffect(() => {
-    const projectId = props.project.id;
-
     setState('updating_assignment');
 
-    console.log('updating the existing assignment!');
+    const update = async () => {
+      // Step 1. Update name/description if needed.
+      if (name !== previous.name || description !== previous.description)
+        await updateAssignmentContext(supabase, context.id, name!, description);
+    
+      // Step 2. Update documents.
+      const documentChanges = diff(previous.documents, documents);
 
-    // TODO
+      // - check for removed documents and delete their layers
+      if (documentChanges.removed.length > 0) {
+        await documentChanges.removed.reduce((promise, document) => {
+          return promise.then(() => {
+            return archiveLayer(supabase, document.layers[0].id);
+          });
+        }, Promise.resolve<void>(undefined));
+      }
 
-    /* Step 1. Create a new context for this assignment
-    createAssignmentContext(supabase, name!, description, projectId)
-      .then(({ error, data }) => {
-        if (error) {
-          console.error(error);
+      // - check for added documents and create layers
+      if (documentChanges.added.length > 0) {
+        const layers = await documentChanges.added.reduce((promise, document) => {
+          return promise.then(layers => {
+            return createLayerInContext(supabase, document.id, context.project_id, context.id)
+              .then(layer => ([...layers, layer]))
+          });
+        }, Promise.resolve<Layer[]>([]));
 
-          setState('failed');
-          props.onError(error.message);
-        } else {
-          const context = data;
+        // - for each created layer, add members to the 'Layer Student' group
+        await layers.reduce((promise, layer) => {
+          return promise.then(() => 
+              addUsersToLayer(supabase, layer.id, 'Layer Student', team));
+        }, Promise.resolve<void>(undefined));
+      }
 
-          // Step 2. For each document, create a layer in this context
-          documents.reduce((promise, document) => {
-            return promise.then(layers => {
-              return createLayerInContext(supabase, document.id, projectId, context.id)
-                .then(layer => ([...layers, layer]))
-            });
-          }, Promise.resolve<Layer[]>([])).then(layers => {
-            
-            // Step 3. For each layer, add users to the 'Layer Student' group
-            layers.reduce((promise, layer) => {
-              return promise.then(() => 
-                addUsersToLayer(supabase, layer.id, 'Layer Student', team));
-            }, Promise.resolve<void>(undefined)).then(() => {
-              setState('success');
-              props.onCreated(context);
-            })            
-          }).catch(error => {
-            console.error(error);
+      // Step 3. Update users if necessary
+      const memberChanges = diff(previous.team, team);
 
-            setState('failed');
-            props.onError(error.message);
-          })
-        }
+      // IDs of the layers on the existing documents
+      const existingLayerIds = documentChanges.unchanged.map(d => d.layers[0].id)
+
+      // - Members were added (and some documents existed previously)
+      if (memberChanges.added.length > 0 && documentChanges.unchanged.length > 0) {
+        await existingLayerIds.reduce((promise, layerId) => {
+          // - insert added users to its 'Layer Student' group
+          return promise.then(() => 
+              addUsersToLayer(supabase, layerId, 'Layer Student', memberChanges.added));
+        }, Promise.resolve<void>(undefined));
+      }
+
+      // Members were removed (and some documents existed previously)
+      if (memberChanges.removed.length > 0 && documentChanges.unchanged.length > 0) {
+        await existingLayerIds.reduce((promise, layerId) => {
+          return promise.then(() =>
+            removeUsersFromLayer(supabase, layerId, 'Layer Student', memberChanges.removed));
+        }, Promise.resolve<void>(undefined));
+      }
+
+      setState('success');
+    }
+
+    update()
+      .then(() => props.onSaved(context))
+      .catch(error => { 
+        setState('failed');
+        props.onError(error)
       });
-    */
   }, []);
 
   return (

--- a/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { addUsersToLayer, createAssignmentContext, createLayerInContext } from '@backend/helpers';
+import { supabase } from '@backend/supabaseBrowserClient';
+import { Spinner } from '@components/Spinner';
+import { AnimatedCheck } from '@components/AnimatedIcons';
+import type { Layer } from 'src/Types';
+import type { ProgressProps, ProgressState } from './Progress';
+
+import './Progress.css';
+
+export const ProgressUpdating = (props: ProgressProps) => {
+
+  const { t } = props.i18n;
+
+  const { name, description, documents, team } = props.assignment;
+
+  const [state, setState] = useState<ProgressState>('idle');
+  
+  useEffect(() => {
+    const projectId = props.project.id;
+
+    setState('updating_assignment');
+
+    console.log('updating the existing assignment!');
+
+    // TODO
+
+    /* Step 1. Create a new context for this assignment
+    createAssignmentContext(supabase, name!, description, projectId)
+      .then(({ error, data }) => {
+        if (error) {
+          console.error(error);
+
+          setState('failed');
+          props.onError(error.message);
+        } else {
+          const context = data;
+
+          // Step 2. For each document, create a layer in this context
+          documents.reduce((promise, document) => {
+            return promise.then(layers => {
+              return createLayerInContext(supabase, document.id, projectId, context.id)
+                .then(layer => ([...layers, layer]))
+            });
+          }, Promise.resolve<Layer[]>([])).then(layers => {
+            
+            // Step 3. For each layer, add users to the 'Layer Student' group
+            layers.reduce((promise, layer) => {
+              return promise.then(() => 
+                addUsersToLayer(supabase, layer.id, 'Layer Student', team));
+            }, Promise.resolve<void>(undefined)).then(() => {
+              setState('success');
+              props.onCreated(context);
+            })            
+          }).catch(error => {
+            console.error(error);
+
+            setState('failed');
+            props.onError(error.message);
+          })
+        }
+      });
+    */
+  }, []);
+
+  return (
+    <div className="saving-assignment">
+      {state === 'idle' || state === 'updating_assignment' ? (
+        <Spinner />
+      ) : state === 'success' ? (
+        <>
+          <AnimatedCheck size={40} />
+          <p>
+            {t['The assignment was updated successfully']}
+          </p>
+        </>
+      ) : (
+        <p>{t['Something went wrong']}</p>
+      )}
+    </div>
+  )
+
+}

--- a/src/apps/project-assignments/Wizard/Progress/index.ts
+++ b/src/apps/project-assignments/Wizard/Progress/index.ts
@@ -1,1 +1,2 @@
-export * from './Progress';
+export * from './ProgressCreating';
+export * from './ProgressUpdating';

--- a/src/apps/project-assignments/Wizard/Verify/Verify.tsx
+++ b/src/apps/project-assignments/Wizard/Verify/Verify.tsx
@@ -10,11 +10,13 @@ interface VerifyProps {
 
   assignment: AssignmentSpec;
 
+  isUpdate: boolean;
+
   onCancel(): void;
 
   onBack(): void;
 
-  onCreateAssignment(): void;
+  onSaveAssignment(): void;
 
 }
 
@@ -99,7 +101,9 @@ export const Verify = (props: VerifyProps) => {
         <button 
           className="primary"
           disabled={!isValid}
-          onClick={props.onCreateAssignment}>{t['Create Assignment']}</button>
+          onClick={props.onSaveAssignment}>
+          {props.isUpdate ? t['Update Assignment'] :  t['Create Assignment']}
+        </button>
       </section>
     </>
   )

--- a/src/apps/project-assignments/Wizard/index.ts
+++ b/src/apps/project-assignments/Wizard/index.ts
@@ -1,1 +1,2 @@
+export * from './AssignmentSpec';
 export * from './AssignmentWizard';

--- a/src/backend/helpers/assignmentHelpers.ts
+++ b/src/backend/helpers/assignmentHelpers.ts
@@ -22,6 +22,23 @@ export const createAssignmentContext = (
     .then(({ error, data }) => 
       ({ error, data: data as Context }));
 
+export const updateAssignmentContext = (
+  supabase: SupabaseClient,
+  contextId: string,
+  name: string,
+  description?: string
+) =>
+  supabase
+    .from('contexts')
+    .update({
+      name, description
+    })
+    .eq('id', contextId)
+    .select()
+    .single()
+    .then(({ error, data }) =>
+      ({ error, data: data as Context }));
+
 /**
  * Archives an assigment context and all associated entities.
  */

--- a/src/backend/helpers/assignmentHelpers.ts
+++ b/src/backend/helpers/assignmentHelpers.ts
@@ -70,6 +70,9 @@ export const getAssignment = (
           id,
           created_at,
           created_by,
+          updated_at,
+          updated_by,
+          bucket_id,
           name,
           content_type,
           meta_data

--- a/src/backend/helpers/layerHelpers.ts
+++ b/src/backend/helpers/layerHelpers.ts
@@ -77,7 +77,7 @@ export const addUsersToLayer = (
         supabase
           .from('group_users')
           .insert(records)
-          .then(({ data, error }) => {
+          .then(({ error }) => {
             if (error)
               reject(error)
             else 
@@ -86,6 +86,44 @@ export const addUsersToLayer = (
       }
     });
 });
+
+export const removeUsersFromLayer = (
+  supabase: SupabaseClient,
+  layerId: string,
+  groupName: string,
+  users: UserProfile[]
+): Promise<void> => new Promise((resolve, reject) => {
+  // Step 1. get layer group with the given name
+  supabase
+    .from('layer_groups')
+    .select(`
+      id,
+      name
+    `)
+    .eq('layer_id', layerId)
+    .eq('name', groupName)
+    .then(({ error, data }) => {
+      if (error || data?.length !== 1) {
+        reject(error);
+      } else {
+        const groupId = data[0].id;
+        const userIds = users.map(user => user.id);
+
+        // Step 2. remove users from this group
+        supabase
+          .from('group_users')
+          .delete()
+          .in('user_id', userIds)
+          .then(({ error }) => {
+            if (error)
+              reject(error)
+            else 
+              resolve();
+          });
+      }
+    });
+});
+
 
 /**
  * Retrieves all layers on the given documents

--- a/src/components/AssignmentCard/AssignmentCard.tsx
+++ b/src/components/AssignmentCard/AssignmentCard.tsx
@@ -12,8 +12,9 @@ interface AssignmentCardProps {
 
   canUpdate?: boolean;
 
-  // Just temporary, for hacking/testing
   assignment: Context;
+
+  onEdit(): void;
 
   onDelete(): void;
 
@@ -44,6 +45,7 @@ export const AssignmentCard = (props: AssignmentCardProps) => {
         <div className="bottom">
           <AssignmentCardActions 
             i18n={props.i18n} 
+            onEdit={props.onEdit}
             onDelete={props.onDelete} />
         </div>
       )}

--- a/src/components/AssignmentCard/AssignmentCardActions.tsx
+++ b/src/components/AssignmentCard/AssignmentCardActions.tsx
@@ -1,10 +1,12 @@
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import { DotsThreeVertical, Trash } from '@phosphor-icons/react';
+import { DotsThreeVertical, PencilSimple, Trash } from '@phosphor-icons/react';
 import type { Translations } from 'src/Types';
 
 interface AssignmentCardActionsProps {
 
   i18n: Translations;
+
+  onEdit(): void;
 
   onDelete(): void;
 
@@ -13,6 +15,8 @@ interface AssignmentCardActionsProps {
 const { Content, Item, Portal, Root, Trigger } = Dropdown;
 
 export const AssignmentCardActions = (props: AssignmentCardActionsProps) => {
+
+  const { t } = props.i18n;
 
   const stopEvent = (evt: React.MouseEvent) => {
     evt.preventDefault();
@@ -39,8 +43,13 @@ export const AssignmentCardActions = (props: AssignmentCardActionsProps) => {
           className="dropdown-content no-icons" 
           sideOffset={5} 
           align="start">
+          
+          <Item className="dropdown-item" onSelect={withStopEvent(props.onEdit)}>
+            <PencilSimple size={16} /> <span>{t['Edit assignment']}</span>
+          </Item>
+
           <Item className="dropdown-item" onSelect={withStopEvent(props.onDelete)}>
-            <Trash size={16} /> <span>Delete assignment</span>
+            <Trash size={16} /> <span>{t['Delete assignment']}</span>
           </Item>
         </Content>
       </Portal>

--- a/src/components/AssignmentCard/AssignmentCardActions.tsx
+++ b/src/components/AssignmentCard/AssignmentCardActions.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
 import { DotsThreeVertical, PencilSimple, Trash } from '@phosphor-icons/react';
 import type { Translations } from 'src/Types';
@@ -18,6 +19,8 @@ export const AssignmentCardActions = (props: AssignmentCardActionsProps) => {
 
   const { t } = props.i18n;
 
+  const [open, setOpen] = useState(false);
+
   const stopEvent = (evt: React.MouseEvent) => {
     evt.preventDefault();
     evt.stopPropagation();
@@ -27,10 +30,11 @@ export const AssignmentCardActions = (props: AssignmentCardActionsProps) => {
     evt.preventDefault();
     evt.stopPropagation();
     fn();
+    setOpen(false);
   }
 
   return (
-    <Root>
+    <Root open={open} onOpenChange={setOpen}>
       <Trigger asChild>
         <button className="unstyled icon-only project-card-actions">
           <DotsThreeVertical weight="bold" size={20}/>

--- a/src/i18n/de/project-assignments.json
+++ b/src/i18n/de/project-assignments.json
@@ -9,7 +9,8 @@
   "Cancel": "Abbrechen",
   "Next": "Weiter",
   "Back": "Zurück",
-  "Create Assignment": "Arbeitsauftrag Erstellen",
+  "Create Assignment": "Arbeitsauftrag erstellen",
+  "Update Assignment": "Arbeitsauftrag aktualisieren",
 
   "Step": "Schritt",
 
@@ -45,6 +46,7 @@
   "Please consider adding instructions.": "Keine Anweisungen.",
 
   "The assignment was created successfully": "Der Arbeitsauftrag wurde erfolgreich erstellt, und dem Dashboard der Teammitglieder hinzugefügt.",
+  "The assignment was updated successfully": "Der Arbeitsauftrag wurde erfolgreich aktualisiert.",
 
   "Edit assignment": "Arbeitsauftrag ändern",
   "Delete assignment": "Arbeitsauftrag löschen",

--- a/src/i18n/de/project-assignments.json
+++ b/src/i18n/de/project-assignments.json
@@ -46,6 +46,13 @@
 
   "The assignment was created successfully": "Der Arbeitsauftrag wurde erfolgreich erstellt, und dem Dashboard der Teammitglieder hinzugefügt.",
 
+  "Edit assignment": "Arbeitsauftrag ändern",
+  "Delete assignment": "Arbeitsauftrag löschen",
+
+  "Deleted": "Gelöscht",
+  "Assignment deleted successfully": "Der Arbeitsauftrag wurde gelöscht",
+
   "Something went wrong": "Etwas ist schiefgelaufen",
-  "Could not delete the assignment.": "Der Arbeitsauftrag konnte nicht gelöscht werden."
+  "Could not delete the assignment.": "Der Arbeitsauftrag konnte nicht gelöscht werden.",
+  "Could not open the assignment.": "Der Arbeitsauftrag konnte nicht geöffnet werden."
 }

--- a/src/i18n/de/project-assignments.json
+++ b/src/i18n/de/project-assignments.json
@@ -52,7 +52,7 @@
   "Delete assignment": "Arbeitsauftrag löschen",
 
   "Deleted": "Gelöscht",
-  "Assignment deleted successfully": "Der Arbeitsauftrag wurde gelöscht",
+  "Assignment deleted successfully.": "Der Arbeitsauftrag wurde gelöscht.",
 
   "Something went wrong": "Etwas ist schiefgelaufen",
   "Could not delete the assignment.": "Der Arbeitsauftrag konnte nicht gelöscht werden.",

--- a/src/i18n/en/project-assignments.json
+++ b/src/i18n/en/project-assignments.json
@@ -52,7 +52,7 @@
   "Delete assignment": "Delete assignment",
 
   "Deleted": "Deleted",
-  "Assignment deleted successfully": "Assignment deleted successfully",
+  "Assignment deleted successfully.": "Assignment deleted successfully.",
 
   "Something went wrong": "Something went wrong",
   "Could not delete the assignment.": "Could not delete the assignment.",

--- a/src/i18n/en/project-assignments.json
+++ b/src/i18n/en/project-assignments.json
@@ -46,6 +46,13 @@
 
   "The assignment was created successfully": "The assignment was created successfully and was added to the team members' dashboards.",
 
+  "Edit assignment": "Edit assignment",
+  "Delete assignment": "Delete assignment",
+
+  "Deleted": "Deleted",
+  "Assignment deleted successfully": "Assignment deleted successfully",
+
   "Something went wrong": "Something went wrong",
-  "Could not delete the assignment.": "Could not create the document."
+  "Could not delete the assignment.": "Could not delete the assignment.",
+  "Could not open the assignment.": "Could not open the assignment."
 }

--- a/src/i18n/en/project-assignments.json
+++ b/src/i18n/en/project-assignments.json
@@ -10,6 +10,7 @@
   "Next": "Next",
   "Back": "Back",
   "Create Assignment": "Create Assignment",
+  "Update Assignment": "Update Assignment",
 
   "Step": "Step",
 
@@ -45,6 +46,7 @@
   "Please consider adding instructions.": "Please consider adding instructions.",
 
   "The assignment was created successfully": "The assignment was created successfully and was added to the team members' dashboards.",
+  "The assignment was updated successfully": "The assignment was updated successfully.",
 
   "Edit assignment": "Edit assignment",
   "Delete assignment": "Delete assignment",


### PR DESCRIPTION
## In this PR

This PR adds functionality to __edit an existing assignment__ (see https://github.com/performant-software/vico/issues/147, https://github.com/performant-software/vico/issues/154).

- The actions dropdown on the Assignment card now has an extra 'Edit Assignment' option. (Note that the actions menu is only available to admin level users)
- Selecting the 'Edit Assignment' menu option will bring up the same editing wizard that is also shown when creating a new assignment, but with all tabs pre-filled.
- It is possible to change all aspects of the Assignment:
   - Name
   - Documents
   - Team
   - Readme
- UI labels in the wizard are changed accordingly ('Save Assignment' instead of 'Create Assignment'), and localized labels were added
- When saving an existing assignment, the wizard performs different steps. Instead of creating, the following happens:
   - Name and description are checked for changes. The `context` record is updated accordingly, if needed.
   - Documents and team are checked for additions and removals
   - Document `layers` are created and archived as needed, if documents were added to the assignment. Users are added to the newly created document layers.
   - If there were additions or removals to the team, the `Layer Students` groups on existing documents are updated accordingly.