### PR TITLE
Layer De-Duplication

### DIFF
--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type OpenSeadragon from 'openseadragon';
+import { useAnnotator } from '@annotorious/react';
 import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { getAllDocumentLayersInProject } from '@backend/helpers';
 import { useLayerPolicies, useTagVocabulary } from '@backend/hooks';
@@ -8,14 +9,14 @@ import { LoadingOverlay } from '@components/LoadingOverlay';
 import { DocumentNotes, useLayerNames } from '@components/AnnotationDesktop';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { TopBar } from '@components/TopBar';
-import type { DocumentLayer } from 'src/Types';
 import { AnnotatedImage } from './AnnotatedImage';
 import type { ImageAnnotationProps } from './ImageAnnotation';
 import { LeftDrawer } from './LeftDrawer';
 import { RightDrawer } from './RightDrawer';
 import { Toolbar } from './Toolbar';
 import { useIIIF, ManifestErrorDialog } from './IIIF';
-import { useAnnotator } from '@annotorious/react';
+import { deduplicateLayers } from 'src/util/deduplicateLayers';
+import type { DocumentLayer } from 'src/Types';
 import type {
   AnnotationState,
   AnnotoriousOpenSeadragonAnnotator,
@@ -168,7 +169,12 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
           setLayers([...props.document.layers, ...toAdd]);
         });
       } else {
-        setLayers(props.document.layers);
+        const distinct = deduplicateLayers(props.document.layers);
+
+        if (props.document.layers.length !== distinct.length)
+          console.warn('Layers contain duplicates', props.document.layers);
+
+        setLayers(distinct);
       }
     }
   }, [policies]);

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useAnnotator } from '@annotorious/react';
 import type { PresentUser, AnnotationState, Color } from '@annotorious/react';
-import type {
-  HighlightStyle,
-  HighlightStyleExpression,
-  RecogitoTextAnnotator,
-  TextAnnotation,
-} from '@recogito/react-text-annotator';
 import type { PDFAnnotation } from '@recogito/react-pdf-annotator';
 import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { supabase } from '@backend/supabaseBrowserClient';
@@ -21,7 +15,14 @@ import { Toolbar } from './Toolbar';
 import { AnnotatedText } from './AnnotatedText';
 import { LeftDrawer } from './LeftDrawer/LeftDrawer';
 import { RightDrawer } from './RightDrawer';
+import { deduplicateLayers } from 'src/util/deduplicateLayers';
 import type { DocumentLayer } from 'src/Types';
+import type {
+  HighlightStyle,
+  HighlightStyleExpression,
+  RecogitoTextAnnotator,
+  TextAnnotation,
+} from '@recogito/react-text-annotator';
 
 import './TextAnnotationDesktop.css';
 import '@recogito/react-text-annotator/react-text-annotator.css';
@@ -137,7 +138,12 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
           setLayers([...props.document.layers, ...toAdd]);
         });
       } else {
-        setLayers(props.document.layers);
+        const distinct = deduplicateLayers(props.document.layers);
+
+        if (props.document.layers.length !== distinct.length)
+          console.warn('Layers contain duplicates', props.document.layers);
+
+        setLayers(distinct);
       }
     }
   }, [policies]);

--- a/src/util/deduplicateLayers.ts
+++ b/src/util/deduplicateLayers.ts
@@ -1,0 +1,8 @@
+import type { DocumentLayer } from 'src/Types';
+
+// A temporary helper
+export const deduplicateLayers = (layers: DocumentLayer[]) =>
+  layers.reduce<DocumentLayer[]>((distinct, layer) => {
+    const existing = distinct.find(l => l.id === layer.id);
+    return existing ? distinct : [...distinct, layer];
+  }, []);


### PR DESCRIPTION
When the annotation UI mounts, document layer provided through `props.document.layers` are now de-duplicated. This is a temporary fix until we resolve the root cause of our duplicate layers.