### PR TITLE
Loading indicator overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@radix-ui/react-toast": "^1.1.3",
         "@react-spring/web": "^9.7.3",
         "@recogito/annotorious-supabase": "^3.0.0-rc.3",
-        "@recogito/react-pdf-annotator": "^0.2.0",
+        "@recogito/react-pdf-annotator": "^0.3.0",
         "@recogito/react-text-annotator": "^3.0.0-rc.2",
         "@supabase/auth-helpers-shared": "^0.3.4",
         "@supabase/supabase-js": "^2.32.0",
@@ -2440,9 +2440,9 @@
       }
     },
     "node_modules/@recogito/react-pdf-annotator": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@recogito/react-pdf-annotator/-/react-pdf-annotator-0.2.0.tgz",
-      "integrity": "sha512-aDGFsixz/tsonM/aa4lkpE18OWSeWZvsMwAlQ5R1VeiDeYUIj5oUep6ceEm5LP8RcCMQmoPoIe0mUqsoF5F5zA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@recogito/react-pdf-annotator/-/react-pdf-annotator-0.3.0.tgz",
+      "integrity": "sha512-ihEA4AaGLFf701l0p+qADGlYXL7mxnSzra/qL0XWolEkcaIKHQCKRxiRnR9Bxl+erOX2+e4GxxFT43+TorSh3A==",
       "peerDependencies": {
         "@annotorious/react": "^3.0.0-rc.2",
         "react": "16.8.0 || >=17.x || >=18.x",
@@ -10609,9 +10609,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@radix-ui/react-toast": "^1.1.3",
     "@react-spring/web": "^9.7.3",
     "@recogito/annotorious-supabase": "^3.0.0-rc.3",
-    "@recogito/react-pdf-annotator": "^0.2.0",
+    "@recogito/react-pdf-annotator": "^0.3.0",
     "@recogito/react-text-annotator": "^3.0.0-rc.2",
     "@supabase/auth-helpers-shared": "^0.3.4",
     "@supabase/supabase-js": "^2.32.0",

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -4,6 +4,7 @@ import { getAllDocumentLayersInProject, isDefaultContext } from '@backend/helper
 import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Annotation } from '@components/Annotation';
+import { LoadingOverlay } from '@components/LoadingOverlay';
 import { createAppearenceProvider, PresenceStack } from '@components/Presence';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
 import type { PrivacyMode } from '@components/PrivacySelector';
@@ -38,6 +39,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
   const anno = useAnnotator<AnnotoriousOpenSeadragonAnnotator>();
 
   const policies = useLayerPolicies(props.document.layers[0].id);
+
+  const [loading, setLoading] = useState(true);
 
   const [present, setPresent] = useState<PresentUser[]>([]);
 
@@ -133,7 +136,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
   // TODO since Annotorious 3.0.0-rc.2 this needs to be 
   // memo-ized which is a pain - need to fix this inside
   // Annotorious!
-  const options = useMemo(() => ({
+  const options: OpenSeadragon.Options = useMemo(() => ({
     tileSources: props.document.meta_data?.url,
     gestureSettingsMouse: {
       clickToZoom: false
@@ -144,6 +147,10 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
   return (
     <div className="anno-desktop ia-desktop">
+      {loading && (
+        <LoadingOverlay />
+      )}
+
       {policies && (
         <OpenSeadragonAnnotator
           autoSave
@@ -165,6 +172,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               defaultLayer={defaultLayer?.id} 
               layerIds={layers.map(layer => layer.id)}
               appearanceProvider={appearance}
+              onInitialLoad={() => setLoading(false)}
               onPresence={setPresent} 
               onConnectError={onConnectError}
               privacyMode={privacy === 'PRIVATE'} />
@@ -172,7 +180,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
           <OpenSeadragonViewer
             className="ia-osd-container"
-            // @ts-ignore
             options={options} />
 
           {usePopup && (

--- a/src/apps/annotation-text/PDFViewer.tsx
+++ b/src/apps/annotation-text/PDFViewer.tsx
@@ -16,6 +16,8 @@ interface PDFViewerProps {
 
   style?: ((a: TextAnnotation) => DrawingStyle);
 
+  onRendered?(): void;
+
   onError?(): void;
 
 }
@@ -34,7 +36,8 @@ export const PDFViewer = (props: PDFViewerProps) => {
     <PDFAnnotator 
       pdfUrl={downloadURL} 
       filter={props.filter}
-      style={props.style} />
+      style={props.style}
+      onRendered={props.onRendered} />
   )
   
 }

--- a/src/apps/annotation-text/TextAnnotationDesktop.css
+++ b/src/apps/annotation-text/TextAnnotationDesktop.css
@@ -13,6 +13,7 @@
   font-family: Lora;
   font-size: 17px;
   line-height: 190%;
+  min-height: 100%;
   padding: 70px 85px 140px 85px;
   pointer-events: all;
   position: relative;

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -45,7 +45,11 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
   const text = useContent(props.document);
 
-  const [loading, setLoading] = useState(true);
+  const [annotationsLoading, setAnnotationsLoading] = useState(true);
+
+  const [pdfLoading, setPDFLoading] = useState(contentType === 'application/pdf');
+
+  const loading = annotationsLoading || pdfLoading || (!text);
 
   const [present, setPresent] = useState<PresentUser[]>([]);
 
@@ -128,7 +132,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
         contentType === 'application/pdf' ? 'content-wrapper pdf' : 
           'content-wrapper text'}>
 
-      {loading && !text && (
+      {loading && (
         <LoadingOverlay />
       )}
 
@@ -146,7 +150,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
           <PDFViewer
             document={props.document} 
             filter={filter}
-            style={style} />
+            style={style} 
+            onRendered={() => setPDFLoading(false)} />
         ) : text && (
           <TextAnnotator
             filter={filter}
@@ -171,7 +176,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
             defaultLayer={defaultLayer?.id} 
             layerIds={layers.map(layer => layer.id)}
             appearanceProvider={createAppearenceProvider()}
-            onInitialLoad={() => setLoading(false)}
+            onInitialLoad={() => setAnnotationsLoading(false)}
             onPresence={setPresent} 
             privacyMode={privacy === 'PRIVATE'}/>
         }

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -16,13 +16,14 @@ import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
 import { PresenceStack, createAppearenceProvider } from '@components/Presence';
 import { Annotation } from '@components/Annotation';
 import { AnnotationDesktop, ViewMenuPanel } from '@components/AnnotationDesktop';
-import type { TextAnnotationProps } from './TextAnnotation';
-import { Toolbar } from './Toolbar';
+import { LoadingOverlay } from '@components/LoadingOverlay';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { SupabasePlugin } from '@components/SupabasePlugin';
 import { useContent } from './useContent';
-import type { Layer } from 'src/Types';
 import { PDFViewer } from './PDFViewer';
+import type { TextAnnotationProps } from './TextAnnotation';
+import { Toolbar } from './Toolbar';
+import type { Layer } from 'src/Types';
 
 import './TEI.css';
 import './TextAnnotationDesktop.css';
@@ -43,6 +44,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
   const policies = useLayerPolicies(props.document.layers[0].id);
 
   const text = useContent(props.document);
+
+  const [loading, setLoading] = useState(true);
 
   const [present, setPresent] = useState<PresentUser[]>([]);
 
@@ -124,6 +127,11 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
         contentType === 'text/xml' ? 'content-wrapper tei' : 
         contentType === 'application/pdf' ? 'content-wrapper pdf' : 
           'content-wrapper text'}>
+
+      {loading && !text && (
+        <LoadingOverlay />
+      )}
+
       <main>
         {contentType === 'text/xml' && text ? (
           <TEIAnnotator
@@ -163,6 +171,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
             defaultLayer={defaultLayer?.id} 
             layerIds={layers.map(layer => layer.id)}
             appearanceProvider={createAppearenceProvider()}
+            onInitialLoad={() => setLoading(false)}
             onPresence={setPresent} 
             privacyMode={privacy === 'PRIVATE'}/>
         }

--- a/src/components/LoadingOverlay/LoadingOverlay.css
+++ b/src/components/LoadingOverlay/LoadingOverlay.css
@@ -1,0 +1,12 @@
+.loading-overlay {
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 99999;
+}

--- a/src/components/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay/LoadingOverlay.tsx
@@ -1,0 +1,16 @@
+import { Spinner } from '@components/Spinner';
+
+import './LoadingOverlay.css';
+
+/**
+ * A full-screen loading indicator that makes the content underneath inert.
+ */
+export const LoadingOverlay = () => {
+
+  return (
+    <div className="loading-overlay">
+      <Spinner />
+    </div>
+  )
+
+}

--- a/src/components/LoadingOverlay/index.ts
+++ b/src/components/LoadingOverlay/index.ts
@@ -1,0 +1,1 @@
+export * from './LoadingOverlay';

--- a/src/components/SupabasePlugin/SupabasePlugin.ts
+++ b/src/components/SupabasePlugin/SupabasePlugin.ts
@@ -58,9 +58,6 @@ export const SupabasePlugin = (props: SupabasePluginProps) => {
     }
   }, [
     anno, 
-    props.onInitialLoad,
-    props.onInitialLoadError,
-    props.onIntegrityError,
     props.onPresence,
     props.onSaveError,
     props.onSelectionChange


### PR DESCRIPTION
## In this PR

This PR adds a simple, full-screen, semi-transparent loading overlay to the annotation views. The overlay displays a wait spinner, and makes the annotation UI underneath inert. It is removed as soon as the relevant resources for the annotation interface have loaded.

- For plaintext and TEI, loading is complete when the text/TEI content and annotations are fetched from the backend.
- For PDF, loading is complete when the PDF has been rendered and the annotations are fetched.
- For images, loading is complete as soon as the annotations are fetched.
