### PR TITLE
Fix for Cantaloupe loaded images

### DIFF
--- a/src/components/DocumentCard/DocumentCardThumbnail.css
+++ b/src/components/DocumentCard/DocumentCardThumbnail.css
@@ -1,10 +1,3 @@
-.doc-card-thumbnail-spinner {
-  width: 200px;
-  height: 200px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
 
 .document-card-image-container {
   width: 200px;
@@ -13,4 +6,12 @@
 
 .document-card-image-container img {
   object-fit: cover;
+}
+
+.document-card-image-container .spinner-container {
+  width: 200px;
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/components/DocumentCard/DocumentCardThumbnail.tsx
+++ b/src/components/DocumentCard/DocumentCardThumbnail.tsx
@@ -1,49 +1,18 @@
-import React, { useState } from 'react';
 import type { Document } from 'src/Types';
 import { ContentTypeIcon } from '@components/DocumentCard/ContentTypeIcon';
 import './DocumentCardThumbnail.css';
-import { Spinner } from '@components/Spinner';
-import { supabase } from '@backend/supabaseBrowserClient';
+import { IIIFPresentationThumbnail } from './IIIFPresentationThumbnail';
+import { IIIFImageThumbnail } from './IIIFImageThumbnail';
+
 export interface DocumentCardThumbnailProps {
+
   document: Document;
+
 }
 
 export const DocumentCardThumbnail = (props: DocumentCardThumbnailProps) => {
-  const [loading, setLoading] = useState(true);
-
-  const [url, setUrl] = useState<string | null>();
 
   const { document } = props;
-
-  const loadManifestThumbnail = (manifestURL: string) => {
-    fetch(manifestURL)
-      .then((response) => response.json())
-      .then((data) => {
-        setLoading(false);
-        // Look for thumbnail
-        if (data.thumbnail) {
-          setUrl(data.thumbnail['@id']);
-        } else {
-          setUrl(undefined);
-        }
-      });
-  };
-
-  const getImageURLFromStorage = () => {
-    supabase.storage
-      .from('documents')
-      .createSignedUrl(document.id, 3600)
-      .then(({ data, error }) => {
-        if (error) {
-          console.log(
-            `Failed to get signed url for ${document.id}, error: ${error.message}`
-          );
-        } else {
-          setUrl(data?.signedUrl);
-          setLoading(false);
-        }
-      });
-  };
 
   if (document.content_type === 'text/plain') {
     return (
@@ -64,53 +33,15 @@ export const DocumentCardThumbnail = (props: DocumentCardThumbnailProps) => {
       </div>
     );
   } else if (document.meta_data?.protocol === 'IIIF_PRESENTATION') {
-    if (loading && !url) {
-      loadManifestThumbnail(document.meta_data.url);
-    }
     return (
-      <div className='document-card-image-container'>
-        {loading ? (
-          <div>
-            <Spinner className='search-icon spinner' size={14} />
-          </div>
-        ) : (
-          <img
-            src={!loading && url ? url : '/img/iiif-manifest-document.png'}
-            height={200}
-            width={200}
-          />
-        )}
-      </div>
+      <IIIFPresentationThumbnail
+        manifestURL={document.meta_data.url} />
     );
-  } else if (document.content_type?.startsWith('image/')) {
-    if (loading && !url) {
-      getImageURLFromStorage();
-    }
+  } else if (document.content_type?.startsWith('image/') || document.meta_data?.protocol === 'IIIF_IMAGE') {
     return (
-      <div className='document-card-image-container'>
-        {loading ? (
-          <div>
-            <Spinner className='search-icon spinner' size={14} />
-          </div>
-        ) : (
-          <img
-            src={!loading && url ? url : '/img/iiif-manifest-document.png'}
-            height={200}
-            width={200}
-          />
-        )}
-      </div>
-    );
-  } else if (document.meta_data?.protocol === 'IIIF_IMAGE') {
-    const url = document.meta_data.url.replace(
-      '/info.json',
-      '/square/max/0/default.jpg'
-    );
-    return (
-      <div className='document-card-image-container'>
-        <img src={url} height={200} width={200} />
-      </div>
-    );
+      <IIIFImageThumbnail 
+        document={document} />
+    )
   } else {
     return (
       <div className='document-card-body'>

--- a/src/components/DocumentCard/IIIFImageThumbnail.tsx
+++ b/src/components/DocumentCard/IIIFImageThumbnail.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@backend/supabaseBrowserClient';
+import type { Document } from 'src/Types';
+import { Spinner } from '@components/Spinner';
+
+const CANTALOUPE_PATH: string | undefined = import.meta.env.PUBLIC_IIIF_CANTALOUPE_PATH;
+
+interface IIIFImageThumbnailProps {
+
+  document: Document;
+
+}
+
+export const IIIFImageThumbnail = (props: IIIFImageThumbnailProps) => {
+
+  const { document } = props;
+
+  const [authToken, setAuthToken] = useState<string | undefined>();
+
+  const [thumbnailBlob, setThumbnailBlob] = useState<string | undefined>();
+
+  const isUploadedFile = document.content_type?.startsWith('image/');
+
+  const imageManifest = isUploadedFile
+    ? `${CANTALOUPE_PATH}/${document.id}/info.json`
+    : document.meta_data?.url;
+
+  const thumbnailURL = imageManifest?.replace('/info.json', '/square/max/0/default.jpg');
+
+  useEffect(() => {
+    // Standard image tag
+    if (!isUploadedFile || !thumbnailURL) return;
+
+    supabase.auth.getSession().then(({ error, data }) => {
+      if (error) {
+        // Shouldn't really happen at this point
+        console.error(error);
+      } else {
+        setAuthToken(data.session?.access_token);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!authToken || !thumbnailURL) return;
+
+    fetch(thumbnailURL, {
+      headers: {
+        'Authorization': `Bearer ${authToken}`
+      }
+    }).then(res => {
+      if (!res.ok) {
+        console.error('Failed thumbnail download', res);
+      } else {
+        res.blob().then(blob => {
+          const objectURL = URL.createObjectURL(blob);
+          setThumbnailBlob(objectURL);
+        });
+      }
+    }).catch(error => {
+      console.error('Failed thumbnail download', error);
+    });
+  }, [authToken]);
+
+  useEffect(() => {
+    // Cleanup: free resources properly on unmount
+    if (!thumbnailBlob) return;
+
+    return () => {
+      URL.revokeObjectURL(thumbnailBlob);
+    }
+  }, [thumbnailBlob]);
+
+  return isUploadedFile ? (
+    <div className='document-card-image-container'>
+      {!thumbnailBlob ? (
+        <div className="spinner-container">
+          <Spinner className='search-icon spinner' size={14} />
+        </div>
+      ) : (
+        <img
+          src={thumbnailBlob}
+          height={200}
+          width={200}
+        />
+      )}
+    </div>  
+  ) : (
+    <div className='document-card-image-container'>
+      <img
+        src={thumbnailURL}
+        height={200}
+        width={200}
+      />
+    </div>
+  );
+
+}

--- a/src/components/DocumentCard/IIIFPresentationThumbnail.tsx
+++ b/src/components/DocumentCard/IIIFPresentationThumbnail.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Spinner } from '@components/Spinner';
+
+interface IIIFPresentationThumbnailProps {
+
+  manifestURL: string;
+
+}
+
+export const IIIFPresentationThumbnail = (props: IIIFPresentationThumbnailProps) => {
+
+  const [loading, setLoading] = useState(true);
+
+  const [url, setURL] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!props.manifestURL) return;
+
+    fetch(props.manifestURL)
+      .then((response) => response.json())
+      .then((data) => {
+        setLoading(false);
+
+        if (data.thumbnail)
+          setURL(data.thumbnail['@id']);
+      });
+  }, [props.manifestURL]);
+
+  return (
+    <div className='document-card-image-container'>
+      {loading ? (
+        <div className="spinner-container">
+          <Spinner className='search-icon spinner' size={14} />
+        </div>
+      ) : (
+        <img
+          src={url ? url : '/img/iiif-manifest-document.png'}
+          height={200}
+          width={200}
+        />
+      )}
+    </div>
+  );
+
+}


### PR DESCRIPTION
## In this PR

Images loaded from a Cantaloupe based IIIF server behind Supabase requires a token, the current approach to loading IIIF images with an image tag fails.  This PR instead gets a signed URL from Supabase storage to display the image.