### PR TITLE
TEI Behaviors

### DIFF
--- a/src/apps/annotation-text/AnnotatedText/teiBehaviors.ts
+++ b/src/apps/annotation-text/AnnotatedText/teiBehaviors.ts
@@ -31,7 +31,7 @@ export const behaviors = {
         copyAttr('rendition', figure, img);
 
         const desc = figure.querySelector('[data-origname="desc"]');
-        if (desc)
+        if (desc?.innerHTML)
           img.setAttribute('alt', desc.innerHTML);
 
         graphic.appendChild(img);

--- a/src/apps/annotation-text/AnnotatedText/teiBehaviors.ts
+++ b/src/apps/annotation-text/AnnotatedText/teiBehaviors.ts
@@ -9,20 +9,49 @@ const copyAttr = (attr: string, from: Element, to: Element, defaultVal?: any) =>
 }
 
 export const behaviors = {
+  
+  tei: {
 
-  graphic: (elem: Element) => {
-    const content = new Image();
-    content.src = elem.getAttribute('url')?.trim()!;
+    desc: (elem: Element) => {
+      // @ts-ignore
+      elem.hidden = true;
+    },
 
-    copyAttr('width', elem, content);
-    copyAttr('height', elem, content);
-    copyAttr('rend', elem, content);
-    copyAttr('rendition', elem, content);
+    figure: (figure: Element) => {
+      const graphic = Array.from(figure.children).find(child => child.getAttribute('data-origname') === 'graphic');
 
-    const desc = elem.getAttribute('desc') || '';
-    content.setAttribute('alt', desc);
+      if (graphic) {
+        const img = new Image();
+        img.src = graphic.getAttribute('url')?.trim()!;
 
-    elem.appendChild(content);
+        copyAttr('width', graphic, img);
+        copyAttr('height', graphic, img);
+
+        copyAttr('rend', figure, img);
+        copyAttr('rendition', figure, img);
+
+        const desc = figure.querySelector('[data-origname="desc"]');
+        if (desc)
+          img.setAttribute('alt', desc.innerHTML);
+
+        graphic.appendChild(img);
+      }
+    },
+
+    graphic: (elem: Element) => {
+      // Handle 'graphic' element only in case it wasn't aready 
+      // handled as a child of a figure already.
+      if (elem.parentElement?.getAttribute('data-origname') !== 'figure') {
+        const img = new Image();
+        img.src = elem.getAttribute('url')?.trim()!;
+
+        copyAttr('width', elem, img);
+        copyAttr('height', elem, img);
+
+        elem.appendChild(img);
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
## In this PR

This PR adds the following custom CETEIcean behaviors:

- `rend` and `rendition` attributes on `<figure>` elements are copied to the generated HTML `<img>`.
- `width` and `height` attributes on `<graphic>` elements are copied to the generated HTML `<img>`.
- `<desc>` elements are hidden.
- The `innerHTML` of the `<desc>` is copied into the `alt` attribute of the generated HTML `<img>`.