### PR TITLE
Netlify Runtime Issue: Updated Build Config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
   }),
   vite: {
     ssr: {
-      noExternal: ['clsx', '@phosphor-icons/*', '@radix-ui/*']
+      noExternal: ['clsx', '@phosphor-icons/*', '@radix-ui/*', '@recogito/annotorious-supabase']
     },
     optimizeDeps: {
       esbuildOptions: {

--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
   }),
   vite: {
     ssr: {
-      noExternal: ['clsx', '@phosphor-icons/*', '@radix-ui/*']
+      noExternal: ['clsx', '@phosphor-icons/*', '@radix-ui/*', '@recogito/annotorious-supabase']
     }
   }
 });


### PR DESCRIPTION
## In this PR

This PR resolves runtime errors on Netlify. I frankly don't know why our own library (`@recogito/annotorious-supabase`) needed to be added to `noExternal` after the Astro 4.1 upgrade. But without it, Netlify crashed at runtime with the error message `crypto is not defined`.