### PR TITLE
Project Page CSS Enhancements

### DIFF
--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -74,16 +74,12 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           ) : (
             <p className='no-creator-rights'>
               {t["You don't have creator rights"]}{' '}
-              {invitations === 0 ? (
-                <span
-                  dangerouslySetInnerHTML={{ __html: t['Read the tutorial'] }}
-                ></span>
-              ) : invitations === 1 ? (
+              {invitations === 1 ? (
                 <>
                   {t['Fret not one'].split('${icon}')[0]} <Bell size={18} />
                   {t['Fret not one'].split('${icon}')[1]}
                 </>
-              ) : (
+              ) : invitations > 1 && (
                 <>
                   {t['Fret not more']
                     .split('${icon}')[0]

--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -22,17 +22,9 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
 
   const { t } = props.i18n;
 
-  const [fetching, setFetching] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   const [createProjectOpen, setCreateProjectOpen] = useState(false);
-
-  const onCreateProject = () => {
-    if (fetching) return;
-
-    setFetching(true);
-
-    setCreateProjectOpen(true);
-  };
 
   const handleSaveProject = (
     name: string,
@@ -40,6 +32,8 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
     openJoin: boolean,
     openEdit: boolean
   ) => {
+    setBusy(true);
+
     supabase
       .rpc('create_project_rpc', {
         _description: description,
@@ -49,9 +43,10 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
       })
       .then(({ data, error }) => {
         if (error) {
-          setFetching(false);
+          setBusy(false);
           props.onError('Something went wrong');
         } else {
+          setBusy(false);
           props.onProjectCreated(data);
           window.location.href = `/${props.i18n.lang}/projects/${data[0].id}`;
         }
@@ -71,9 +66,8 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           {canCreateProjects ? (
             <Button
               className='primary lg'
-              onClick={onCreateProject}
-              busy={fetching}
-            >
+              onClick={() => setCreateProjectOpen(true)}
+              busy={busy}>
               <RocketLaunch size={20} />{' '}
               <span>{t['Start Your First Annotation Project']}</span>
             </Button>
@@ -102,6 +96,7 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
           )}
         </div>
       </div>
+
       <CreateProjectDialog
         open={createProjectOpen}
         onClose={() => setCreateProjectOpen(false)}

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -7,7 +7,7 @@ import { HeaderSearchAction } from '@components/Search';
 import { HeaderSortAction, type SortFunction } from '@components/Sort';
 import {
   ToggleDisplay,
-  type ToggleDisplayOptions,
+  type ToggleDisplayValue,
 } from '@components/ToggleDisplay';
 import { ProjectFilter } from '../ProjectsHome';
 import type {
@@ -52,9 +52,9 @@ interface HeaderProps {
 
   onSetProjects(projects: ExtendedProjectData[]): void;
 
-  display: ToggleDisplayOptions;
+  display: ToggleDisplayValue;
 
-  onSetDisplay(display: ToggleDisplayOptions): void;
+  onSetDisplay(display: ToggleDisplayValue): void;
 }
 
 export const Header = (props: HeaderProps) => {

--- a/src/apps/dashboard-projects/List/ProjectEntry.css
+++ b/src/apps/dashboard-projects/List/ProjectEntry.css
@@ -4,6 +4,7 @@
   flex-direction: row;
   align-items: center;
   height: 64px;
+  font-size: var(--font-tiny);
   border-bottom: 1px solid var(--gray-200);
 }
 

--- a/src/apps/dashboard-projects/List/ProjectList.css
+++ b/src/apps/dashboard-projects/List/ProjectList.css
@@ -1,5 +1,5 @@
-.projects-list {
-  width: 100%;
+.dashboard-projects-list {
+  margin-top: 2rem;
 }
 
 .project-list-header {

--- a/src/apps/dashboard-projects/ProjectsHome.css
+++ b/src/apps/dashboard-projects/ProjectsHome.css
@@ -1,6 +1,7 @@
 .dashboard-projects-home {
   display: flex;
   flex-direction: column;
+  min-height: 100%;
 }
 
 .dashboard-projects-empty {

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -9,7 +9,7 @@ import { ProjectsGrid } from './Grid';
 import { ProjectsList } from './List';
 import { ProfileNagDialog } from '@components/ProfileNagDialog';
 import { TopBar } from '@components/TopBar';
-import type { ToggleDisplayOptions } from '@components/ToggleDisplay';
+import type { ToggleDisplayValue } from '@components/ToggleDisplay';
 import type {
   ExtendedProjectData,
   Invitation,
@@ -62,7 +62,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const [showProfileNag, setShowProfileNag] = useState(false);
 
-  const [display, setDisplay] = useState<ToggleDisplayOptions>('cards');
+  const [display, setDisplay] = useState<ToggleDisplayValue>('cards');
 
   const isReader = policies ? !policies.get('projects').has('INSERT') : true;
 
@@ -152,11 +152,8 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
     setProjects((projects) => projects.filter((p) => p.id !== project.id));
 
   const onLeaveProject = (project: ExtendedProjectData) => {
-    project.contexts = [];
-
-    setProjects((projects) =>
-      projects.map((p) => (p.id === project.id ? project : p))
-    );
+    project.contexts = []; // Not sure what this is for
+    setProjects(projects => projects.filter(p => p.id !== project.id));
   };
 
   const onError = (error: string) =>
@@ -227,7 +224,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           onSetDisplay={setDisplay}
         />
 
-        {allProjects.length === 0 ? (
+        {filteredProjects.length === 0 ? (
           policies && (
             <ProjectsEmpty
               i18n={props.i18n}

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -10,6 +10,7 @@ import { ProjectsList } from './List';
 import { ProfileNagDialog } from '@components/ProfileNagDialog';
 import { TopBar } from '@components/TopBar';
 import type { ToggleDisplayValue } from '@components/ToggleDisplay';
+import { useLocalStorageBackedState } from 'src/util/hooks';
 import type {
   ExtendedProjectData,
   Invitation,
@@ -18,7 +19,7 @@ import type {
 } from 'src/Types';
 
 import './ProjectsHome.css';
-import { useLocalStorageBackedState } from 'src/util/hooks';
+
 
 export interface ProjectsHomeProps {
   i18n: Translations;

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -63,7 +63,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const [showProfileNag, setShowProfileNag] = useState(false);
 
-  const [display, setDisplay] = useLocalStorageBackedState('rs-dashboard-display', 'cards');
+  const [display, setDisplay] = useLocalStorageBackedState<ToggleDisplayValue>('rs-dashboard-display', 'cards');
 
   const isReader = policies ? !policies.get('projects').has('INSERT') : true;
 

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -18,6 +18,7 @@ import type {
 } from 'src/Types';
 
 import './ProjectsHome.css';
+import { useLocalStorageBackedState } from 'src/util/hooks';
 
 export interface ProjectsHomeProps {
   i18n: Translations;
@@ -62,7 +63,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const [showProfileNag, setShowProfileNag] = useState(false);
 
-  const [display, setDisplay] = useState<ToggleDisplayValue>('cards');
+  const [display, setDisplay] = useLocalStorageBackedState('rs-dashboard-display', 'cards');
 
   const isReader = policies ? !policies.get('projects').has('INSERT') : true;
 
@@ -117,10 +118,6 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           p.created_by?.id !== me.id &&
           p.users.filter((u) => u.user.id === me.id).length > 0
       );
-
-  const allProjects = me.isOrgAdmin
-    ? projects
-    : [...new Set([...myProjects, ...sharedProjects, ...openJoinProjects])];
 
   const filteredProjects = isReader
     ? filter === ProjectFilter.MINE

--- a/src/apps/project-collaboration/ProjectCollaboration.css
+++ b/src/apps/project-collaboration/ProjectCollaboration.css
@@ -1,7 +1,5 @@
 .project-collaboration {
-  padding: 20px 40px;
-  width: 100%;
-  margin-top: 100px;
+  padding: 20px 30px;
   box-sizing: border-box;
 }
 

--- a/src/apps/project-home/AssignmentsView/AssignmentDetail/AssignmentDetail.css
+++ b/src/apps/project-home/AssignmentsView/AssignmentDetail/AssignmentDetail.css
@@ -1,23 +1,11 @@
 .assignment-detail-container {
-  display: flex;
   flex-grow: 1;
-  flex-direction: row;
-  width: 67%;
-  align-items: stretch;
-}
-
-.assignment-detail-divider {
-  width: 30px;
-  margin-left: 30px;
-  border-right: 1px solid var(--gray-200);
 }
 
 .assignment-detail-pane {
-  width: 100%;
   padding-top: 10px;
-  padding-left: 32px;
-  max-height: calc(100vh - 380px);
-  overflow-y: auto;
+  padding-left: 20px;
+  border-left: 1px solid var(--gray-200);
 }
 
 .assignment-detail-title-row {
@@ -34,20 +22,15 @@
   line-height: 27px;
 }
 
-.assignment-detail-buttons {
-  float: right;
-  width: 200px;
-}
-
 .assignment-detail-description-row {
-  padding-top: 14px;
+  padding: 14px 30px 0 0;
   display: flex;
   flex-direction: row;
 }
 
 .assignment-detail-description {
+  flex-grow: 1;
   font-size: 14px;
-  width: 60%;
   font-weight: 400;
   color: var(--gray-600);
   max-height: 150px;
@@ -55,6 +38,7 @@
 }
 
 .assignment-detail-team {
+  flex: 0 0 auto;
   font-size: 14px;
   font-weight: 600;
   margin-left: 10px;
@@ -70,10 +54,14 @@
   margin-left: -8px;
 }
 
+.assignment-detail-team-avatar .avatar {
+ border: 2px solid var(--gray-50);
+ height: 34px;
+ width: 34px;
+}
+
 .assignment-detail-buttons {
   display: flex;
   flex-direction: row;
-  width: 275px;
-  justify-content: space-between;
   margin-right: 30px;
 }

--- a/src/apps/project-home/AssignmentsView/AssignmentDetail/AssignmentDetail.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentDetail/AssignmentDetail.tsx
@@ -35,7 +35,6 @@ export const AssignmentDetail = (props: AssignmentDetailProps) => {
 
   return (
     <div className='assignment-detail-container'>
-      <div className='assignment-detail-divider' />
       <div className='assignment-detail-pane'>
         <div className='assignment-detail-title-row'>
           <div className='assignment-detail-title'>

--- a/src/apps/project-home/AssignmentsView/AssignmentsList/AssignmentsList.css
+++ b/src/apps/project-home/AssignmentsView/AssignmentsList/AssignmentsList.css
@@ -1,26 +1,32 @@
 .assignment-list-list {
-  height: calc(100vh - 380px);
-  overflow-y: auto;
-  width: 480px;
+  padding: 10px 20px 0 0;
 }
 
 .assignments-list-item {
+  box-sizing: border-box;
   width: 390px;
   height: 80px;
-  border-bottom: 1px solid var(--gray-200);
-  padding-left: 30px;
-  padding-top: 30px;
+  border-top: 1px solid var(--gray-200);
+  padding: 20px;
   cursor: pointer;
 }
 
-.assignments-list-item-active {
-  width: 404px;
-  height: 80px;
+.assignments-list-item:first-child {
+  border-top: none;
+}
+
+.assignments-list-item:last-child {
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.assignments-list-item.active + .assignments-list-item {
+  border-top: none;
+}
+
+.assignments-list-item.active {
   border: 1px solid var(--gray-300);
+  border-radius: var(--border-radius);
   background-color: var(--gray-100);
-  padding-left: 30px;
-  padding-top: 30px;
-  cursor: pointer;
 }
 
 .assignments-list-item-date {
@@ -30,8 +36,6 @@
 }
 
 .assignments-list-item-title {
-  margin-top: 10px;
   font-size: 16px;
   font-weight: 600;
-  line-height: 24px;
 }

--- a/src/apps/project-home/AssignmentsView/AssignmentsList/AssignmentsList.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentsList/AssignmentsList.tsx
@@ -19,7 +19,7 @@ export const AssignmentsList = (props: AssignmentsListProps) => {
   return (
     <div className='assignment-list-list' >
       {props.assignments.map(assignment => (
-        <div className={assignment.id === props.currentAssignment ? 'assignments-list-item-active' : 'assignments-list-item'}
+        <div className={assignment.id === props.currentAssignment ? 'assignments-list-item active' : 'assignments-list-item'}
           key={assignment.id}
           onClick={() => props.onAssignmentSelect(assignment)}
         >

--- a/src/apps/project-home/AssignmentsView/AssignmentsView.css
+++ b/src/apps/project-home/AssignmentsView/AssignmentsView.css
@@ -1,21 +1,25 @@
 .project-assignments {
-  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 .project-assignments-document-header-bar {
+  align-items: center;
+  box-shadow: 
+    0 0 3px -1px rgba(0, 0, 0, 0.9),
+    0 0 12px -4px rgba(0, 0, 0, 0.18);
   display: flex;
   flex-direction: row;
-  width: 100%;
-  height: 80px;
-  align-items: center;
   justify-content: space-between;
-  box-shadow: 0 4px 4px -2px rgba(0, 0, 0, 0.15);
+  padding: 10px 30px;
 }
 
 .project-assignments-presentation-pane {
   display: flex;
   flex-direction: row;
-  padding-top: 25px;
+  flex-grow: 1;
+  padding: 10px 0 0 30px;
   position: relative;
   align-items: stretch;
 }

--- a/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
@@ -130,7 +130,7 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
   return (
     <div className='project-assignments'>
       <header className='project-assignments-document-header-bar'>
-        <h1>{t['Assignments']}</h1>
+        <h2>{t['Assignments']}</h2>
         {props.isAdmin && (
           <>
             <Button

--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -205,7 +205,7 @@ export const DocumentsView = (props: DocumentsViewProps) => {
   return (
     <>
       <header className='project-home-document-header-bar'>
-        <h1>{t['Documents']}</h1>
+        <h2>{t['Documents']}</h2>
         {props.isAdmin && (
           <div className='admin-actions'>
             <button

--- a/src/apps/project-home/ProjectHeader/ProjectHeader.css
+++ b/src/apps/project-home/ProjectHeader/ProjectHeader.css
@@ -1,12 +1,7 @@
 .project-header-root {
-  margin-top: 10px;
   background-color: var(--gray-100);
-  padding-left: 40px;
-  padding-right: 40px;
-  position: fixed;
-  top: 90px;
-  width: 100%;
-  box-sizing: border-box;
+  padding: 0 30px;
+  position: relative;
   z-index: 10;
 }
 
@@ -17,31 +12,37 @@
   align-items: center;
 }
 
+.project-header-name-bar h1 {
+  font-size: 1.4rem;
+}
+
 .project-header-description-bar {
   font-weight: 400;
   font-size: 14px;
-  line-height: 22.4px;
   display: block;
-  display: -webkit-box;
-  line-clamp: 3;
   line-height: 160%;
+  max-height: 3rem;
   overflow: hidden;
   padding: 0 2px;
   text-overflow: ellipsis;
   word-wrap: break-word;
   -webkit-box-orient: vertical;
+  transition: all 500ms ease;
+}
+
+.project-header-description-bar.collapsed {
+  display: -webkit-box;
+  line-clamp: 3;
   -webkit-line-clamp: 2;
 }
 
-.project-header-description-bar-expanded {
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 22.4px;
+.project-header-description-bar.expanded {
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
-.project-header-header section.project-header-header-bottom {
-  padding: 6px 25px 0 30px;
-  border-bottom: 1px solid var(--gray-200);
+section.project-header-header-bottom {
+  padding-top: 15px;
 }
 
 .project-header-header-bottom ul {
@@ -74,7 +75,7 @@
   box-shadow: none;
   color: var(--font-light);
   font-size: var(--font-tiny);
-  padding: 8px 4px;
+  padding: 8px 4px 4px 4px;
 }
 
 .project-header-header-bottom .project-header-header-tabs li:hover {
@@ -103,14 +104,18 @@
   width: 250px;
   justify-content: space-between;
 }
+
 .project-header-button {
   border: 1px solid black;
   border-radius: 4px;
-  padding: 10px 16px 10px 16px;
+  padding: 8px 16px;
   display: flex;
   flex-direction: row;
   justify-content: center;
-  width: 130px;
+}
+
+.project-header-button svg {
+  flex: 0 0 auto;
 }
 
 .project-header-button-text {
@@ -123,7 +128,7 @@
 
 .show-button {
   position: absolute;
-  bottom: -6px;
+  bottom: 0;
   right: 10px;
   z-index: 1000;
   color: var(--primary);

--- a/src/apps/project-home/ProjectHeader/ProjectHeader.css
+++ b/src/apps/project-home/ProjectHeader/ProjectHeader.css
@@ -108,6 +108,7 @@ section.project-header-header-bottom {
 .project-header-button {
   border: 1px solid black;
   border-radius: 4px;
+  box-shadow: none;
   padding: 8px 16px;
   display: flex;
   flex-direction: row;

--- a/src/apps/project-home/ProjectHeader/ProjectHeader.tsx
+++ b/src/apps/project-home/ProjectHeader/ProjectHeader.tsx
@@ -61,8 +61,8 @@ export const ProjectHeader = (props: ProjectHeaderProps) => {
         id='project-description'
         className={
           expanded
-            ? 'project-header-description-bar-expanded'
-            : 'project-header-description-bar'
+            ? 'project-header-description-bar expanded'
+            : 'project-header-description-bar collapsed'
         }
       >
         {props.description}

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -1,19 +1,33 @@
+body {
+  display: flex;
+  flex-direction: column;
+}
+
 .project-home {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding-top: 20px;
-  padding-left: 40px;
-  padding-right: 40px;
   position: relative;
   background-color: white;
 }
 
-.project-home h1 {
-  margin-bottom: 0.4em;
+.project-home-document-header-bar {
+  align-items: center;
+  box-shadow: 
+    0 0 3px -1px rgba(0, 0, 0, 0.9),
+    0 0 12px -4px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 10px 30px;
 }
 
-.project-home h1 > span {
+.project-home h2 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.project-home h2 > span {
   display: inline-block;
   border: 1px dashed transparent;
   border-radius: var(--border-radius);
@@ -29,7 +43,10 @@
 
 .project-home .admin-actions {
   display: flex;
-  width: 500px;
+}
+
+.project-home .admin-actions button {
+  white-space: nowrap;
 }
 
 .project-home-add-document {
@@ -38,6 +55,7 @@
 
 .project-home-grid-wrapper {
   flex-grow: 1;
+  padding: 0 30px;
   position: relative;
 }
 
@@ -128,14 +146,4 @@
   font-size: var(--font-tiny);
   margin: 0;
   letter-spacing: 0.01ch;
-}
-
-.project-home-document-header-bar {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  height: 80px;
-  align-items: center;
-  justify-content: space-between;
-  box-shadow: 0 4px 4px -2px rgba(0, 0, 0, 0.15);
 }

--- a/src/apps/project-home/ProjectHome.css
+++ b/src/apps/project-home/ProjectHome.css
@@ -25,6 +25,7 @@ body {
 .project-home h2 {
   font-size: 1.2rem;
   margin: 0;
+  padding: 0.5rem 0;
 }
 
 .project-home h2 > span {

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -152,7 +152,9 @@ export const ProjectHome = (props: ProjectHomeProps) => {
         projects={props.projects}
         me={props.user}
       />
+
       <BackButtonBar i18n={props.i18n} showBackToProjects={true} />
+
       <ProjectHeader
         i18n={props.i18n}
         isAdmin={isAdmin || false}
@@ -164,7 +166,8 @@ export const ProjectHome = (props: ProjectHomeProps) => {
         onGotoUsers={handleGotoUsers}
         showTabs={!props.project.is_open_edit}
       />
-      <div className='project-home' style={{ marginTop: isAdmin ? 240 : 190 }}>
+
+      <div className='project-home'>
         <ToastProvider>
           {tab === 'documents' ? (
             <DocumentsView

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -1,8 +1,7 @@
 .project-settings {
-  padding: 20px 40px;
+  padding: 20px 30px;
   width: 100%;
   box-sizing: border-box;
-  margin-top: 180px;
 }
 
 .project-settings-inputs {
@@ -26,10 +25,8 @@
 }
 
 .project-settings .tagging-vocabulary {
-  border-top: 1px solid var(--gray-200);
-  border-bottom: 1px solid var(--gray-200);
   max-width: 65ch;
-  padding: 20px;
+  padding: 20px 0;
   z-index: 100;
 }
 
@@ -87,6 +84,7 @@
   transform: translateX(2px);
   will-change: transform;
 }
+
 .project-settings-switch-thumb[data-state='checked'] {
   transform: translateX(19px);
   background-color: var(--bright-blue);

--- a/src/apps/project-settings/ProjectSettings.css
+++ b/src/apps/project-settings/ProjectSettings.css
@@ -224,9 +224,6 @@
   background-color: var(--gray-300);
 }
 
-.project-settings-radio-group-item:focus {
-}
-
 .project-settings-radio-group-indicator {
   display: flex;
   align-items: center;

--- a/src/apps/project-settings/SettingsHeader.css
+++ b/src/apps/project-settings/SettingsHeader.css
@@ -1,9 +1,5 @@
 .settings-header-root {
-  margin-top: 10px;
-  padding-right: 40px;
-  position: fixed;
-  top: 90px;
-  width: 100%;
+  padding-right: 30px;
   box-sizing: border-box;
   z-index: 10;
   background-color: white;

--- a/src/components/AccountActions/AccountActions.css
+++ b/src/components/AccountActions/AccountActions.css
@@ -40,15 +40,3 @@
   font-size: 0.675em;
   font-weight: 400;
 }
-
-.divider {
-  margin-top: 10px;
-  border-top: 1px solid black;
-  padding-top: 10px;
-}
-
-.site-text {
-  display: flex;
-  justify-content: space-around;
-  font-size: small;
-}

--- a/src/components/AccountActions/AccountActions.tsx
+++ b/src/components/AccountActions/AccountActions.tsx
@@ -105,10 +105,15 @@ export const AccountActions = (props: AccountProps) => {
               <SignOut size={16} />
               <a href={`/${lang}/sign-out`}>{t['Sign out']}</a>
             </Item>
+
             {props.profile.isOrgAdmin && (
               <>
-                <div className='divider' />
-                <div className='site-text'>{t['Site Administration']}</div>
+                <div className='dropdown-divider' />
+
+                <div className='dropdown-label'>
+                  {t['Site Administration']}
+                </div>
+
                 <Item
                   className='dropdown-item'
                   onSelect={goto(`/${lang}/users`)}

--- a/src/components/BackButtonBar/BackButtonBar.css
+++ b/src/components/BackButtonBar/BackButtonBar.css
@@ -1,17 +1,18 @@
 .back-button-bar-header {
   align-items: center;
   background-color: var(--secondary);
-  border-bottom: 1px solid white;
   box-sizing: border-box;
   display: flex;
   height: 40px;
   font-size: 14px;
   font-weight: 600;
-  padding: 0 40px;
+  margin-top: 60px;
+  padding: 20px 30px;
   width: 100%;
-  z-index: 9999;
-  position: fixed;
-  top: 60px;
+}
+
+.back-button-bar-header svg {
+  margin-right: 0.5rem;
 }
 
 .back-button-bar-back {

--- a/src/components/BackButtonBar/BackButtonBar.tsx
+++ b/src/components/BackButtonBar/BackButtonBar.tsx
@@ -25,7 +25,7 @@ export const BackButtonBar = (props: BackButtonBarProps) => {
           window.location.href = `/${props.i18n.lang}/projects`;
         }}
         >
-          <ArrowLeft style={{ paddingRight: 7 }} />
+          <ArrowLeft size={18} />
           {props.i18n.t['Back to Projects']}
         </div>
 

--- a/src/components/CreateProjectDialog/CreateProjectDialog.css
+++ b/src/components/CreateProjectDialog/CreateProjectDialog.css
@@ -12,6 +12,7 @@
   display: flex;
   justify-content: flex-end;
 }
+
 .create-project-switch-root {
   width: 42px;
   height: 25px;
@@ -41,6 +42,7 @@
   transform: translateX(2px);
   will-change: transform;
 }
+
 .create-project-switch-thumb[data-state='checked'] {
   transform: translateX(19px);
   background-color: var(--bright-blue);
@@ -92,6 +94,12 @@
 }
 
 .create-project-radio-group-item {
+  align-items: center;
+  display: flex;
+  gap: 0.25rem;
+} 
+
+.create-project-radio-group-button {
   background-color: white;
   width: 20px;
   height: 20px;
@@ -100,11 +108,11 @@
   padding: 0 !important;
 }
 
-.create-project-radio-group-item[data-state='checked'] {
+.create-project-radio-group-button[data-state='checked'] {
   border-color: var(--primary);
 }
 
-.create-project-radio-group-item:hover {
+.create-project-radio-group-button:hover {
   background-color: var(--gray-300);
 }
 

--- a/src/components/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/src/components/CreateProjectDialog/CreateProjectDialog.tsx
@@ -155,13 +155,13 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                       <RadioGroup.Item
                         className='create-project-radio-group-button'
                         value='assignments'
-                        id='r1'
+                        id='r3'
                       >
                         <RadioGroup.Indicator className='create-project-radio-group-indicator' />
                       </RadioGroup.Item>
                       <label
                         className='create-project-radio-group-label text-body-small-bold'
-                        htmlFor='r1'
+                        htmlFor='r3'
                       >
                         {t['Assignments']}
                       </label>
@@ -177,13 +177,13 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                       <RadioGroup.Item
                         className='create-project-radio-group-button'
                         value='single_team'
-                        id='r2'
+                        id='r4'
                       >
                         <RadioGroup.Indicator className='create-project-radio-group-indicator' />
                       </RadioGroup.Item>
                       <label
                         className='create-project-radio-group-label text-body-small-bold'
-                        htmlFor='r2'
+                        htmlFor='r4'
                       >
                         {t['Single Team']}
                       </label>

--- a/src/components/CreateProjectDialog/CreateProjectDialog.tsx
+++ b/src/components/CreateProjectDialog/CreateProjectDialog.tsx
@@ -88,9 +88,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                     value === 'public' ? setOpenJoin(true) : setOpenJoin(false)
                   }
                 >
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div className='create-project-radio-group-item'>
                     <RadioGroup.Item
-                      className='create-project-radio-group-item'
+                      className='create-project-radio-group-button'
                       value='private'
                       id='r1'
                     >
@@ -110,9 +110,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                       ]
                     }
                   </div>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div className='create-project-radio-group-item'>
                     <RadioGroup.Item
-                      className='create-project-radio-group-item'
+                      className='create-project-radio-group-button'
                       value='public'
                       id='r2'
                     >
@@ -151,9 +151,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                         : setOpenEdit(true)
                     }
                   >
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <div className='create-project-radio-group-item'>
                       <RadioGroup.Item
-                        className='create-project-radio-group-item'
+                        className='create-project-radio-group-button'
                         value='assignments'
                         id='r1'
                       >
@@ -173,9 +173,9 @@ export const CreateProjectDialog = (props: CreateProjectDialogProps) => {
                         ]
                       }
                     </div>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <div className='create-project-radio-group-item'>
                       <RadioGroup.Item
-                        className='create-project-radio-group-item'
+                        className='create-project-radio-group-button'
                         value='single_team'
                         id='r2'
                       >

--- a/src/components/DocumentCard/DocumentCard.css
+++ b/src/components/DocumentCard/DocumentCard.css
@@ -26,25 +26,24 @@
   box-sizing: border-box;
   display: flex;
   height: 56px;
+  justify-content: space-between;
   width: 200px;
   line-height: 120%;
   flex-wrap: wrap;
-  padding: 8px;
+  padding: 12px 3px 12px 8px;
   position: relative;
   background-color: var(--gray-200);
 }
 
-.document-card-actions {
-  position: absolute;
-  top: 10px;
-  right: 1px;
+.document-card-actions button.unstyled.icon-only {
+  height: 38px;
+  width: 38px;
 }
 
 .document-card-name {
   font-family: Inter;
   font-size: 14px;
   font-weight: 500;
-  width: 90%;
   display: -webkit-box;
   line-clamp: 2;
   overflow: hidden;

--- a/src/components/DocumentCard/DocumentCard.css
+++ b/src/components/DocumentCard/DocumentCard.css
@@ -27,8 +27,9 @@
   display: flex;
   height: 56px;
   width: 200px;
+  line-height: 120%;
   flex-wrap: wrap;
-  padding-left: 8px;
+  padding: 8px;
   position: relative;
   background-color: var(--gray-200);
 }
@@ -41,7 +42,7 @@
 
 .document-card-name {
   font-family: Inter;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500;
   width: 90%;
   display: -webkit-box;

--- a/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/src/components/DocumentCard/DocumentCardActions.tsx
@@ -68,7 +68,7 @@ export const DocumentCardActions = (props: DocumentCardActionsProps) => {
           <button 
             className="unstyled icon-only"
             aria-label={`${t['Menu actions for document:']} ${props.document.name}`}>
-            <DotsThreeVertical weight="bold" size={20}/>
+            <DotsThreeVertical weight="bold" size={22}/>
           </button>
         </Trigger>
 

--- a/src/components/Notifications/Notifications.css
+++ b/src/components/Notifications/Notifications.css
@@ -17,8 +17,8 @@ button.unstyled.icon-only.notification-actions-trigger {
   height: 1tpx;
   line-height: 15px;
   position: absolute;
-  right: -5px;
-  top: -5px;
+  right: 0;
+  top: 0;
   width: 15px;
 }
 

--- a/src/components/OwnerPill/OwnerPill.css
+++ b/src/components/OwnerPill/OwnerPill.css
@@ -1,11 +1,17 @@
 .owner-pill {
-  width: 75px;
-  height: 24px;
-  border-radius: 12px;
-  gap: 4px;
+  align-items: center;
   background-color: var(--gray-200);
+  border-radius: 100vw;
   display: flex;
   flex-direction: row;
+  gap: 4px;
   justify-content: center;
-  align-items: center;
+  padding: 0 0.625rem 0 0.375rem;
+  line-height: 200%;
+}
+
+.owner-pill svg {
+  flex: 0 0 auto;
+  height: 14px;
+  width: 14px;
 }

--- a/src/components/Presence/PresenceStack.tsx
+++ b/src/components/Presence/PresenceStack.tsx
@@ -3,10 +3,10 @@ import type { PresentUser } from '@annotorious/react';
 import { animated, useTransition } from '@react-spring/web';
 import * as Popover from '@radix-ui/react-popover';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import { getDisplayName } from '@components/AnnotationDesktop';
 import { Avatar } from '@components/Avatar';
 
 import './PresenceStack.css';
-import { getDisplayName } from '@components/AnnotationDesktop';
 
 interface PresenceStackProps {
 

--- a/src/components/ProjectCard/JoinProjectDialog.css
+++ b/src/components/ProjectCard/JoinProjectDialog.css
@@ -2,17 +2,3 @@
   display: flex;
   justify-content: space-between;
 }
-
-.join-project-dialog-button-join {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--dark-blue);
-  color: var(--gray-100);
-}
-
-.join-project-dialog-button-cancel {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--gray-300);
-  color: var(--gray-900);
-}

--- a/src/components/ProjectCard/JoinProjectDialog.tsx
+++ b/src/components/ProjectCard/JoinProjectDialog.tsx
@@ -35,13 +35,13 @@ export const JoinProjectDialog = (props: JoinProjectDialogProps) => {
 
           <div className='join-project-dialog-button-container'>
             <button
-              className='join-project-dialog-button-cancel'
+              className='flat'
               onClick={props.onClose}
             >
               {t['Cancel']}
             </button>
             <button
-              className='join-project-dialog-button-join'
+              className='primary flat'
               onClick={props.onJoin}
             >
               {t['Join']}

--- a/src/components/ProjectCard/OpenJoin.css
+++ b/src/components/ProjectCard/OpenJoin.css
@@ -4,10 +4,3 @@
   flex-direction: row;
   justify-content: flex-end;
 }
-
-.open-join-button {
-  min-height: 34px;
-  height: 34px;
-  background-color: var(--dark-blue);
-  color: var(--gray-100);
-}

--- a/src/components/ProjectCard/OpenJoin.tsx
+++ b/src/components/ProjectCard/OpenJoin.tsx
@@ -15,9 +15,9 @@ export const OpenJoin = (props: OpenJoinProps) => {
 
   return (
     <div className='open-join-bar'>
-      <button className='open-join-button' onClick={props.onJoin}>
+      <button className='primary sm flat' onClick={props.onJoin}>
         <div>{t['Join']}</div>
-        <SignIn color='white' />
+        <SignIn size={16} />
       </button>
     </div>
   );

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -25,6 +25,8 @@
 }
 
 .project-card-body {
+  display: flex;
+  flex-direction: column;
   flex-grow: 1;
   padding: 15px 20px 5px 15px;
 }
@@ -65,8 +67,12 @@
 }
 
 .project-card-body ul.document-stats {
+  align-items: flex-end;
   color: var(--font-light);
+  display: flex;
+  flex-grow: 1;
   font-size: 11.5px;
+  justify-content: flex-end;
   list-style-type: none;
   margin: 0;
   padding: 0;

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -17,7 +17,7 @@
 }
 
 .project-card-header .owner-pill {
-  margin-right: 5px;
+  margin-right: -5px;
 }
 
 .project-card:hover {

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -16,6 +16,10 @@
   justify-content: space-between;
 }
 
+.project-card-header .owner-pill {
+  margin-right: 5px;
+}
+
 .project-card:hover {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px -2px rgba(0, 0, 0, 0.28);
 }

--- a/src/components/ToggleDisplay/ToggleDisplay.tsx
+++ b/src/components/ToggleDisplay/ToggleDisplay.tsx
@@ -3,24 +3,33 @@ import { SquaresFour, ListBullets } from '@phosphor-icons/react';
 
 import './ToggleDisplay.css';
 
-export type ToggleDisplayOptions = 'cards' | 'rows';
+export type ToggleDisplayValue = 'cards' | 'rows';
 
 interface ToggleDisplayProps {
-  display: ToggleDisplayOptions;
-  onChangeDisplay(display: ToggleDisplayOptions): void;
+
+  display: ToggleDisplayValue;
+
+  onChangeDisplay(display: ToggleDisplayValue): void;
+
 }
 
 export const ToggleDisplay = (props: ToggleDisplayProps) => {
+
+  // Note that the Radix toggle group can have a value of undefined.
+  // In our case, we want to emulate radio group behavior!
+  const onValueChange = (value?: string) => {
+    if (value)
+      props.onChangeDisplay(value as ToggleDisplayValue);
+  }
+
   return (
     <ToggleGroup.Root
       className='toggle-display-group'
       type='single'
       aria-label='Text alignment'
       value={props.display}
-      onValueChange={(value) =>
-        props.onChangeDisplay(value as ToggleDisplayOptions)
-      }
-    >
+      onValueChange={onValueChange}>
+
       <ToggleGroup.Item className='toggle-display-item' value='cards'>
         <SquaresFour size={16} />
       </ToggleGroup.Item>
@@ -29,5 +38,6 @@ export const ToggleDisplay = (props: ToggleDisplayProps) => {
         <ListBullets size={16} />
       </ToggleGroup.Item>
     </ToggleGroup.Root>
-  );
-};
+  )
+
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -50,3 +50,4 @@ const favicon = `/${config.branding.favicon}` || '/favicon.svg';
 </html>
 
 <style define:vars={{ siteColor, backgroundColor, textColor }}></style>
+

--- a/src/themes/default/button/index.css
+++ b/src/themes/default/button/index.css
@@ -110,6 +110,7 @@ button.icon-only {
   display: inline-flex;
   justify-content: center;
   min-width: auto;
+  padding: 0;
 }
 
 button.icon-only svg {

--- a/src/themes/default/button/unstyled.css
+++ b/src/themes/default/button/unstyled.css
@@ -26,13 +26,15 @@ button.unstyled:not(:disabled):hover {
 button.unstyled.icon-only {
   border: 2px solid transparent;
   border-radius: 50%;
-  width: 34px;
   height: 34px;
   outline: none;
-  padding: 2px;
+  padding: 0;
+  width: 34px;
 }
 
 button.unstyled.icon-only svg {
+  height: 100%;
   margin: 1px 0 0 0;
-  padding: 0;
+  padding: 0.5rem;
+  width: 100%;
 }

--- a/src/themes/default/dropdown/index.css
+++ b/src/themes/default/dropdown/index.css
@@ -96,6 +96,19 @@
   position: absolute;
 }
 
+.dropdown-divider {
+  border-top: 1px solid var(--gray-200);
+  margin: 0.25rem 0.5rem;
+}
+
+.dropdown-label {
+  color: var(--gray-500);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0.125rem 10px 0 10px;
+  margin: 0 5px;
+}
+
 @keyframes slideUpAndFade {
   from {
     opacity: 0;

--- a/src/themes/default/index.css
+++ b/src/themes/default/index.css
@@ -181,8 +181,10 @@ body {
   color: var(--gray-900);
   font-family: Inter, Arial, Helvetica, sans-serif;
   font-size: 16px;
+  height: 100%;
   line-height: 160%;
   margin: 0;
+  min-height: 100%;
   padding: 0;
 }
 

--- a/src/util/hooks/index.ts
+++ b/src/util/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useLocalStorageBackedState';

--- a/src/util/hooks/useLocalStorageBackedState.ts
+++ b/src/util/hooks/useLocalStorageBackedState.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export const useLocalStorageBackedState = <T>(key: string, defaultValue: T) => {
+
+  const [value, setValue] = useState<T>(defaultValue);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(key);
+
+    if (saved) {
+      try {
+        setValue(JSON.parse(saved) as T);
+      } catch (error) {
+        console.error('Error parsing stored state', error);
+      }
+    }
+  }, [key]);
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [value]);
+
+  return [value, setValue] as const;
+
+}


### PR DESCRIPTION
## In this PR

This PR adds a number of style and behavior fixes to the project page.

- Page layout refactoring: there are no more stacked `position: fixed` elements with hard-coded heights, making the layout more robust against different browser font & screen sizes.
- Removed leftover bottom margins (from the time when we still had a bottom bar) and made the page scroll as a whole, eliminating weird scroll/overflow problems (incl. #286).
- Adjusted paddings, borders and font sizes in various places, according to Figma design.
- Removed instances of hard-wired (e.g. button) widths and made sure button contents don't overflow, labels don't wrap and icons don't get squeezed to 0 size for longer labels (usually German translations).
- Added unfold animation when clicking the 'more' button on long project descriptions.

And some tiny tweaks to the main dashboard:

- Project Card: the icon row now stays at the bottom of the top section of the card. Previously, if any of the cards had a heading that wrapped around to a second line, the position of the icon row was wrong for all cards with a single-line heading.

__BEFORE:__

<img width="701" alt="Bildschirmfoto 2024-07-24 um 07 43 41" src="https://github.com/user-attachments/assets/41fe15e4-531f-454e-8370-961e2fb4f3b5">

__AFTER:__

<img width="701" alt="Bildschirmfoto 2024-07-24 um 07 43 04" src="https://github.com/user-attachments/assets/a4e975a6-6a4a-4854-a2d8-d470ec3211c2">


__Note that this PR is stacked on top of PR #226__

