### PR TITLE
Fix for org admin visibility of projects

### DIFF
--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -92,22 +92,29 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
   // Filtered projects
   const myProjects = projects.filter((p) => p.created_by?.id === me.id);
 
-  const sharedProjects = isReader
-    ? projects.filter(({ created_by, users }) =>
-        users.find((user) => user.user.id === me.id && me.id !== created_by?.id)
-      )
-    : projects.filter(
-        (p) =>
-          p.created_by?.id !== me.id &&
-          p.users.filter((u) => u.user.id === me.id).length > 0
-      );
-
   const openJoinProjects = projects.filter(
     (p) =>
       me.id !== p.created_by?.id &&
       p.is_open_join &&
       p.users.filter((u) => u.user.id === me.id).length === 0
   );
+
+  const sharedProjects = isReader
+    ? projects.filter(({ created_by, users }) =>
+        users.find((user) => user.user.id === me.id && me.id !== created_by?.id)
+      )
+    : me.isOrgAdmin
+    ? projects.filter(
+        (p) =>
+          p.created_by?.id !== me.id &&
+          p.users.filter((u) => u.user.id === me.id).length === 0 &&
+          !p.is_open_join
+      )
+    : projects.filter(
+        (p) =>
+          p.created_by?.id !== me.id &&
+          p.users.filter((u) => u.user.id === me.id).length > 0
+      );
 
   const allProjects = me.isOrgAdmin
     ? projects


### PR DESCRIPTION
## In this PR

- On the Projects Dashboard, Org admins could not see projects that they did not create, were not members of, or were open join.  This adds all projects that are not these to the shared with me tab.  IN the future we may want to add an All Others tab for Org Admins.