### PR TITLE
Save Error Indicator

### DIFF
--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -49,7 +49,7 @@ interface AnnotatedImageProps {
 
   onChangePresent(present: PresentUser[]): void;
 
-  onConnectionErrorChanged(error: boolean): void;
+  onConnectionError(): void;
 
   onSaveError(): void;
 
@@ -124,9 +124,8 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
           appearanceProvider={appearance}
           onInitialLoad={props.onLoad}
           onPresence={props.onChangePresent} 
-          onConnected={() => props.onConnectionErrorChanged(false)}
-          onConnectError={() => props.onConnectionErrorChanged(true)}
-          onInitialLoadError={() => props.onConnectionErrorChanged(true)}
+          onConnectError={props.onConnectionError}
+          onInitialLoadError={props.onConnectionError}
           onSaveError={props.onSaveError}
           privacyMode={privacy === 'PRIVATE'} />
       }

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -49,7 +49,9 @@ interface AnnotatedImageProps {
 
   onChangePresent(present: PresentUser[]): void;
 
-  onConnectError(): void;
+  onConnectionError(): void;
+
+  onSaveError(): void;
 
   onLoad(): void;
 
@@ -122,7 +124,9 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
           appearanceProvider={appearance}
           onInitialLoad={props.onLoad}
           onPresence={props.onChangePresent} 
-          onConnectError={props.onConnectError}
+          onConnectError={props.onConnectionError}
+          onInitialLoadError={props.onConnectionError}
+          onSaveError={props.onSaveError}
           privacyMode={privacy === 'PRIVATE'} />
       }
 

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -49,7 +49,7 @@ interface AnnotatedImageProps {
 
   onChangePresent(present: PresentUser[]): void;
 
-  onConnectionError(): void;
+  onConnectionErrorChanged(error: boolean): void;
 
   onSaveError(): void;
 
@@ -124,8 +124,9 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
           appearanceProvider={appearance}
           onInitialLoad={props.onLoad}
           onPresence={props.onChangePresent} 
-          onConnectError={props.onConnectionError}
-          onInitialLoadError={props.onConnectionError}
+          onConnected={() => props.onConnectionErrorChanged(false)}
+          onConnectError={() => props.onConnectionErrorChanged(true)}
+          onInitialLoadError={() => props.onConnectionErrorChanged(true)}
           onSaveError={props.onSaveError}
           privacyMode={privacy === 'PRIVATE'} />
       }

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -35,8 +35,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
   const [connectionError, setConnectionError] = useState(false);
 
-  const [saveError, setSaveError] = useState(false);
-
   const [present, setPresent] = useState<PresentUser[]>([]);
 
   const [rightPanel, setRightPanel] = useState<DrawerPanel | undefined>();
@@ -126,15 +124,14 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               )}
               
               <Menubar 
-                showConnectionError={connectionError}
-                showSaveError={saveError}
                 i18n={props.i18n} 
                 document={props.document} 
                 present={present} 
                 rightPanel={rightPanel}
                 onZoom={onZoom}
                 onToggleBranding={() => setShowBranding(!showBranding)}
-                onSetRightDrawer={onSetRightPanel} />
+                onSetRightDrawer={onSetRightPanel} 
+                showConnectionError={connectionError} />
             </div>
 
             <main>
@@ -156,8 +153,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                     tagVocabulary={tagVocabulary}
                     usePopup={usePopup}
                     onChangePresent={setPresent}
-                    onConnectionErrorChanged={setConnectionError}
-                    onSaveError={() => setSaveError(true)}
+                    onConnectionError={() => setConnectionError(true)}
+                    onSaveError={() => setConnectionError(true)}
                     onLoad={() => setLoading(false)} />
                 )}
               </div>

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -156,7 +156,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                     tagVocabulary={tagVocabulary}
                     usePopup={usePopup}
                     onChangePresent={setPresent}
-                    onConnectionError={() => setConnectionError(true)}
+                    onConnectionErrorChanged={setConnectionError}
                     onSaveError={() => setSaveError(true)}
                     onLoad={() => setLoading(false)} />
                 )}

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -33,6 +33,10 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
   const [showBranding, setShowBranding] = useState(true);
 
+  const [connectionError, setConnectionError] = useState(false);
+
+  const [saveError, setSaveError] = useState(false);
+
   const [present, setPresent] = useState<PresentUser[]>([]);
 
   const [rightPanel, setRightPanel] = useState<DrawerPanel | undefined>();
@@ -102,11 +106,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     }
   }
 
-  const onError = (error: Error) => {
-    // TODO UI feedback
-    console.error(error);
-  }
-
   return (
     <FilterState present={present}>
       <ColorState present={present}>
@@ -114,7 +113,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
           channelId={props.channelId}
           layerId={defaultLayer?.id}
           present={present}
-          onError={onError}>  
+          onError={() => setConnectionError(true)}>  
 
           <div className="anno-desktop ia-desktop">
             {loading && (
@@ -127,6 +126,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               )}
               
               <Menubar 
+                showConnectionError={connectionError}
+                showSaveError={saveError}
                 i18n={props.i18n} 
                 document={props.document} 
                 present={present} 
@@ -155,7 +156,8 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                     tagVocabulary={tagVocabulary}
                     usePopup={usePopup}
                     onChangePresent={setPresent}
-                    onConnectError={onConnectError}
+                    onConnectionError={() => setConnectionError(true)}
+                    onSaveError={() => setSaveError(true)}
                     onLoad={() => setLoading(false)} />
                 )}
               </div>

--- a/src/apps/annotation-image/Menubar/Menubar.tsx
+++ b/src/apps/annotation-image/Menubar/Menubar.tsx
@@ -3,7 +3,7 @@ import type { PresentUser } from '@annotorious/react';
 import { Avatar } from '@components/Avatar';
 import { PresenceStack } from '@components/Presence';
 import type { DocumentInTaggedContext, Translations } from 'src/Types';
-import { DocumentNotesMenuIcon, LayersPanelMenuIcon, DrawerPanel } from '@components/AnnotationDesktop';
+import { DocumentNotesMenuIcon, LayersPanelMenuIcon, DrawerPanel, ErrorBadge } from '@components/AnnotationDesktop';
 import { 
   ArrowsOutSimple,
   CaretLeft, 
@@ -13,7 +13,6 @@ import {
   MagnifyingGlassMinus, 
   MagnifyingGlassPlus, 
 } from '@phosphor-icons/react';
-import { ErrorBadge } from '@components/AnnotationDesktop/ErrorBadge';
 
 interface MenubarProps {
 
@@ -32,8 +31,6 @@ interface MenubarProps {
   onSetRightDrawer(panel?: DrawerPanel): void;
 
   showConnectionError: boolean;
-
-  showSaveError: boolean;
 
 }
 
@@ -99,7 +96,7 @@ export const Menubar = (props: MenubarProps) => {
           </button>
         </div>
 
-        {(props.showConnectionError || props.showSaveError) && (
+        {(props.showConnectionError) && (
           <ErrorBadge i18n={props.i18n} />
         )}
       </div>

--- a/src/apps/annotation-image/Menubar/Menubar.tsx
+++ b/src/apps/annotation-image/Menubar/Menubar.tsx
@@ -30,6 +30,10 @@ interface MenubarProps {
 
   onSetRightDrawer(panel?: DrawerPanel): void;
 
+  showConnectionError: boolean;
+
+  showSaveError: boolean;
+
 }
 
 export const Menubar = (props: MenubarProps) => {

--- a/src/apps/annotation-image/Menubar/Menubar.tsx
+++ b/src/apps/annotation-image/Menubar/Menubar.tsx
@@ -13,6 +13,7 @@ import {
   MagnifyingGlassMinus, 
   MagnifyingGlassPlus, 
 } from '@phosphor-icons/react';
+import { ErrorBadge } from '@components/AnnotationDesktop/ErrorBadge';
 
 interface MenubarProps {
 
@@ -97,6 +98,10 @@ export const Menubar = (props: MenubarProps) => {
             <ListBullets size={17} />
           </button>
         </div>
+
+        {(props.showConnectionError || props.showSaveError) && (
+          <ErrorBadge i18n={props.i18n} />
+        )}
       </div>
 
       <div className="anno-menubar-right ia-menubar-right">

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
@@ -45,6 +45,10 @@ interface AnnotatedTextProps {
 
   onChangePresent(present: PresentUser[]): void;
 
+  onConnectionError(): void;
+
+  onSaveError(): void;
+
   onLoad(): void;
 
 }
@@ -129,6 +133,9 @@ export const AnnotatedText = (props: AnnotatedTextProps) => {
               appearanceProvider={createAppearenceProvider()}
               onInitialLoad={() => setAnnotationsLoading(false)}
               onPresence={props.onChangePresent}
+              onConnectError={props.onConnectionError}
+              onInitialLoadError={props.onConnectionError}
+              onSaveError={props.onSaveError}
               privacyMode={privacy === 'PRIVATE'}
             />
           )}

--- a/src/apps/annotation-text/Menubar/Menubar.tsx
+++ b/src/apps/annotation-text/Menubar/Menubar.tsx
@@ -1,7 +1,7 @@
 import { ArrowsOutSimple, CaretLeft, Chats, GraduationCap, ListBullets } from '@phosphor-icons/react';
 import type { PresentUser } from '@annotorious/react';
 import { isMe } from '@recogito/annotorious-supabase';
-import { DocumentNotesMenuIcon, LayersPanelMenuIcon, DrawerPanel } from '@components/AnnotationDesktop';
+import { DocumentNotesMenuIcon, LayersPanelMenuIcon, DrawerPanel, ErrorBadge } from '@components/AnnotationDesktop';
 import { Avatar } from '@components/Avatar';
 import { PresenceStack } from '@components/Presence';
 import type { DocumentInTaggedContext, Translations } from 'src/Types';
@@ -22,6 +22,8 @@ interface MenubarProps {
   onToggleBranding(): void;
 
   onSetRightDrawer(panel?: DrawerPanel): void;
+
+  showConnectionError: boolean;
 
 }
 
@@ -93,6 +95,10 @@ export const Menubar = (props: MenubarProps) => {
 
             <PDFControls i18n={props.i18n} />
           </>
+        )}
+
+        {(props.showConnectionError) && (
+          <ErrorBadge i18n={props.i18n} />
         )}
       </div>
 

--- a/src/apps/annotation-text/Menubar/Menubar.tsx
+++ b/src/apps/annotation-text/Menubar/Menubar.tsx
@@ -97,7 +97,7 @@ export const Menubar = (props: MenubarProps) => {
           </>
         )}
 
-        {(props.showConnectionError) && (
+        {props.showConnectionError && (
           <ErrorBadge i18n={props.i18n} />
         )}
       </div>

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -116,11 +116,6 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
       : (a: TextAnnotation, b: TextAnnotation) =>
         a.target.selector[0].start - b.target.selector[0].start;
 
-  const onError = (error: Error) => {
-    // TODO UI feedback
-    console.error(error);
-  }
-
   return (
     <FilterState present={present}>
       <ColorState present={present}>
@@ -128,7 +123,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
           channelId={props.channelId}
           layerId={defaultLayer?.id}
           present={present}
-          onError={onError}>
+          onError={() => setConnectionError(true)}>
 
           <div className="anno-desktop ta-desktop">
             {loading && (

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -28,6 +28,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
   const [showBranding, setShowBranding] = useState(true);
 
+  const [connectionError, setConnectionError] = useState(false);
+
   const [present, setPresent] = useState<PresentUser[]>([]);
 
   const [rightPanel, setRightPanel] = useState<DrawerPanel | undefined>();
@@ -144,7 +146,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
                 present={present}
                 rightPanel={rightPanel}
                 onToggleBranding={() => setShowBranding(!showBranding)}
-                onSetRightDrawer={onSetRightPanel} />
+                onSetRightDrawer={onSetRightPanel} 
+                showConnectionError={connectionError} />
             </div>
 
             <main>
@@ -164,6 +167,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
                   tagVocabulary={tagVocabulary}
                   usePopup={usePopup}
                   onChangePresent={setPresent}
+                  onConnectionError={() => setConnectionError(true)}
+                  onSaveError={() => setConnectionError(true)}
                   onLoad={() => setLoading(false)}
                   styleSheet={props.styleSheet}
                 />

--- a/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.css
+++ b/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.css
@@ -1,0 +1,20 @@
+.anno-error-badge {
+  align-items: center;
+  background-color: rgba(255, 0, 0, 0.35);
+  border: 1px solid var(--red-500);
+  border-radius: var(--border-radius);
+  color: rgb(128, 0, 0);
+  display: flex;
+  gap: 0.5em;
+  margin-left: 10px;
+  font-size: var(--font-tiny);
+  padding: 1px 12px;
+}
+
+.anno-error-badge button.anno-error-refresh.link {
+  all: unset;
+  cursor: pointer;
+  font-weight: 500;
+  text-decoration: underline;
+  white-space: nowrap;
+}

--- a/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.css
+++ b/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.css
@@ -9,6 +9,8 @@
   margin-left: 10px;
   font-size: var(--font-tiny);
   padding: 1px 12px;
+  position: relative;
+  z-index: 999;
 }
 
 .anno-error-badge button.anno-error-refresh.link {
@@ -17,4 +19,14 @@
   font-weight: 500;
   text-decoration: underline;
   white-space: nowrap;
+}
+
+.anno-error-clicktrap {
+  background-color: rgba(255, 255, 255, 0.65);
+  position: fixed;
+  top: 0;
+  left: 0; 
+  width: 100vw;
+  height: 100vh;
+  z-index: 998;
 }

--- a/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.tsx
+++ b/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.tsx
@@ -15,17 +15,21 @@ export const ErrorBadge = (props: ErrorBadgeProps) => {
   const onRefresh = () => location.reload();
 
   return (
-    <div className="anno-error-badge">
-      <div className="anno-error-badge-message">
-        {t['Connection Lost.']}
+    <>
+      <div className="anno-error-badge">
+        <div className="anno-error-badge-message">
+          {t['Connection Lost.']}
+        </div>
+
+        <button 
+          className="anno-error-refresh link"
+          onClick={onRefresh}>
+          {t['Try refreshing the page.']}
+        </button>
       </div>
 
-      <button 
-        className="anno-error-refresh link"
-        onClick={onRefresh}>
-        {t['Try refreshing the page.']}
-      </button>
-    </div>
+      <div className="anno-error-clicktrap" />
+    </>
   )
 
 }

--- a/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.tsx
+++ b/src/components/AnnotationDesktop/ErrorBadge/ErrorBadge.tsx
@@ -1,0 +1,31 @@
+import type { Translations } from 'src/Types';
+
+import './ErrorBadge.css';
+
+interface ErrorBadgeProps {
+
+  i18n: Translations;
+
+}
+
+export const ErrorBadge = (props: ErrorBadgeProps) => {
+
+  const { t } = props.i18n;
+
+  const onRefresh = () => location.reload();
+
+  return (
+    <div className="anno-error-badge">
+      <div className="anno-error-badge-message">
+        {t['Connection Lost.']}
+      </div>
+
+      <button 
+        className="anno-error-refresh link"
+        onClick={onRefresh}>
+        {t['Try refreshing the page.']}
+      </button>
+    </div>
+  )
+
+}

--- a/src/components/AnnotationDesktop/ErrorBadge/index.ts
+++ b/src/components/AnnotationDesktop/ErrorBadge/index.ts
@@ -1,0 +1,1 @@
+export * from './ErrorBadge';

--- a/src/components/AnnotationDesktop/index.ts
+++ b/src/components/AnnotationDesktop/index.ts
@@ -1,5 +1,6 @@
 export * from './AnnotationList';
 export * from './DocumentNotes';
+export * from './ErrorBadge';
 export * from './LayerConfiguration';
 export * from './UndoStack';
 export * from './DrawerPanel';

--- a/src/components/SupabasePlugin/SupabasePlugin.ts
+++ b/src/components/SupabasePlugin/SupabasePlugin.ts
@@ -37,7 +37,7 @@ export const SupabasePlugin = (props: SupabasePluginProps) => {
   useEffect(() => {
     if (anno) {
       const supabase = Supabase(anno, props);
-      
+
       supabase
         .connect()
         .then(user => props.onConnected && props.onConnected(user))
@@ -59,7 +59,6 @@ export const SupabasePlugin = (props: SupabasePluginProps) => {
   }, [
     anno, 
     props.onPresence,
-    props.onSaveError,
     props.onSelectionChange
   ]);
 

--- a/src/i18n/de/annotation-common.json
+++ b/src/i18n/de/annotation-common.json
@@ -57,5 +57,8 @@
   "Back to assignment overview": "Zurück zur Arbeitsauftragsübersicht",
   "Back to project overview": "Zurück zur Projekt-Übersicht",
   "Zoom in": "Zoom +",
-  "Zoom out": "Zoom -"
+  "Zoom out": "Zoom -",
+  "Add an annotation...": "Neuer Kommentar...",
+  "Connection Lost.": "Verbindung unterbrochen.",
+  "Try refreshing the page.": "Seite neu laden."
 }

--- a/src/i18n/en/annotation-common.json
+++ b/src/i18n/en/annotation-common.json
@@ -58,5 +58,7 @@
   "Back to project overview": "Back to project overview",
   "Zoom in": "Zoom in",
   "Zoom out": "Zoom out",
-  "Add an annotation...": "Add an annotation..."
+  "Add an annotation...": "Add an annotation...",
+  "Connection Lost.": "Connection Lost.",
+  "Try refreshing the page.": "Try refreshing the page."
 }


### PR DESCRIPTION
## In this PR

This PR adds an error alert to the annotation UI, which pops up on Supabase connection or annotation save errors. Because connection errors are fatal, the alert also blocks the annotation UI and prompts the user to reload the page.

<img width="1115" alt="Bildschirmfoto 2024-02-29 um 16 46 37" src="https://github.com/recogito/recogito-client/assets/470971/14836bd9-1675-4b1e-b820-9548bd6ae7ed">

P.S.: this also addresses issue: https://github.com/performant-software/cove-recogito/issues/61#issuecomment-1971167443. (If the user is logged out, this would cause a connection error. Refreshing the page would redirect to the login page.)