### PR TITLE
Quill: Rejecting Pasted Images > 64k

### DIFF
--- a/src/components/QuillEditor/QuillEditor.tsx
+++ b/src/components/QuillEditor/QuillEditor.tsx
@@ -1,5 +1,5 @@
 import Quill from 'quill';
-import { Delta, Op, type QuillOptions } from 'quill/core';
+import { Delta, type Op, type QuillOptions } from 'quill/core';
 import { useEffect, useRef } from 'react';
 import { useQuillEditor } from './QuillEditorRoot';
 import type { Translations } from 'src/Types';


### PR DESCRIPTION
## In this PR

This PR addresses issue https://github.com/performant-software/vico/issues/225.

Not sure if this is the best possible solution... Whenever the Quill editor content changes, Recogito now checks the `ops` for embedded Base64 images. If any are found that exceed a pre-defined size (currently hard-wired to 64k), these are filtered out, and the Quill editor content is replaced. In the UI, the effect is that the user can paste small images normally, while pasting an image that's too large will simply appear to do nothing.

__Update:__ To prevent the check from happening on every editor change, I tried to tie the logic to the paste event instead. But without success. (The default `addMatcher` mechanism to listen to and intercept changes didn't trigger for images, only for text - which I believe [may be a bug in Quill](https://github.com/slab/quill/issues/4337). And the `paste` event triggered before the image was actually inserted.) It looks like [others have reverted to the same approach before](https://github.com/slab/quill/issues/1108#issuecomment-410857732).

I therefore suggest we leave it at this for now, see whether there is a performance hit and/or we hear back from the Quill team, and revisit later, if so. (We could always listen to the paste event and evaluate after a `setTimeout`, as a fallback. But that seems messy.)