### PR TITLE
IIIF View Improvements

### DIFF
--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -93,7 +93,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
   useEffect(() => {
     // The 'pages' sidebar should be open by default
     // in case of multi-page IIIF images
-    if (canvases.length > 0)
+    if (canvases.length > 1)
       setLeftPanelOpen(true);
   }, [canvases]);
 

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -90,6 +90,13 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     DrawingStyleExpression<ImageAnnotation>
   >(() => DEFAULT_STYLE);
 
+  useEffect(() => {
+    // The 'pages' sidebar should be open by default
+    // in case of multi-page IIIF images
+    if (canvases.length > 0)
+      setLeftPanelOpen(true);
+  }, [canvases]);
+
   const onChangeStyle = (style?: (a: SupabaseAnnotation) => Color) => {
     if (style) {
       const hse: DrawingStyleExpression<ImageAnnotation> = (
@@ -255,9 +262,10 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
 
         <main>
           <LeftDrawer
-            iiifCanvases={canvases}
             currentImage={currentImage}
+            defaultTab={canvases.length > 0 ? 'PAGES' : undefined}
             i18n={props.i18n}
+            iiifCanvases={canvases}
             layers={layers}
             layerNames={layerNames}
             open={leftPanelOpen}

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -263,7 +263,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
         <main>
           <LeftDrawer
             currentImage={currentImage}
-            defaultTab={canvases.length > 0 ? 'PAGES' : undefined}
             i18n={props.i18n}
             iiifCanvases={canvases}
             layers={layers}

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -36,7 +36,7 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
   const [tab, setTab] = useState<'FILTERS' | 'PAGES'>('FILTERS');
 
   useEffect(() => {
-    if (!props.open && props.iiifCanvases.length > 0)
+    if (!props.open && props.iiifCanvases.length > 1)
       setTab('PAGES');
   }, [props.iiifCanvases]);
 

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -55,7 +55,7 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
       className="anno-drawer ia-drawer ia-left-drawer"
       style={style}>
       <aside>
-        {props.iiifCanvases.length > 0 && (
+        {props.iiifCanvases.length > 1 && (
           <div className="tablist">
             <ul>
               <li 

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -13,8 +13,6 @@ interface LeftDrawerProps {
 
   currentImage?: string;
 
-  defaultTab?: 'FILTERS' | 'PAGES';
-
   i18n: Translations;
 
   iiifCanvases: Canvas[];
@@ -35,12 +33,12 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
 
   const { t } = props.i18n;
 
-  const [tab, setTab] = useState<'FILTERS' | 'PAGES'>(props.defaultTab || 'FILTERS');
+  const [tab, setTab] = useState<'FILTERS' | 'PAGES'>('FILTERS');
 
   useEffect(() => {
-    if (!props.open && props.defaultTab)
-      setTab(props.defaultTab);
-  }, [props.defaultTab]);
+    if (!props.open && props.iiifCanvases.length > 0)
+      setTab('PAGES');
+  }, [props.iiifCanvases]);
 
   const transition = useTransition([props.open], {
     from: { transform: 'translateX(-140px)', opacity: 0 },
@@ -57,23 +55,25 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
       className="anno-drawer ia-drawer ia-left-drawer"
       style={style}>
       <aside>
-        <div className="tablist">
-          <ul>
-            <li 
-              className={tab === 'FILTERS' ? 'active' : undefined}>
-              <button onClick={() => setTab('FILTERS')}>
-                <Faders size={18} /> {t['Filters']}
-              </button>
-            </li>
+        {props.iiifCanvases.length > 0 && (
+          <div className="tablist">
+            <ul>
+              <li 
+                className={tab === 'FILTERS' ? 'active' : undefined}>
+                <button onClick={() => setTab('FILTERS')}>
+                  <Faders size={18} /> {t['Filters']}
+                </button>
+              </li>
 
-            <li 
-              className={tab === 'PAGES' ? 'active' : undefined}>
-              <button onClick={() => setTab('PAGES')}>
-                <Files size={18} /> {t['Pages']}
-              </button>
-            </li>
-          </ul>
-        </div>
+              <li 
+                className={tab === 'PAGES' ? 'active' : undefined}>
+                <button onClick={() => setTab('PAGES')}>
+                  <Files size={18} /> {t['Pages']}
+                </button>
+              </li>
+            </ul>
+          </div>
+        )}
 
         <div className="tabcontent">
           {tab === 'FILTERS' ? (

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Faders, Files } from '@phosphor-icons/react';
 import type { Canvas } from '@allmaps/iiif-parser';
 import type { PresentUser } from '@annotorious/react';
@@ -12,6 +12,8 @@ import './LeftDrawer.css';
 interface LeftDrawerProps {
 
   currentImage?: string;
+
+  defaultTab?: 'FILTERS' | 'PAGES';
 
   i18n: Translations;
 
@@ -33,7 +35,12 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
 
   const { t } = props.i18n;
 
-  const [tab, setTab] = useState<'FILTERS' | 'PAGES'>('FILTERS');
+  const [tab, setTab] = useState<'FILTERS' | 'PAGES'>(props.defaultTab || 'FILTERS');
+
+  useEffect(() => {
+    if (!props.open && props.defaultTab)
+      setTab(props.defaultTab);
+  }, [props.defaultTab]);
 
   const transition = useTransition([props.open], {
     from: { transform: 'translateX(-140px)', opacity: 0 },


### PR DESCRIPTION
## In this PR

This PR makes small enhancements to the image annotation view. See also: https://github.com/performant-software/vico/issues/229

* In case of a multi-page IIIF presentation manifest, the thumbnail sidebar is open initially.
* In case of a single image, there is no more "Filters / Pages" tab. Only the filter panel is shown. (Previously, the Pages tab was available, but always empty.)