### PR TITLE
Dashboard CSS/Behavior Fixes

### DIFF
--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -74,16 +74,12 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           ) : (
             <p className='no-creator-rights'>
               {t["You don't have creator rights"]}{' '}
-              {invitations === 0 ? (
-                <span
-                  dangerouslySetInnerHTML={{ __html: t['Read the tutorial'] }}
-                ></span>
-              ) : invitations === 1 ? (
+              {invitations === 1 ? (
                 <>
                   {t['Fret not one'].split('${icon}')[0]} <Bell size={18} />
                   {t['Fret not one'].split('${icon}')[1]}
                 </>
-              ) : (
+              ) : invitations > 1 && (
                 <>
                   {t['Fret not more']
                     .split('${icon}')[0]

--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -22,17 +22,9 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
 
   const { t } = props.i18n;
 
-  const [fetching, setFetching] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
-
-  const onCreateProject = () => {
-    if (fetching) return;
-
-    setFetching(true);
-
-    setCreateProjectOpen(true);
-  };
 
   const handleSaveProject = (
     name: string,
@@ -40,6 +32,8 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
     openJoin: boolean,
     openEdit: boolean
   ) => {
+    setBusy(true);
+
     supabase
       .rpc('create_project_rpc', {
         _description: description,
@@ -49,9 +43,10 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
       })
       .then(({ data, error }) => {
         if (error) {
-          setFetching(false);
+          setBusy(false);
           props.onError('Something went wrong');
         } else {
+          setBusy(false);
           props.onProjectCreated(data);
           window.location.href = `/${props.i18n.lang}/projects/${data[0].id}`;
         }
@@ -71,9 +66,8 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           {canCreateProjects ? (
             <Button
               className='primary lg'
-              onClick={onCreateProject}
-              busy={fetching}
-            >
+              onClick={() => setCreateProjectOpen(true)}
+              busy={busy}>
               <RocketLaunch size={20} />{' '}
               <span>{t['Start Your First Annotation Project']}</span>
             </Button>
@@ -102,6 +96,7 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           )}
         </div>
       </div>
+
       <CreateProjectDialog
         open={createProjectOpen}
         onClose={() => setCreateProjectOpen(false)}

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -7,7 +7,7 @@ import { HeaderSearchAction } from '@components/Search';
 import { HeaderSortAction, type SortFunction } from '@components/Sort';
 import {
   ToggleDisplay,
-  type ToggleDisplayOptions,
+  type ToggleDisplayValue,
 } from '@components/ToggleDisplay';
 import { ProjectFilter } from '../ProjectsHome';
 import type {
@@ -52,9 +52,9 @@ interface HeaderProps {
 
   onSetProjects(projects: ExtendedProjectData[]): void;
 
-  display: ToggleDisplayOptions;
+  display: ToggleDisplayValue;
 
-  onSetDisplay(display: ToggleDisplayOptions): void;
+  onSetDisplay(display: ToggleDisplayValue): void;
 }
 
 export const Header = (props: HeaderProps) => {

--- a/src/apps/dashboard-projects/List/ProjectEntry.css
+++ b/src/apps/dashboard-projects/List/ProjectEntry.css
@@ -4,6 +4,7 @@
   flex-direction: row;
   align-items: center;
   height: 64px;
+  font-size: var(--font-tiny);
   border-bottom: 1px solid var(--gray-200);
 }
 

--- a/src/apps/dashboard-projects/List/ProjectList.css
+++ b/src/apps/dashboard-projects/List/ProjectList.css
@@ -1,5 +1,5 @@
-.projects-list {
-  width: 100%;
+.dashboard-projects-list {
+  margin-top: 2rem;
 }
 
 .project-list-header {

--- a/src/apps/dashboard-projects/ProjectsHome.css
+++ b/src/apps/dashboard-projects/ProjectsHome.css
@@ -1,6 +1,7 @@
 .dashboard-projects-home {
   display: flex;
   flex-direction: column;
+  min-height: 100%;
 }
 
 .dashboard-projects-empty {

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -9,7 +9,7 @@ import { ProjectsGrid } from './Grid';
 import { ProjectsList } from './List';
 import { ProfileNagDialog } from '@components/ProfileNagDialog';
 import { TopBar } from '@components/TopBar';
-import type { ToggleDisplayOptions } from '@components/ToggleDisplay';
+import type { ToggleDisplayValue } from '@components/ToggleDisplay';
 import type {
   ExtendedProjectData,
   Invitation,
@@ -62,7 +62,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const [showProfileNag, setShowProfileNag] = useState(false);
 
-  const [display, setDisplay] = useState<ToggleDisplayOptions>('cards');
+  const [display, setDisplay] = useState<ToggleDisplayValue>('cards');
 
   const isReader = policies ? !policies.get('projects').has('INSERT') : true;
 
@@ -152,11 +152,8 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
     setProjects((projects) => projects.filter((p) => p.id !== project.id));
 
   const onLeaveProject = (project: ExtendedProjectData) => {
-    project.contexts = [];
-
-    setProjects((projects) =>
-      projects.map((p) => (p.id === project.id ? project : p))
-    );
+    project.contexts = []; // Not sure what this is for
+    setProjects(projects => projects.filter(p => p.id !== project.id));
   };
 
   const onError = (error: string) =>
@@ -227,7 +224,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           onSetDisplay={setDisplay}
         />
 
-        {allProjects.length === 0 ? (
+        {filteredProjects.length === 0 ? (
           policies && (
             <ProjectsEmpty
               i18n={props.i18n}

--- a/src/components/AccountActions/AccountActions.css
+++ b/src/components/AccountActions/AccountActions.css
@@ -40,15 +40,3 @@
   font-size: 0.675em;
   font-weight: 400;
 }
-
-.divider {
-  margin-top: 10px;
-  border-top: 1px solid black;
-  padding-top: 10px;
-}
-
-.site-text {
-  display: flex;
-  justify-content: space-around;
-  font-size: small;
-}

--- a/src/components/AccountActions/AccountActions.tsx
+++ b/src/components/AccountActions/AccountActions.tsx
@@ -105,10 +105,15 @@ export const AccountActions = (props: AccountProps) => {
               <SignOut size={16} />
               <a href={`/${lang}/sign-out`}>{t['Sign out']}</a>
             </Item>
+
             {props.profile.isOrgAdmin && (
               <>
-                <div className='divider' />
-                <div className='site-text'>{t['Site Administration']}</div>
+                <div className='dropdown-divider' />
+
+                <div className='dropdown-label'>
+                  {t['Site Administration']}
+                </div>
+
                 <Item
                   className='dropdown-item'
                   onSelect={goto(`/${lang}/users`)}

--- a/src/components/CreateProjectDialog/CreateProjectDialog.css
+++ b/src/components/CreateProjectDialog/CreateProjectDialog.css
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: flex-end;
 }
+
 .create-project-switch-root {
   width: 42px;
   height: 25px;
@@ -41,6 +42,7 @@
   transform: translateX(2px);
   will-change: transform;
 }
+
 .create-project-switch-thumb[data-state='checked'] {
   transform: translateX(19px);
   background-color: var(--bright-blue);
@@ -92,6 +94,12 @@
 }
 
 .create-project-radio-group-item {
+  align-items: center;
+  display: flex;
+  gap: 0.25rem;
+} 
+
+.create-project-radio-group-button {
   background-color: white;
   width: 20px;
   height: 20px;
@@ -100,11 +108,11 @@
   padding: 0 !important;
 }
 
-.create-project-radio-group-item[data-state='checked'] {
+.create-project-radio-group-button[data-state='checked'] {
   border-color: var(--primary);
 }
 
-.create-project-radio-group-item:hover {
+.create-project-radio-group-button:hover {
   background-color: var(--gray-300);
 }
 

--- a/src/components/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/src/components/CreateProjectDialog/CreateProjectDialog.tsx
@@ -88,9 +88,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                     value === 'public' ? setOpenJoin(true) : setOpenJoin(false)
                   }
                 >
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div className='create-project-radio-group-item'>
                     <RadioGroup.Item
-                      className='create-project-radio-group-item'
+                      className='create-project-radio-group-button'
                       value='private'
                       id='r1'
                     >
@@ -110,9 +110,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                       ]
                     }
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div className='create-project-radio-group-item'>
                     <RadioGroup.Item
-                      className='create-project-radio-group-item'
+                      className='create-project-radio-group-button'
                       value='public'
                       id='r2'
                     >
@@ -151,9 +151,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                         : setOpenEdit(true)
                     }
                   >
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <div className='create-project-radio-group-item'>
                       <RadioGroup.Item
-                        className='create-project-radio-group-item'
+                        className='create-project-radio-group-button'
                         value='assignments'
                         id='r1'
                       >
@@ -173,9 +173,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                         ]
                       }
                     </div>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <div className='create-project-radio-group-item'>
                       <RadioGroup.Item
-                        className='create-project-radio-group-item'
+                        className='create-project-radio-group-button'
                         value='single_team'
                         id='r2'
                       >

--- a/src/components/Notifications/Notifications.css
+++ b/src/components/Notifications/Notifications.css
@@ -17,8 +17,8 @@ button.unstyled.icon-only.notification-actions-trigger {
   height: 1tpx;
   line-height: 15px;
   position: absolute;
-  right: -5px;
-  top: -5px;
+  right: 0;
+  top: 0;
   width: 15px;
 }
 

--- a/src/components/OwnerPill/OwnerPill.css
+++ b/src/components/OwnerPill/OwnerPill.css
@@ -1,11 +1,17 @@
 .owner-pill {
-  width: 75px;
-  height: 24px;
-  border-radius: 12px;
-  gap: 4px;
+  align-items: center;
   background-color: var(--gray-200);
+  border-radius: 100vw;
   display: flex;
   flex-direction: row;
+  gap: 4px;
   justify-content: center;
-  align-items: center;
+  padding: 0 0.625rem 0 0.375rem;
+  line-height: 200%;
+}
+
+.owner-pill svg {
+  flex: 0 0 auto;
+  height: 14px;
+  width: 14px;
 }

--- a/src/components/ProjectCard/JoinProjectDialog.css
+++ b/src/components/ProjectCard/JoinProjectDialog.css
@@ -2,17 +2,3 @@
   display: flex;
   justify-content: space-between;
 }
-
-.join-project-dialog-button-join {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--dark-blue);
-  color: var(--gray-100);
-}
-
-.join-project-dialog-button-cancel {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--gray-300);
-  color: var(--gray-900);
-}

--- a/src/components/ProjectCard/JoinProjectDialog.tsx
+++ b/src/components/ProjectCard/JoinProjectDialog.tsx
@@ -35,13 +35,13 @@ export const JoinProjectDialog = (props: JoinProjectDialogProps) => {
 
           <div className='join-project-dialog-button-container'>
             <button
-              className='join-project-dialog-button-cancel'
+              className='flat'
               onClick={props.onClose}
             >
               {t['Cancel']}
             </button>
             <button
-              className='join-project-dialog-button-join'
+              className='primary flat'
               onClick={props.onJoin}
             >
               {t['Join']}

--- a/src/components/ProjectCard/OpenJoin.css
+++ b/src/components/ProjectCard/OpenJoin.css
@@ -4,10 +4,3 @@
   flex-direction: row;
   justify-content: flex-end;
 }
-
-.open-join-button {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--dark-blue);
-  color: var(--gray-100);
-}

--- a/src/components/ProjectCard/OpenJoin.tsx
+++ b/src/components/ProjectCard/OpenJoin.tsx
@@ -15,9 +15,9 @@ export const OpenJoin = (props: OpenJoinProps) => {
 
   return (
     <div className='open-join-bar'>
-      <button className='open-join-button' onClick={props.onJoin}>
+      <button className='primary sm flat' onClick={props.onJoin}>
         <div>{t['Join']}</div>
-        <SignIn color='white' />
+        <SignIn size={16} />
       </button>
     </div>
   );

--- a/src/components/ToggleDisplay/ToggleDisplay.tsx
+++ b/src/components/ToggleDisplay/ToggleDisplay.tsx
@@ -3,24 +3,33 @@ import { SquaresFour, ListBullets } from '@phosphor-icons/react';
 
 import './ToggleDisplay.css';
 
-export type ToggleDisplayOptions = 'cards' | 'rows';
+export type ToggleDisplayValue = 'cards' | 'rows';
 
 interface ToggleDisplayProps {
-  display: ToggleDisplayOptions;
-  onChangeDisplay(display: ToggleDisplayOptions): void;
+
+  display: ToggleDisplayValue;
+
+  onChangeDisplay(display: ToggleDisplayValue): void;
+
 }
 
 export const ToggleDisplay = (props: ToggleDisplayProps) => {
+
+  // Note that the Radix toggle group can have a value of undefined.
+  // In our case, we want to emulate radio group behavior!
+  const onValueChange = (value?: string) => {
+    if (value)
+      props.onChangeDisplay(value as ToggleDisplayValue);
+  }
+
   return (
     <ToggleGroup.Root
       className='toggle-display-group'
       type='single'
       aria-label='Text alignment'
       value={props.display}
-      onValueChange={(value) =>
-        props.onChangeDisplay(value as ToggleDisplayOptions)
-      }
-    >
+      onValueChange={onValueChange}>
+
       <ToggleGroup.Item className='toggle-display-item' value='cards'>
         <SquaresFour size={16} />
       </ToggleGroup.Item>
@@ -29,5 +38,6 @@ export const ToggleDisplay = (props: ToggleDisplayProps) => {
         <ListBullets size={16} />
       </ToggleGroup.Item>
     </ToggleGroup.Root>
-  );
-};
+  )
+
+}

--- a/src/themes/default/button/index.css
+++ b/src/themes/default/button/index.css
@@ -110,6 +110,7 @@ button.icon-only {
   display: inline-flex;
   justify-content: center;
   min-width: auto;
+  padding: 0;
 }
 
 button.icon-only svg {

--- a/src/themes/default/button/unstyled.css
+++ b/src/themes/default/button/unstyled.css
@@ -26,13 +26,15 @@ button.unstyled:not(:disabled):hover {
 button.unstyled.icon-only {
   border: 2px solid transparent;
   border-radius: 50%;
-  width: 34px;
   height: 34px;
   outline: none;
-  padding: 2px;
+  padding: 0;
+  width: 34px;
 }
 
 button.unstyled.icon-only svg {
+  height: 100%;
   margin: 1px 0 0 0;
-  padding: 0;
+  padding: 0.5rem;
+  width: 100%;
 }

--- a/src/themes/default/dropdown/index.css
+++ b/src/themes/default/dropdown/index.css
@@ -96,6 +96,19 @@
   position: absolute;
 }
 
+.dropdown-divider {
+  border-top: 1px solid var(--gray-200);
+  margin: 0.25rem 0.5rem;
+}
+
+.dropdown-label {
+  color: var(--gray-500);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0.125rem 10px 0 10px;
+  margin: 0 5px;
+}
+
 @keyframes slideUpAndFade {
   from {
     opacity: 0;

--- a/src/themes/default/index.css
+++ b/src/themes/default/index.css
@@ -181,8 +181,10 @@ body {
   color: var(--gray-900);
   font-family: Inter, Arial, Helvetica, sans-serif;
   font-size: 16px;
+  height: 100%;
   line-height: 160%;
   margin: 0;
+  min-height: 100%;
   padding: 0;
 }
 


### PR DESCRIPTION
## In this PR

This PR adds a number of style and behavior fixes to the main project dashboard.

- Fixed 'busy' button spin icon behavior on the initial, empty dashboard.
- Grid/Table view toggle button: the Radix Toggle Group component allows for an unselected state. (I.e. neither the Grid nor the Table button is selected.) Added a fix that now properly emulates radio button behavior, so that either Grid or Table is selected.
- Minor cosmetic tweaks to the table view and owner pill.
- Minor cosmetic tweaks to the user account menu's admin section.
- Cleanup: removed redundant button styles on the "public project" card and "join project" dialog, and used global theme styles.
- On Chrome, buttons with an icon only (such as 'X' close buttons) were only clickable if you hit the icon, but not the padding around it (even though the padding is inside the HTML `<button>` component). This is fixed now.