### PR TITLE
Minor Bugfixes

### DIFF
--- a/src/apps/annotation-image/IIIF/useIIIF.ts
+++ b/src/apps/annotation-image/IIIF/useIIIF.ts
@@ -23,10 +23,6 @@ const isSupported = (manifest: Manifest) => {
   return true;
 };
 
-/**
- * TODO add additional checks on the document metadata, to ensure
- * we are dealing with a IIIF (image or presentation) manifest.
- */
 export const useIIIF = (document: DocumentWithContext) => {
   const [sequence, setSequence] = useState<Sequence | undefined>();
 
@@ -49,7 +45,6 @@ export const useIIIF = (document: DocumentWithContext) => {
 
     const url = isUploadedFile
       ? // Locally uploaded image - for now, assume this is served via built-in IIIF
-        // TODO how to construct the right IIIF URL?
         `${CANTALOUPE_PATH}/${document.id}/info.json`
       : document.meta_data?.url;
 
@@ -58,7 +53,7 @@ export const useIIIF = (document: DocumentWithContext) => {
       return;
     }
 
-    if (url.endsWith('info.json')) {
+    if (url.endsWith('info.json')  || url.includes('info.json?')) {
       if (isUploadedFile) {
         // For uploaded files, we need to include the auth token
         // into image requests

--- a/src/apps/annotation-text/TextAnnotationDesktop.css
+++ b/src/apps/annotation-text/TextAnnotationDesktop.css
@@ -32,6 +32,7 @@ html, body {
   z-index: 5;
 }
 
+.r6o-presence-layer, 
 .ta-desktop main .r6o-annotatable .r6o-highlight-layer.presence {
   z-index: 10;
 }

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -364,7 +364,7 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
                           className='project-settings-label-detail text-body-large-bold'
                           htmlFor='firstName'
                         >
-                          {t['Project Visibility']}
+                          {t['Project Type']}
                         </Label.Root>
                         <RadioGroup.Root
                           className='project-settings-radio-group-root'

--- a/src/components/QuillEditor/QuillEditor.css
+++ b/src/components/QuillEditor/QuillEditor.css
@@ -21,6 +21,8 @@
 
 .quill-rte .ql-editor img {
   display: inline-block;
+  max-height: 30vh;
+  max-width: 100%;
 }
 
 .quill-rte-toolbar {


### PR DESCRIPTION
## In this PR

Fixes three small issues:
- Images embedded in Quill rich text are now scaled to a maximum size (100% width of the editor or max. 0.3 * viewport height, whichever limit is encountered first)
- Fixes the wrong label reported in https://github.com/performant-software/vico/issues/299
- Addresses the issue reported by the ATRIUM project, that IIIF image manifests with query params (`.../info.json?foo=bar`) were not opened in the annotation view.