### PR TITLE
Redirect to join project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,8 @@
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
         "eslint": "^8.52.0",
-        "eslint-plugin-react": "^7.33.2"
+        "eslint-plugin-react": "^7.33.2",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.52.0",
-    "eslint-plugin-react": "^7.33.2"
+    "eslint-plugin-react": "^7.33.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -32,6 +32,10 @@ export interface Project {
   name: string;
 
   description?: string;
+
+  is_open_join: boolean;
+
+  is_open_edit: boolean;
 }
 
 /**

--- a/src/apps/join-project/JoinProject.css
+++ b/src/apps/join-project/JoinProject.css
@@ -1,0 +1,22 @@
+.join-project-root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.join-project-title {
+  font-size: x-large;
+}
+
+.join-project-description {
+  padding-top: 15px;
+  padding-bottom: 15px;
+}
+
+.join-project-dialog-button-join {
+  background-color: var(--brighter-blue);
+  color: var(--gray-200);
+}

--- a/src/apps/join-project/JoinProject.tsx
+++ b/src/apps/join-project/JoinProject.tsx
@@ -1,0 +1,59 @@
+import { joinProject } from '@backend/helpers';
+import type { ExtendedProjectData, Translations } from 'src/Types';
+import { supabase } from '@backend/supabaseBrowserClient';
+import './JoinProject.css';
+
+interface JoinProjectProps {
+  i18n: Translations;
+
+  project: ExtendedProjectData;
+}
+
+export const JoinProject = (props: JoinProjectProps) => {
+  const { t } = props.i18n;
+
+  const handleJoin = () => {
+    joinProject(supabase, props.project.id).then((resp) => {
+
+      if (resp) {
+        const url = new URLSearchParams(window.location.search);
+        const redirectUrl = url.get('redirect-to');
+        if (redirectUrl) {
+          window.location.href = redirectUrl;
+        } else {
+          window.location.href = `/${props.i18n.lang}/projects`;
+        }
+      } else {
+        window.location.href = `/${props.i18n.lang}/projects`;
+      }
+    });
+  }
+
+  return (
+    <div className='join-project-root'>
+
+      <div className='join-project-title'>
+        {`${t['Join']} ${['Project']} ${props.project.name}?`}
+      </div>
+
+      <div className='join-project-description'>
+        {t['You are not a member message']}
+      </div>
+
+      <div className='join-project-button-container'>
+        <button
+          className='join-project-dialog-button-cancel'
+          onClick={() => (window.location.href = `/${props.i18n.lang}/projects`)}
+        >
+          {t['Cancel']}
+        </button>
+        <button
+          className='join-project-dialog-button-join'
+          onClick={handleJoin}
+        >
+          {t['Join']}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/apps/join-project/index.ts
+++ b/src/apps/join-project/index.ts
@@ -1,0 +1,1 @@
+export * from './JoinProject';

--- a/src/backend/helpers/contextHelpers.ts
+++ b/src/backend/helpers/contextHelpers.ts
@@ -1,0 +1,16 @@
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export const isOpenJoinEditFromContext = (supabase: SupabaseClient, contextId: string) =>
+  supabase
+    .rpc('is_open_edit_join_from_context_rpc', { _context_id: contextId })
+    .then(({ data, error }) => {
+      if (error) {
+        console.error('Error joining project', error);
+        return null;
+      } else {
+        return data as string;
+      }
+    });
+
+

--- a/src/backend/helpers/index.ts
+++ b/src/backend/helpers/index.ts
@@ -6,3 +6,4 @@ export * from './policyHelpers';
 export * from './projectHelpers';
 export * from './tagHelpers';
 export * from './userPermissionsHelpers'
+export * from './contextHelpers'

--- a/src/components/Annotation/Card/BaseCard.tsx
+++ b/src/components/Annotation/Card/BaseCard.tsx
@@ -20,7 +20,12 @@ export const BaseCard = (props: BaseCardProps) => {
 
   const comments = annotation.bodies.filter(
     (b: AnnotationBody) => !b.purpose || b.purpose === 'commenting'
-  );
+  ).slice().sort((a, b) => {
+    if (!a.created || !b.created)
+      return 0; // Should never be the case
+
+    return a.created.getTime() - b.created.getTime();
+  });
 
   // Keep a list of comments that should not be color-highlighted
   // on render, either because they were already in the annotation, or they

--- a/src/i18n/en/dashboard-projects.json
+++ b/src/i18n/en/dashboard-projects.json
@@ -54,5 +54,6 @@
   "open-edit-info": "With 'Open Edit' switched on, any member of your project can edit the default assignment",
   "Join": "Join",
   "Join Project": "Join Project",
-  "Join Project Message": "This project allows all users to become members. Would you like to join?"
+  "Join Project Message": "This project allows all users to become members. Would you like to join?",
+  "You are not a member message": "You are not yet a member of this project, would you like to join?"
 }

--- a/src/pages/[lang]/annotate/[context]/[document]/index.astro
+++ b/src/pages/[lang]/annotate/[context]/[document]/index.astro
@@ -31,7 +31,6 @@ if (document.error || !document.data) {
   // Lets check if this is an open join project
   const resp = await isOpenJoinEditFromContext(supabase, contextId);
   if (resp) {
-    console.log('is open!');
     return Astro.redirect(
       `/${lang}/projects/${resp}/join?redirect-to=${Astro.url.pathname}`
     );

--- a/src/pages/[lang]/annotate/[context]/[document]/index.astro
+++ b/src/pages/[lang]/annotate/[context]/[document]/index.astro
@@ -7,6 +7,7 @@ import { ImageAnnotation } from '@apps/annotation-image';
 import { TextAnnotation } from '@apps/annotation-text';
 import { getDocumentInContext } from '@backend/helpers';
 import { getCollection } from '@backend/crud/collections';
+import { isOpenJoinEditFromContext } from '@backend/helpers';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -27,6 +28,16 @@ if (!contextId || !documentId) {
 // Will return empty if this user has no access priviliges
 const document = await getDocumentInContext(supabase, documentId, contextId);
 if (document.error || !document.data) {
+  // Lets check if this is an open join project
+  const resp = await isOpenJoinEditFromContext(supabase, contextId);
+  if (resp) {
+    console.log('is open!');
+    return Astro.redirect(
+      `/${lang}/projects/${resp}/join?redirect-to=${Astro.url.pathname}`
+    );
+  }
+
+  console.log('Error!');
   // https://javascript.plainenglish.io/return-custom-404-responses-in-astro-b844b0e0146d
   const error = await fetch(`${Astro.url}/404`);
   return new Response(error.body, {
@@ -70,31 +81,37 @@ if (document.data.content_type === 'text/plain') {
   return new Response(error.body, { headers: error.headers, status: 500 });
 }
 ---
-<BaseLayout title={document.data.name}>
-  {viewer === 'TEI' && !styleSheet && (
-    <link rel="stylesheet" href="/tei.css" slot="head">
-  )}
 
-  {viewer === 'OPENSEADRAGON' ? (
-    <ImageAnnotation
-      client:only
-      i18n={getTranslations(Astro.request, 'annotation-image')}
-      document={document.data}
-      channelId={channelId}
-    />
-  ) : (
-    <TextAnnotation
-      client:only
-      i18n={getTranslations(Astro.request, 'annotation-text')}
-      document={document.data}
-      channelId={channelId}
-      styleSheet={styleSheet}
-    />
-  )}
+<BaseLayout title={document.data.name}>
+  {
+    viewer === 'TEI' && !styleSheet && (
+      <link rel='stylesheet' href='/tei.css' slot='head' />
+    )
+  }
+
+  {
+    viewer === 'OPENSEADRAGON' ? (
+      <ImageAnnotation
+        client:only
+        i18n={getTranslations(Astro.request, 'annotation-image')}
+        document={document.data}
+        channelId={channelId}
+      />
+    ) : (
+      <TextAnnotation
+        client:only
+        i18n={getTranslations(Astro.request, 'annotation-text')}
+        document={document.data}
+        channelId={channelId}
+        styleSheet={styleSheet}
+      />
+    )
+  }
 </BaseLayout>
 
 <style>
-  html, body {
+  html,
+  body {
     height: 100%;
   }
 </style>

--- a/src/pages/[lang]/projects/[project]/join.astro
+++ b/src/pages/[lang]/projects/[project]/join.astro
@@ -1,0 +1,43 @@
+---
+import HeaderLayout from '@layouts/HeaderLayout.astro';
+import { createSupabaseServerClient } from '@backend/supabaseServerClient';
+import { getMyProfile } from '@backend/crud';
+import { getLangFromUrl, getTranslations } from '@i18n';
+import { getProjectExtended } from '@backend/helpers';
+import { JoinProject } from '@apps/join-project';
+
+const lang = getLangFromUrl(Astro.url);
+
+const i18n = getTranslations(Astro.request, 'dashboard-projects');
+
+const supabase = await createSupabaseServerClient(Astro.request, Astro.cookies);
+if (!supabase) return Astro.redirect(`/${lang}/sign-in`);
+
+const projectId = Astro.params.project;
+
+const profile = await getMyProfile(supabase);
+if (profile.error || !profile.data) {
+  const error = await fetch(`${Astro.url}/500`);
+  return new Response(error.body, { headers: error.headers, status: 500 });
+}
+
+const project = await getProjectExtended(supabase, projectId as string);
+if (project.error || !project.data) {
+  const error = await fetch(`${Astro.url}/404`);
+  return new Response(error.body, {
+    headers: { 'Content-Type': 'text/html;charset=utf-8' },
+    status: 404,
+    statusText: 'Not Found',
+  });
+}
+---
+
+<HeaderLayout title='join'>
+  <JoinProject client:load i18n={i18n} project={project.data} />
+</HeaderLayout>
+
+<style>
+  h1 {
+    padding-left: 40px !important;
+  }
+</style>


### PR DESCRIPTION
## In this PR

The client allows users to send direct links to users to access a specific annotation context.  Currently when a user is not a member of the project, they receive a 404 Not Found. This update checks wether the project is Open Join/Open Edit.  If so the user is presented a UI which allow them to join the project:

![image](https://github.com/recogito/recogito-client/assets/17829439/5de3f60c-0d43-42a0-ac8d-d16039efdccb)

If they choose Join, they will be joined to the project and redirected to the annotation they were trying to access.

If the project is not Open Join/Open Edit the behavior is the same as before.