### PR TITLE
Fixes to CSV and TEI Export

### DIFF
--- a/src/util/export/csv/annotationsToCSV.ts
+++ b/src/util/export/csv/annotationsToCSV.ts
@@ -14,7 +14,7 @@ const serializeTarget = (t: SupabaseAnnotationTarget) => {
   // Shorthand
   const round = (num: number) => Math.round(num * 100) / 100;
 
-  const { selector } = t;
+  const selector = t.selector && Array.isArray(t.selector) ? t.selector[0] : t.selector;
 
   // Notes don't have selectors!
   if (!selector)
@@ -61,6 +61,15 @@ const sortRows = (a: any, b: any): number => {
  return createdDate1 - createdDate2;
 }
 
+const getQuote = (t: SupabaseAnnotationTarget) => {
+  if (t.selector) {
+    const selector = Array.isArray(t.selector) ? t.selector[0] : t.selector;
+    return selector.quote;
+  } else {
+    return '';
+  }
+}
+
 /** Crosswalks a list of annotations to CSV using Papaparse **/
 export const annotationsToCSV = (
   annotations: SupabaseAnnotation[], 
@@ -81,7 +90,7 @@ export const annotationsToCSV = (
       const row: any = {
         annotation_id: a.id,
         document: doc.name,
-        text_quote: a.target.selector ? 'quote' in a.target.selector ? a.target.selector.quote : '' : '', 
+        text_quote: getQuote(a.target), 
         target: serializeTarget(a.target),
         body_purpose: body.purpose,
         body_value: serializeBodyValue(body),

--- a/src/util/export/serializeQuillComment.ts
+++ b/src/util/export/serializeQuillComment.ts
@@ -8,8 +8,12 @@ export const serializeQuill = (value: string) => {
   input.ops?.forEach((op: DeltaOperation) => {
     if (typeof op.insert === "string") {
       serialized += op.insert;
+    } else if ('image' in op.insert) {
+      serialized += op.insert.image;
+    } else if ('video' in op.insert) {
+      serialized += op.insert.video;
     }
   })
 
-  return serialized;
+  return serialized.trim();
 }

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -86,8 +86,10 @@ export const mergeAnnotations = (xml: string, annotations: SupabaseAnnotation[])
     annotationEl.setAttribute('xml:id', `uid-${a.id}`);
 
     // See https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-annotation.html#tei_att.target
+    const selector = a.target.selector && Array.isArray(a.target.selector) ? a.target.selector[0] : a.target.selector;
+    
     // @ts-ignore
-    const { startSelector, endSelector } = a.target.selector;
+    const { startSelector, endSelector } = selector;
     annotationEl.setAttribute('target', `${startSelector.value} ${endSelector.value}`);
 
     // Add creation and last update timestamp


### PR DESCRIPTION
## In this PR

This PR:
- fixes regressions in the TEI and CSV, following yesterday's breaking changes to the core data model of `@recogito/text-annotator`
- tweaks the Quill serializer, so that image and video URLs are included in the serialization