### PR TITLE
Removed dependence on group names in the client

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -89,6 +89,10 @@ export interface Group {
 
   name: string;
 
+  is_admin: boolean;
+
+  is_default: boolean;
+
   members: Array<{
     user: UserProfile;
 
@@ -200,6 +204,10 @@ export interface ExtendedAssignmentData extends Context {
           name: string;
 
           description?: string;
+
+          is_admin: boolean;
+
+          is_default: boolean;
 
           members: Array<{
             user: UserProfile;

--- a/src/apps/project-assignments/Wizard/AssignmentSpec.ts
+++ b/src/apps/project-assignments/Wizard/AssignmentSpec.ts
@@ -1,7 +1,10 @@
-import type { DocumentInContext, ExtendedAssignmentData, UserProfile } from 'src/Types';
+import type {
+  DocumentInContext,
+  ExtendedAssignmentData,
+  UserProfile,
+} from 'src/Types';
 
 export interface AssignmentSpec {
-
   id?: string;
 
   name?: string;
@@ -11,15 +14,16 @@ export interface AssignmentSpec {
   team: UserProfile[];
 
   description?: string;
-
 }
 
 // Utility crosswalk between ExtendedAssignmentData and AssignmentSpec
-export const toAssignmentSpec = (data: ExtendedAssignmentData): AssignmentSpec => ({
+export const toAssignmentSpec = (
+  data: ExtendedAssignmentData
+): AssignmentSpec => ({
   id: data.id,
   name: data.name,
   description: data.description,
-  documents: data.layers.map(layer => ({
+  documents: data.layers.map((layer) => ({
     id: layer.document.id,
     name: layer.document.name,
     created_at: layer.document.created_at,
@@ -29,19 +33,24 @@ export const toAssignmentSpec = (data: ExtendedAssignmentData): AssignmentSpec =
     bucket_id: layer.document.bucket_id,
     content_type: layer.document.content_type,
     meta_data: layer.document.meta_data,
-    layers: [{
-      id: layer.id,
-      document_id: layer.document.id,
-      project_id: data.project_id,
-      name: layer.name,
-      description: layer.description,
-      context: {
-        id: data.id,
-        name: data.name,
-        description: data.description,
-        project_id: data.project_id
-      }
-    }]
+    layers: [
+      {
+        id: layer.id,
+        document_id: layer.document.id,
+        project_id: data.project_id,
+        name: layer.name,
+        description: layer.description,
+        context: {
+          id: data.id,
+          name: data.name,
+          description: data.description,
+          project_id: data.project_id,
+        },
+      },
+    ],
   })),
-  team: data.layers[0].groups.find(g => g.name === 'Layer Student')?.members.map(m => m.user) || []
+  team:
+    data.layers[0].groups
+      .find((g) => g.is_default === true)
+      ?.members.map((m) => m.user) || [],
 });

--- a/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressCreating.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import { addUsersToLayer, createAssignmentContext, createLayerInContext } from '@backend/helpers';
+import {
+  addUsersToLayer,
+  createAssignmentContext,
+  createLayerInContext,
+} from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Spinner } from '@components/Spinner';
 import { AnimatedCheck } from '@components/AnimatedIcons';
@@ -9,21 +13,20 @@ import type { ProgressProps, ProgressState } from './Progress';
 import './Progress.css';
 
 export const ProgressCreating = (props: ProgressProps) => {
-
   const { t } = props.i18n;
 
   const { name, description, documents, team } = props.assignment;
 
   const [state, setState] = useState<ProgressState>('idle');
-  
+
   useEffect(() => {
     const projectId = props.project.id;
 
     setState('creating_assignment');
 
     // Step 1. Create a new context for this assignment
-    createAssignmentContext(supabase, name!, description, projectId)
-      .then(({ error, data }) => {
+    createAssignmentContext(supabase, name!, description, projectId).then(
+      ({ error, data }) => {
         if (error) {
           console.error(error);
 
@@ -33,46 +36,53 @@ export const ProgressCreating = (props: ProgressProps) => {
           const context = data;
 
           // Step 2. For each document, create a layer in this context
-          documents.reduce((promise, document) => {
-            return promise.then(layers => {
-              return createLayerInContext(supabase, document.id, projectId, context.id)
-                .then(layer => ([...layers, layer]))
-            });
-          }, Promise.resolve<Layer[]>([])).then(layers => {
-            
-            // Step 3. For each layer, add users to the 'Layer Student' group
-            layers.reduce((promise, layer) => {
-              return promise.then(() => 
-                addUsersToLayer(supabase, layer.id, 'Layer Student', team));
-            }, Promise.resolve<void>(undefined)).then(() => {
-              setState('success');
-              props.onSaved(context);
-            })            
-          }).catch(error => {
-            console.error(error);
+          documents
+            .reduce((promise, document) => {
+              return promise.then((layers) => {
+                return createLayerInContext(
+                  supabase,
+                  document.id,
+                  projectId,
+                  context.id
+                ).then((layer) => [...layers, layer]);
+              });
+            }, Promise.resolve<Layer[]>([]))
+            .then((layers) => {
+              // Step 3. For each layer, add users to the 'Layer Student' group
+              layers
+                .reduce((promise, layer) => {
+                  return promise.then(() =>
+                    addUsersToLayer(supabase, layer.id, 'default', team)
+                  );
+                }, Promise.resolve<void>(undefined))
+                .then(() => {
+                  setState('success');
+                  props.onSaved(context);
+                });
+            })
+            .catch((error) => {
+              console.error(error);
 
-            setState('failed');
-            props.onError(error.message);
-          })
+              setState('failed');
+              props.onError(error.message);
+            });
         }
-      });
+      }
+    );
   }, []);
 
   return (
-    <div className="saving-assignment">
+    <div className='saving-assignment'>
       {state === 'idle' || state === 'creating_assignment' ? (
         <Spinner />
       ) : state === 'success' ? (
         <>
           <AnimatedCheck size={40} />
-          <p>
-            {t['The assignment was created successfully']}
-          </p>
+          <p>{t['The assignment was created successfully']}</p>
         </>
       ) : (
         <p>{t['Something went wrong']}</p>
       )}
     </div>
-  )
-
-}
+  );
+};

--- a/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
+++ b/src/apps/project-assignments/Wizard/Progress/ProgressUpdating.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from 'react';
 import { archiveLayer } from '@backend/crud';
-import { addUsersToLayer, createLayerInContext, removeUsersFromLayer, updateAssignmentContext } from '@backend/helpers';
+import {
+  addUsersToLayer,
+  createLayerInContext,
+  removeUsersFromLayer,
+  updateAssignmentContext,
+} from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Spinner } from '@components/Spinner';
 import { AnimatedCheck } from '@components/AnimatedIcons';
@@ -11,21 +16,22 @@ import type { AssignmentSpec } from '../AssignmentSpec';
 import './Progress.css';
 
 interface ProgressUpdatingProps extends ProgressProps {
-
   previous: AssignmentSpec;
-
 }
 
 /**
  * Helper to determine which items in ys were added and removed, compared to xs.
  */
-const diff = <T extends { id: string }>(xs: T[], ys: T[]): { added: T[], removed: T[], unchanged: T[] } => {
+const diff = <T extends { id: string }>(
+  xs: T[],
+  ys: T[]
+): { added: T[]; removed: T[]; unchanged: T[] } => {
   const added = [];
   const removed = [];
   const unchanged = [];
 
-  const xsIdSet = new Set(xs.map(item => item.id));
-  const ysIdSet = new Set(ys.map(item => item.id));
+  const xsIdSet = new Set(xs.map((item) => item.id));
+  const ysIdSet = new Set(ys.map((item) => item.id));
 
   for (const item of xs) {
     if (ysIdSet.has(item.id)) {
@@ -45,10 +51,9 @@ const diff = <T extends { id: string }>(xs: T[], ys: T[]): { added: T[], removed
   }
 
   return { added, removed, unchanged };
-}
+};
 
 export const ProgressUpdating = (props: ProgressUpdatingProps) => {
-
   const { t } = props.i18n;
 
   const { previous } = props;
@@ -58,12 +63,12 @@ export const ProgressUpdating = (props: ProgressUpdatingProps) => {
   const [state, setState] = useState<ProgressState>('idle');
 
   const context: Context = {
-    id:  previous.id!,
+    id: previous.id!,
     name: name!,
     description,
-    project_id: props.project.id
+    project_id: props.project.id,
   };
-  
+
   useEffect(() => {
     setState('updating_assignment');
 
@@ -71,7 +76,7 @@ export const ProgressUpdating = (props: ProgressUpdatingProps) => {
       // Step 1. Update name/description if needed.
       if (name !== previous.name || description !== previous.description)
         await updateAssignmentContext(supabase, context.id, name!, description);
-    
+
       // Step 2. Update documents.
       const documentChanges = diff(previous.documents, documents);
 
@@ -86,17 +91,25 @@ export const ProgressUpdating = (props: ProgressUpdatingProps) => {
 
       // - check for added documents and create layers
       if (documentChanges.added.length > 0) {
-        const layers = await documentChanges.added.reduce((promise, document) => {
-          return promise.then(layers => {
-            return createLayerInContext(supabase, document.id, context.project_id, context.id)
-              .then(layer => ([...layers, layer]))
-          });
-        }, Promise.resolve<Layer[]>([]));
+        const layers = await documentChanges.added.reduce(
+          (promise, document) => {
+            return promise.then((layers) => {
+              return createLayerInContext(
+                supabase,
+                document.id,
+                context.project_id,
+                context.id
+              ).then((layer) => [...layers, layer]);
+            });
+          },
+          Promise.resolve<Layer[]>([])
+        );
 
         // - for each created layer, add members to the 'Layer Student' group
         await layers.reduce((promise, layer) => {
-          return promise.then(() => 
-              addUsersToLayer(supabase, layer.id, 'Layer Student', team));
+          return promise.then(() =>
+            addUsersToLayer(supabase, layer.id, 'default', team)
+          );
         }, Promise.resolve<void>(undefined));
       }
 
@@ -104,51 +117,63 @@ export const ProgressUpdating = (props: ProgressUpdatingProps) => {
       const memberChanges = diff(previous.team, team);
 
       // IDs of the layers on the existing documents
-      const existingLayerIds = documentChanges.unchanged.map(d => d.layers[0].id)
+      const existingLayerIds = documentChanges.unchanged.map(
+        (d) => d.layers[0].id
+      );
 
       // - Members were added (and some documents existed previously)
-      if (memberChanges.added.length > 0 && documentChanges.unchanged.length > 0) {
+      if (
+        memberChanges.added.length > 0 &&
+        documentChanges.unchanged.length > 0
+      ) {
         await existingLayerIds.reduce((promise, layerId) => {
           // - insert added users to its 'Layer Student' group
-          return promise.then(() => 
-              addUsersToLayer(supabase, layerId, 'Layer Student', memberChanges.added));
+          return promise.then(() =>
+            addUsersToLayer(supabase, layerId, 'default', memberChanges.added)
+          );
         }, Promise.resolve<void>(undefined));
       }
 
       // Members were removed (and some documents existed previously)
-      if (memberChanges.removed.length > 0 && documentChanges.unchanged.length > 0) {
+      if (
+        memberChanges.removed.length > 0 &&
+        documentChanges.unchanged.length > 0
+      ) {
         await existingLayerIds.reduce((promise, layerId) => {
           return promise.then(() =>
-            removeUsersFromLayer(supabase, layerId, 'Layer Student', memberChanges.removed));
+            removeUsersFromLayer(
+              supabase,
+              layerId,
+              'default',
+              memberChanges.removed
+            )
+          );
         }, Promise.resolve<void>(undefined));
       }
 
       setState('success');
-    }
+    };
 
     update()
       .then(() => props.onSaved(context))
-      .catch(error => { 
+      .catch((error) => {
         setState('failed');
-        props.onError(error)
+        props.onError(error);
       });
   }, []);
 
   return (
-    <div className="saving-assignment">
+    <div className='saving-assignment'>
       {state === 'idle' || state === 'updating_assignment' ? (
         <Spinner />
       ) : state === 'success' ? (
         <>
           <AnimatedCheck size={40} />
-          <p>
-            {t['The assignment was updated successfully']}
-          </p>
+          <p>{t['The assignment was updated successfully']}</p>
         </>
       ) : (
         <p>{t['Something went wrong']}</p>
       )}
     </div>
-  )
-
-}
+  );
+};

--- a/src/backend/helpers/projectHelpers.ts
+++ b/src/backend/helpers/projectHelpers.ts
@@ -1,36 +1,40 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { createContext, createProject, deleteContext, deleteProject, getGroupMembers, zipMembers } from '@backend/crud';
+import {
+  createContext,
+  createProject,
+  deleteContext,
+  deleteProject,
+  getGroupMembers,
+  zipMembers,
+} from '@backend/crud';
 import type { Context, ExtendedProjectData, Project } from 'src/Types';
 import type { Response } from '@backend/Types';
 import { createSystemTag } from './tagHelpers';
 
 /**
  * Initializes a new project.
- * 
+ *
  * 1. creates the Project record.
  * 2. creates a new Context.
  * 3. TODO: tags the Context as a 'DEFAULT' context.
  */
 export const initProject = (
-  supabase: SupabaseClient, 
+  supabase: SupabaseClient,
   name: string
 ): Promise<ExtendedProjectData> => {
   // First promise: create the project
-  const a: Promise<Project> =
-    new Promise((resolve, reject) => 
-      createProject(supabase, name)
-        .then(({ error, data }) => {
-          if (error)
-            reject(error);
-          else
-            resolve(data);
-        }));
+  const a: Promise<Project> = new Promise((resolve, reject) =>
+    createProject(supabase, name).then(({ error, data }) => {
+      if (error) reject(error);
+      else resolve(data);
+    })
+  );
 
   // Follow-on promise: create a new context
-  const b: Promise<Context> = a.then(project =>
-    new Promise((resolve, reject) => 
-      createContext(supabase, project.id)
-        .then(({ error, data }) => {
+  const b: Promise<Context> = a.then(
+    (project) =>
+      new Promise((resolve, reject) =>
+        createContext(supabase, project.id).then(({ error, data }) => {
           if (error) {
             // If context creation failed, roll back the project
             deleteProject(supabase, project.id).then(() => {
@@ -39,34 +43,39 @@ export const initProject = (
           } else {
             resolve(data);
           }
-        })));
+        })
+      )
+  );
 
   // Wait for both promises to complete, tag the default context,
   // and return the extended project data.
-  return Promise.all([a, b]).then(([ project, defaultContext]) => 
-    new Promise((resolve, reject) =>
-      createSystemTag(supabase, 'DEFAULT_CONTEXT', defaultContext.id)
-        .then(() => {
-          getProjectExtended(supabase, project.id)
-            .then(({ error, data }) => {
-              if (error)
-                reject(error)
-              else 
-                resolve(data);
+  return Promise.all([a, b]).then(
+    ([project, defaultContext]) =>
+      new Promise((resolve, reject) =>
+        createSystemTag(supabase, 'DEFAULT_CONTEXT', defaultContext.id)
+          .then(() => {
+            getProjectExtended(supabase, project.id).then(({ error, data }) => {
+              if (error) reject(error);
+              else resolve(data);
             });
-        })
-        .catch(error => {
-          // Tag creation failed? Roll back context and project
-          deleteContext(supabase, defaultContext.id)
-            .then(() => deleteProject(supabase, project.id))
-            .then(() => reject(error));
-        })));
-}
+          })
+          .catch((error) => {
+            // Tag creation failed? Roll back context and project
+            deleteContext(supabase, defaultContext.id)
+              .then(() => deleteProject(supabase, project.id))
+              .then(() => reject(error));
+          })
+      )
+  );
+};
 
-export const listMyProjectsExtended = (supabase: SupabaseClient): Response<ExtendedProjectData[]> => 
+export const listMyProjectsExtended = (
+  supabase: SupabaseClient
+): Response<ExtendedProjectData[]> =>
   supabase
     .from('projects')
-    .select(`
+    .select(
+      `
       id,
       created_at,
       created_by:profiles!projects_created_by_fkey(
@@ -100,38 +109,47 @@ export const listMyProjectsExtended = (supabase: SupabaseClient): Response<Exten
         id,
         name
       )
-    `)
-    .then(({ error, data }) => { 
+    `
+    )
+    .then(({ error, data }) => {
       if (error) {
         return { error, data: [] as ExtendedProjectData[] };
       } else {
         const projects = data;
         // All group IDs of all projects in `data`
-        const groupIds = projects.reduce((ids, project) => 
-          ([...ids, ...project.groups.map(g => g.id)]), [] as string[]);
+        const groupIds = projects.reduce(
+          (ids, project) => [...ids, ...project.groups.map((g) => g.id)],
+          [] as string[]
+        );
 
-        return getGroupMembers(supabase, groupIds)
-          .then(({ error, data }) => {
-            if (error) {
-              return { error, data: [] as ExtendedProjectData[] };
-            } else {
-              // Re-assign group members to projects
-              const projectsExtended = projects.map(p => ({
-                ...p,
-                groups: zipMembers(p.groups, data)
-              } as unknown as ExtendedProjectData));
+        return getGroupMembers(supabase, groupIds).then(({ error, data }) => {
+          if (error) {
+            return { error, data: [] as ExtendedProjectData[] };
+          } else {
+            // Re-assign group members to projects
+            const projectsExtended = projects.map(
+              (p) =>
+                ({
+                  ...p,
+                  groups: zipMembers(p.groups, data),
+                } as unknown as ExtendedProjectData)
+            );
 
-              return { error, data: projectsExtended };
-            } 
-          });
+            return { error, data: projectsExtended };
+          }
+        });
       }
     });
 
 // TODO redundancy needs cleaning up!
-export const getProjectExtended = (supabase: SupabaseClient, projectId: string): Response<ExtendedProjectData> => 
+export const getProjectExtended = (
+  supabase: SupabaseClient,
+  projectId: string
+): Response<ExtendedProjectData> =>
   supabase
     .from('projects')
-    .select(`
+    .select(
+      `
       id,
       created_at,
       created_by:profiles!projects_created_by_fkey(
@@ -163,37 +181,39 @@ export const getProjectExtended = (supabase: SupabaseClient, projectId: string):
       ),
       groups:project_groups (
         id,
-        name
+        name,
+        is_admin,
+        is_default
       )
-    `)
+    `
+    )
     .eq('id', projectId)
     .single()
-    .then(({ error, data }) => { 
+    .then(({ error, data }) => {
       if (error) {
         return { error, data: undefined as unknown as ExtendedProjectData };
       } else {
         const project = data;
 
-        const groupIds = project.groups.map(g => g.id);
+        const groupIds = project.groups.map((g) => g.id);
 
-        return getGroupMembers(supabase, groupIds)
-          .then(({ error, data }) => {
-            if (error) {
-              return { error, data: undefined as unknown as ExtendedProjectData };
-            } else {
-              // Re-assign group members to groups
-              const projectExtended = {
-                ...project,
-                groups: project.groups.map(g => ({
-                  ...g,
-                  members: data
-                    .filter(m => m.in_group === g.id)
-                    .map(({ user, since }) => ({ user, since }))
-                }))
-              } as unknown as ExtendedProjectData;
+        return getGroupMembers(supabase, groupIds).then(({ error, data }) => {
+          if (error) {
+            return { error, data: undefined as unknown as ExtendedProjectData };
+          } else {
+            // Re-assign group members to groups
+            const projectExtended = {
+              ...project,
+              groups: project.groups.map((g) => ({
+                ...g,
+                members: data
+                  .filter((m) => m.in_group === g.id)
+                  .map(({ user, since }) => ({ user, since })),
+              })),
+            } as unknown as ExtendedProjectData;
 
-              return { error, data: projectExtended };
-            } 
-          });
+            return { error, data: projectExtended };
+          }
+        });
       }
     });

--- a/src/layouts/project/ProjectSidebar.tsx
+++ b/src/layouts/project/ProjectSidebar.tsx
@@ -1,28 +1,20 @@
-
-import { useEffect, useState } from 'react'; 
-import { 
+import { useEffect, useState } from 'react';
+import {
   ArrowLineLeft,
   Folders,
-  GooglePodcastsLogo, 
-  GraduationCap, 
-  PuzzlePiece, 
-  Sliders, 
-  UsersThree
+  GooglePodcastsLogo,
+  GraduationCap,
+  Sliders,
+  UsersThree,
 } from '@phosphor-icons/react';
 import { AccountActions } from '@components/AccountActions';
 import { Avatar } from '@components/Avatar';
 import { NavItem } from './NavItem';
-import type { 
-  ExtendedAssignmentData,
-  ExtendedProjectData, 
-  MyProfile,
-  Translations 
-} from 'src/Types';
+import type { ExtendedProjectData, MyProfile, Translations } from 'src/Types';
 
 import './ProjectSidebar.css';
 
 export interface ProjectSidebarProps {
-
   active: string;
 
   i18n: Translations;
@@ -32,119 +24,126 @@ export interface ProjectSidebarProps {
   project: ExtendedProjectData;
 
   me: MyProfile;
-
 }
 
 const setCookie = () => {
   const maxAge = 100 * 365 * 24 * 60 * 60; // 100 years, never expires
   document.cookie = `x-project-sidebar-collapsed=true; path=/; max-age=${maxAge}; SameSite=Lax; secure`;
-}
+};
 
 const clearCookie = () => {
   const expires = new Date(0).toUTCString();
   document.cookie = `x-project-sidebar-collapsed=false; path=/; expires=${expires}; SameSite=Lax; secure`;
-}
+};
 
 export const ProjectSidebar = (props: ProjectSidebarProps) => {
-  
   const { active, me } = props;
 
   const { lang, t } = props.i18n;
 
   // Find the admin group and check if I'm in there
-  const isAdmin = props.project.groups.find(g => 
-    g.name === 'Project Admins')?.members.some(m => m.user.id === me.id) || me.isOrgAdmin;
+  const isAdmin =
+    props.project.groups
+      .find((g) => g.is_admin === true)
+      ?.members.some((m) => m.user.id === me.id) || me.isOrgAdmin;
 
   const [open, setOpen] = useState(!props.collapsed);
 
   useEffect(() => {
-    if (open)
-      clearCookie();
-    else 
-      setCookie();
+    if (open) clearCookie();
+    else setCookie();
   }, [open]);
 
-  const link = (segment: string = '') => props.project ? 
-    `/${lang}/projects/${props.project.id}/${segment}` : undefined;
+  const link = (segment: string = '') =>
+    props.project
+      ? `/${lang}/projects/${props.project.id}/${segment}`
+      : undefined;
 
   return (
-    <aside 
-      className={open ? 'project-sidebar open' : 'project-sidebar collapsed'}>
-      <nav className="project-primary-nav">
+    <aside
+      className={open ? 'project-sidebar open' : 'project-sidebar collapsed'}
+    >
+      <nav className='project-primary-nav'>
         <ul>
           <li>
             <ul>
-              <NavItem 
-                className="no-hover"
+              <NavItem
+                className='no-hover'
                 icon={GooglePodcastsLogo}
-                label="Recogito"
-                link={`/${lang}/projects`} />
+                label='Recogito'
+                link={`/${lang}/projects`}
+              />
 
-              <NavItem 
+              <NavItem
                 active={active === 'Documents'}
                 icon={Folders}
                 label={t['Documents']}
-                link={link()} />
+                link={link()}
+              />
 
               {isAdmin && (
                 <NavItem
                   active={active === 'Collaboration'}
                   icon={UsersThree}
                   label={t['Collaboration']}
-                  link={link('collaboration')} />
+                  link={link('collaboration')}
+                />
               )}
 
               <NavItem
                 active={active === 'Assignments'}
                 icon={GraduationCap}
                 label={t['Assignments']}
-                link={link('assignments')} />
+                link={link('assignments')}
+              />
 
               {/* <NavItem
                 active={active === 'Add Ons'}
                 icon={PuzzlePiece}
                 label={t['Add Ons']}
               link={link('addons')} /> */}
-              
+
               {isAdmin && (
                 <NavItem
                   active={active === 'Settings'}
                   icon={Sliders}
                   label={t['Settings']}
-                  link={link('settings')} />
+                  link={link('settings')}
+                />
               )}
             </ul>
           </li>
         </ul>
       </nav>
-      
-      <div className="project-sidebar-spacer" />
 
-      <section className="project-sidebar-actions">
+      <div className='project-sidebar-spacer' />
+
+      <section className='project-sidebar-actions'>
         <ul>
-          <li className="project-sidebar-toggle project-sidebar-row">
+          <li className='project-sidebar-toggle project-sidebar-row'>
             <button onClick={() => setOpen(!open)}>
-              <span className="project-sidebar-col fixed">
+              <span className='project-sidebar-col fixed'>
                 <ArrowLineLeft size={20} />
               </span>
             </button>
           </li>
-          <li className="project-sidebar-row">
-            <AccountActions 
+          <li className='project-sidebar-row'>
+            <AccountActions
               i18n={props.i18n}
-              align="start"
+              align='start'
               alignOffset={5}
-              profile={me}>
-
+              profile={me}
+            >
               <button>
-                <span className="project-sidebar-col fixed">
-                  <Avatar 
-                    id={me.id} 
-                    name={me.nickname} 
-                    avatar={me.avatar_url} />
+                <span className='project-sidebar-col fixed'>
+                  <Avatar
+                    id={me.id}
+                    name={me.nickname}
+                    avatar={me.avatar_url}
+                  />
                 </span>
 
-                <span className="project-sidebar-col collapsible">
+                <span className='project-sidebar-col collapsible'>
                   {props.me?.nickname || ''}
                 </span>
               </button>
@@ -153,6 +152,5 @@ export const ProjectSidebar = (props: ProjectSidebarProps) => {
         </ul>
       </section>
     </aside>
-  )
-
-}
+  );
+};


### PR DESCRIPTION
# This PR adds

The recogito client was depending on specific names of groups to add users and such in various flows.  This PR removes this dependence.

All organization_groups, project_groups, and layer_groups now have is_admin and is_default columns that are set in the config.json for default groups.

So searches for "Org Admins" now uses a search for is_admin in the group.  "Project Admin" and "Project Student", and "Layer Student" is handled similarly.

Note that the Supabase support for this is only deployed on Bonn Staging for now.