### PR TITLE
Fix: color-coding dropdown no longer loses state when changing sideba…

### DIFF
--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorCoding.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorCoding.ts
@@ -3,6 +3,8 @@ import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 
 export interface ColorCoding {
 
+  name: string;
+
   getStyle(): ((a: SupabaseAnnotation, selected?: boolean) => DrawingStyle);
 
   getLegend(): ColorLegendValue[];

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorSettings.tsx
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorSettings.tsx
@@ -25,9 +25,9 @@ export const ColorSettings = (props: ColorSettingsProps) => {
 
   const { t } = props.i18n;
 
-  const [value, setValue] = useState('none');
+  const { name, legend, style, setCoding } = useColorCoding();
 
-  const { legend, style, setCoding } = useColorCoding();
+  const [value, setValue] = useState(name || 'none');
 
   const showAssignmentOption = props.layers && props.layers.length > 1;
 

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorState.tsx
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/ColorState.tsx
@@ -5,6 +5,8 @@ import type { ColorCoding, ColorLegendValue } from './ColorCoding';
 
 interface ColorStateContextValue {
 
+  name?: string;
+
   style?: ((a: SupabaseAnnotation) => DrawingStyle);
 
   legend: ColorLegendValue[];
@@ -55,7 +57,7 @@ export const ColorState = (props: ColorStateProps) => {
   }, [annotations, props.present]);
 
   return (
-    <ColorStateContext.Provider value={{ style, legend, setCoding }}>
+    <ColorStateContext.Provider value={{ name: coding?.name, style, legend, setCoding }}>
       {props.children}
     </ColorStateContext.Provider>
   )

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByAssignment.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByAssignment.ts
@@ -27,6 +27,6 @@ export const colorByAssignment = (layers: Layer[]) => (): ColorCoding => {
 
   const update = (annotations: SupabaseAnnotation[]) => getLegend();
 
-  return { getLegend, getStyle, update };
+  return { name: 'assignment', getLegend, getStyle, update };
 
 }

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByCreator.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByCreator.ts
@@ -40,6 +40,6 @@ export const colorByCreator = (annotations: SupabaseAnnotation[], present?: Pres
     return getLegend();
   }
 
-  return { getLegend, getStyle, update };
+  return { name:'creator', getLegend, getStyle, update };
 
 }

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByFirstTag.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByFirstTag.ts
@@ -35,6 +35,6 @@ export const colorByFirstTag = (annotations: SupabaseAnnotation[]): ColorCoding 
     return getLegend();
   }
 
-  return { getLegend, getStyle, update };
+  return { name: 'tag', getLegend, getStyle, update };
 
 }

--- a/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByPrivacy.ts
+++ b/src/components/AnnotationDesktop/LayersPanel/ColorSettings/colorCodings/colorByPrivacy.ts
@@ -22,6 +22,6 @@ export const colorByPrivacy = (): ColorCoding => {
 
   const update = (annotations: SupabaseAnnotation[]) => getLegend();
 
-  return { getLegend, getStyle, update };
+  return { name: 'privacy', getLegend, getStyle, update };
 
 }


### PR DESCRIPTION
## In this PR

This PR addresses [the issue reported here](https://github.com/recogito/recogito-client/pull/115#issuecomment-1883658700), which is that the color-coding dropdown lost state when switching back and forth between different sidebar tabs. 