### PR TITLE
Minor bugfixes

### DIFF
--- a/src/components/Annotation/Card/BaseCard.tsx
+++ b/src/components/Annotation/Card/BaseCard.tsx
@@ -62,10 +62,8 @@ export const BaseCard = (props: BaseCardProps) => {
   const beforeReply = (b: AnnotationBody) =>
     (dontEmphasise.current = new Set([...dontEmphasise.current, b.id]));
 
-  const onReply = (b: AnnotationBody) => {
-    props.onCreateBody(b);
+  const onReply = (b: AnnotationBody) =>
     props.onReply && props.onReply(b);
-  }
 
   useEffect(() => {
     const eqSet = (x: Set<any>, y: Set<any>) =>
@@ -84,7 +82,7 @@ export const BaseCard = (props: BaseCardProps) => {
         .querySelectorAll('.is-new')
         .forEach((el) => el.classList.remove('is-new'));
     }, 100);
-  }, [comments]);
+  }, [comments.map(c => c.id).join(',')]);
 
   return (
     <>

--- a/src/components/Annotation/Card/CardProps.ts
+++ b/src/components/Annotation/Card/CardProps.ts
@@ -17,7 +17,7 @@ export interface CardProps {
 
   tagVocabulary?: string[];
 
-  onReply?(body: AnnotationBody): void;
+  onReply(body: AnnotationBody): void;
 
   onDeleteAnnotation(): void;
 

--- a/src/components/Annotation/Popup/Popup.tsx
+++ b/src/components/Annotation/Popup/Popup.tsx
@@ -39,8 +39,10 @@ export const Popup = (props: PopupProps) => {
   const hasBodies = selected.bodies.length > 0;
 
   // Close the popup after a reply
-  const onReply = () =>
+  const onReply = (body: AnnotationBody) => {
+    store.addBody(body);
     anno.state.selection.clear();
+  }
 
   const onDeleteAnnotation = (annotation: Anno) => 
     store.deleteAnnotation(annotation);

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -159,10 +159,10 @@ export const AnnotationList = (props: AnnotationListProps) => {
                     <Annotation.ReplyForm
                       autofocus={autofocus}
                       i18n={props.i18n}
+                      me={me} 
                       scrollIntoView
                       annotation={a} 
                       placeholder={props.i18n.t['Comment...']}
-                      me={me} 
                       onSubmit={onCreateBody} />
                   </div>
                 ) : (
@@ -189,6 +189,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
                   annotation={a} 
                   present={props.present}
                   tagVocabulary={props.tagVocabulary} 
+                  onReply={onCreateBody}
                   onCreateBody={onCreateBody} 
                   onDeleteBody={onDeleteBody} 
                   onUpdateBody={onUpdateBody}
@@ -202,6 +203,7 @@ export const AnnotationList = (props: AnnotationListProps) => {
                   present={props.present}
                   policies={props.policies} 
                   tagVocabulary={props.tagVocabulary} 
+                  onReply={onCreateBody}
                   onCreateBody={onCreateBody} 
                   onDeleteBody={onDeleteBody} 
                   onUpdateBody={onUpdateBody}


### PR DESCRIPTION
## In this PR

This PR fixes a problem with the previous PR https://github.com/recogito/recogito-client/pull/86. (PR #86 resolved the issue of replies getting added twice, but introduced another bug which caused the first comment to be discarded when using the popup.)

The PR also fixes a small animation issue: when writing a reply, your own comment got an emphasis animation. Emphasis animation, however, was only supposed to happen on comments created __by other users in the realtime session__ (as an extra hint that someone has posted). This is now fixed, and replies you write yourself just get appended to the annotation without emphasis animation.