### PR TITLE
Account Settings Facelift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,19 +108,27 @@
       }
     },
     "node_modules/@annotorious/annotorious": {
-      "version": "3.0.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.29.tgz",
-      "integrity": "sha512-Snt/htM3fdjTipsIRBS+y29n8Npbmpaw4egMFdQxs+1/tlVFIXzgH3KxUNWYTgnlIQMLzXlTauHjjtYySBcOYA==",
+      "version": "3.0.0-rc.30",
+      "resolved": "https://registry.npmjs.org/@annotorious/annotorious/-/annotorious-3.0.0-rc.30.tgz",
+      "integrity": "sha512-XwnoEXpa7YnhPeVlyMVoUfVX1Pn4SCoJ9osjtRhdzua2qv5ziSEQ3238EBvRcfxWnXy9fnKXJWcQEbJsTWQA4Q==",
       "dependencies": {
-        "@annotorious/core": "3.0.0-rc.29",
-        "rbush": "^3.0.1",
+        "@annotorious/core": "3.0.0-rc.30",
+        "rbush": "^4.0.0",
         "uuid": "^10.0.0"
       }
     },
+    "node_modules/@annotorious/annotorious/node_modules/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-F5xw+166FYDZI6jEcz+sWEHL5/J+du3kQWkwqWrPKb6iVoLPZh+2KhTS4OoYqrw1v/RO1xQe6WsLwBvrUAlvXw==",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
     "node_modules/@annotorious/core": {
-      "version": "3.0.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.29.tgz",
-      "integrity": "sha512-C2xjeOmNwGaqnQXW5pKlQLFo8RkoQZK27XJ2F09KqJhbFpMYtyDztCxPM/7mHOJeCPHsr25zW8taDpeeZdWtsQ==",
+      "version": "3.0.0-rc.30",
+      "resolved": "https://registry.npmjs.org/@annotorious/core/-/core-3.0.0-rc.30.tgz",
+      "integrity": "sha512-2cCnrzx6XNMFfS7toH4tG9/9nI9AX5O+0hVxnHM6+xtqYdaLKY+hRWh4pPWtPEP6hODRKrwjCsJO42qr5wGbOg==",
       "dependencies": {
         "dequal": "^2.0.3",
         "nanoevents": "^9.0.0",
@@ -129,12 +137,12 @@
       }
     },
     "node_modules/@annotorious/openseadragon": {
-      "version": "3.0.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.29.tgz",
-      "integrity": "sha512-jTkHPNac/olqH81OUq+XhDq++Ar0MXEeOyz8H3VMv0U6CiWLB6/yvF0u2cNY0KAywrr0oF1egB1pYwdjwRQtgg==",
+      "version": "3.0.0-rc.30",
+      "resolved": "https://registry.npmjs.org/@annotorious/openseadragon/-/openseadragon-3.0.0-rc.30.tgz",
+      "integrity": "sha512-qWBrEjKp69P2HVPR9iAf9wb1vCWSbBBePpSRFr8u2VAWX9m/Op3kg9E9kfF01tV/ntcu22rGpJHmS/ELI3dD6w==",
       "dependencies": {
-        "@annotorious/annotorious": "3.0.0-rc.29",
-        "@annotorious/core": "3.0.0-rc.29",
+        "@annotorious/annotorious": "3.0.0-rc.30",
+        "@annotorious/core": "3.0.0-rc.30",
         "pixi.js": "^7.4.2",
         "uuid": "^10.0.0"
       },
@@ -143,13 +151,13 @@
       }
     },
     "node_modules/@annotorious/react": {
-      "version": "3.0.0-rc.29",
-      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-rc.29.tgz",
-      "integrity": "sha512-XFp5inVWERwoh+FJwkXoewSjJaWxRN2dsiALWspcMuEeD7PGftfKhAeeJiFMJkHgh2GYl5lss3lLA9W3Mc7Xmg==",
+      "version": "3.0.0-rc.30",
+      "resolved": "https://registry.npmjs.org/@annotorious/react/-/react-3.0.0-rc.30.tgz",
+      "integrity": "sha512-PU1EcMZaLYM+2HamzZA6/FSWr19kL93oVMPAIHWRNZ1XBL+Io73brnrlYOTIDiw8xx/03dLsYIBD9O7jpK3EjA==",
       "dependencies": {
-        "@annotorious/annotorious": "3.0.0-rc.29",
-        "@annotorious/core": "3.0.0-rc.29",
-        "@annotorious/openseadragon": "3.0.0-rc.29",
+        "@annotorious/annotorious": "3.0.0-rc.30",
+        "@annotorious/core": "3.0.0-rc.30",
+        "@annotorious/openseadragon": "3.0.0-rc.30",
         "@neodrag/react": "^2.0.4"
       },
       "peerDependencies": {
@@ -3733,9 +3741,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.5.tgz",
-      "integrity": "sha512-TEHlGwNGGmKPdeMtca1lFTYCedrhTAv3nZVoSjrKQ+wkMmaERuCe57zkC5KSWFzLYkb5FVHW8Hrr+PX1DDwplQ==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.2.tgz",
+      "integrity": "sha512-qyCQaNg90HmJstsvr2aJNxK2zgoKh9ZZA8oqb7UT2LCh3mj9zpa3Iwu167AuyNxsxrUE8eEJ2yH6wLCij4EApA==",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",
@@ -8465,9 +8473,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/linkedom": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.3.tgz",
-      "integrity": "sha512-z8i9nX5rbiO3keLJ+rJabVmJ/nCdYzQRONPU0L9c6buYErX5yxb0pQX+sWdX8r0QvpaZrjAtjM0scbX10xYH9Q==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.4.tgz",
+      "integrity": "sha512-JhLErxMIEOKByMi3fURXgI1fYOzR87L1Cn0+MI9GlMckFrqFZpV1SUGox1jcKtsKN3y6JgclcQf0FzZT//BuGw==",
       "dependencies": {
         "css-select": "^5.1.0",
         "cssom": "^0.5.0",

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -231,7 +231,6 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
           i18n={props.i18n}
           invitations={[]}
           me={props.me}
-          projects={[]}
           showNotifications={false}
           onError={() => setConnectionError(true)} />
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -204,7 +204,6 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
             i18n={props.i18n}
             invitations={[]}
             me={props.me}
-            projects={[]}
             showNotifications={false}
             onError={() => {}} />
 

--- a/src/apps/dashboard-account/AccountPreferences.css
+++ b/src/apps/dashboard-account/AccountPreferences.css
@@ -1,22 +1,29 @@
 .dashboard-account-preferences {
   font-size: var(--font-small);
+  margin-top: 60px;
 }
 
 .dashboard-account-preferences main {
   margin: 0 auto;
-  max-width: 900px;
-  padding: 30px 40px;
+  max-width: 65ch;
+  padding: 20px 40px;
 }
 
 .dashboard-account-preferences h2 {
-  margin-top: 3.5em;
+  margin-top: 3.5rem;
 } 
 
 .dashboard-account-preferences fieldset {
   margin-bottom: 2.5em;
 }
 
+.dashboard-account-preferences fieldset input {
+  flex-grow: 1;
+}
+
 .dashboard-account-preferences .field {
+  align-items: center;
+  font-weight: 500;
   margin: 0.6em 0;
 }
 
@@ -26,6 +33,7 @@
 }
 
 .dashboard-account-preferences .field input {
+  background-color: var(--gray-50);
   width: 320px;
 }
 
@@ -41,4 +49,18 @@
   margin: 0 8px 0 5px;
   vertical-align: top;
   width: 24px;
+}
+
+.dashboard-account-preferences .public-information-hint {
+  color: var(--font-light);
+  line-height: 170%;
+}
+
+.dashboard-account-preferences .actions {
+  display: flex;
+  justify-content: flex-end;
+} 
+
+.dashboard-account-preferences .actions button {
+  padding: 10px 24px;
 }

--- a/src/apps/dashboard-account/AccountPreferences.tsx
+++ b/src/apps/dashboard-account/AccountPreferences.tsx
@@ -6,7 +6,8 @@ import { supabase } from '@backend/supabaseBrowserClient';
 import { Avatar } from '@components/Avatar';
 import { Toast, ToastProvider } from '@components/Toast';
 import type { ToastContent } from '@components/Toast';
-import type { Translations, MyProfile } from 'src/Types';
+import { TopBar } from '@components/TopBar';
+import type { Translations, MyProfile, Invitation } from 'src/Types';
 import { getGravatar } from './getGravatar';
 
 import './AccountPreferences.css';
@@ -14,6 +15,8 @@ import './AccountPreferences.css';
 interface AccountPreferencesProps {
 
   i18n: Translations;
+
+  invitations: Invitation[];
 
   profile: MyProfile;
 
@@ -32,6 +35,13 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
   useEffect(() => {
     getGravatar(profile.email).then(setGravatar);
   }, []);
+
+  const onError = (error: string) =>
+    setError({
+      title: t['Something went wrong'],
+      description: t[error] || error,
+      type: 'error',
+    });
 
   const formik = useFormik({
     initialValues: {
@@ -63,6 +73,13 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
   return (
     <ToastProvider>
       <div className="dashboard-account-preferences">
+        <TopBar
+          i18n={props.i18n}
+          invitations={props.invitations}
+          onError={onError}
+          me={profile}
+          showNotifications={true} />
+
         <main>
           <a href={`/${lang}/projects`}>
             <ArrowLeft className="text-bottom" size={16} /><span>Back</span>

--- a/src/apps/dashboard-account/AccountPreferences.tsx
+++ b/src/apps/dashboard-account/AccountPreferences.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useFormik } from 'formik';
-import { ArrowLeft } from '@phosphor-icons/react';
 import { updateMyProfile } from '@backend/crud/profiles';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Avatar } from '@components/Avatar';
@@ -24,7 +23,7 @@ interface AccountPreferencesProps {
 
 export const AccountPreferences = (props: AccountPreferencesProps) => {
 
-  const { lang, t } = props.i18n;
+  const { t } = props.i18n;
 
   const { profile } = props;
 
@@ -61,14 +60,17 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
             type: 'error' 
           });
         } else {
-          setError({ 
-            title: t['Profile updated'], 
-            type: 'success' 
-          });
+          // Note: unlike window.history.back(), this also reloads the page.
+          // If we use .back(), the profile nag dialog would pop up again
+          // even if the user has just set a name.
+          window.location.href = document.referrer;
         }
       });
     }
   });
+
+  const onCancel = () => 
+    window.location.href = document.referrer;
 
   return (
     <ToastProvider>
@@ -81,9 +83,6 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
           showNotifications={true} />
 
         <main>
-          <a href={`/${lang}/projects`}>
-            <ArrowLeft className="text-bottom" size={16} /><span>Back</span>
-          </a>
           <h1>{t['Your User Profile']}</h1>
           <form onSubmit={formik.handleSubmit}>
             <fieldset>
@@ -116,9 +115,10 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
             </fieldset>
 
             <h2>{t['Public Information']}</h2>
-            <span>
+
+            <p className="public-information-hint">
               {t['Other users can see this information about you. All fields are optional.']}
-            </span>
+            </p>
 
             <fieldset>
               <div className="field">
@@ -170,7 +170,20 @@ export const AccountPreferences = (props: AccountPreferencesProps) => {
               </div>
             </fieldset>
 
-            <button className="primary" type="submit">Submit</button>
+            <div className="actions">
+              <button 
+                className="unstyled"
+                type="button"
+                onClick={onCancel}>
+                {t['Cancel']}
+              </button>
+              
+              <button 
+                className="primary" 
+                type="submit">
+                {t['Save']}
+              </button>
+            </div>
           </form>
         </main>
       </div>

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -189,7 +189,6 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
           invitations={invitations}
           i18n={props.i18n}
           onError={onError}
-          projects={projects}
           me={me}
           showNotifications={true}
           onInvitationAccepted={onInvitationAccepted}

--- a/src/apps/project-collaboration/ProjectCollaboration.tsx
+++ b/src/apps/project-collaboration/ProjectCollaboration.tsx
@@ -140,7 +140,6 @@ export const ProjectCollaboration = (props: ProjectCollaborationProps) => {
         invitations={props.invitations}
         i18n={props.i18n}
         onError={onError}
-        projects={props.projects}
         me={props.user}
       />
       <BackButtonBar

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -149,7 +149,6 @@ export const ProjectHome = (props: ProjectHomeProps) => {
         invitations={props.invitations}
         i18n={props.i18n}
         onError={onError}
-        projects={props.projects}
         me={props.user}
       />
 

--- a/src/apps/project-settings/ProjectSettings.tsx
+++ b/src/apps/project-settings/ProjectSettings.tsx
@@ -31,9 +31,9 @@ import './ProjectSettings.css';
 
 interface ProjectSettingsProps {
   invitations: Invitation[];
-  projects: ExtendedProjectData[];
 
   me: MyProfile;
+  
   i18n: Translations;
 
   project: ExtendedProjectData;
@@ -244,7 +244,6 @@ export const ProjectSettings = (props: ProjectSettingsProps) => {
         invitations={props.invitations}
         i18n={props.i18n}
         onError={onError}
-        projects={props.projects}
         me={props.me}
       />
       <BackButtonBar

--- a/src/apps/user-management/UserManagement.tsx
+++ b/src/apps/user-management/UserManagement.tsx
@@ -178,7 +178,6 @@ export const UserManagement = (props: UserManagementProps) => {
           invitations={[]}
           i18n={props.i18n}
           onError={(error) => console.log(error)}
-          projects={[]}
           me={props.me}
         />
         <div className='user-management-header'>

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -10,7 +10,6 @@
   z-index: 9999;
   position: fixed;
   top: 0;
-  width: 100%;
 }
 
 .top-bar-branding {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -12,10 +12,10 @@ import './TopBar.css';
 
 interface TopBarProps {
   i18n: Translations;
-  invitations: Invitation[];
-  me: MyProfile;
 
-  projects: ExtendedProjectData[];
+  invitations: Invitation[];
+
+  me: MyProfile;
 
   onError(error: string): void;
 

--- a/src/i18n/de/dashboard-account.json
+++ b/src/i18n/de/dashboard-account.json
@@ -2,15 +2,17 @@
   "Account Preferences": "Account Einstellungen",
   "Your User Profile": "Dein Benutzerprofil",
   "E-Mail": "E-Mail",
-  "We found a Gravatar for your address.": "Wir haben einen Gravatar für Deine Addresse gefunden.",
+  "We found a Gravatar for your address.": "Deine Adresse hat einen Gravatar.",
   "Use as my Avatar.": "Verwenden.",
   "Public Information": "Öffentliche Information",
-  "Other users can see this information about you. All fields are optional.": "Gib entweder einen Anzeigenamen oder einen Vor- und Nachnamen ein. Der eingegebene Name wird in den Annotationen angezeigt. Wenn Du sowohl einen Anzeigenamen als auch einen Vor- und Nachnamen eingibst, wird anderen Benutzern nur der Anzeigename angezeigt.",
+  "Other users can see this information about you. All fields are optional.": "Die angegebenen Namen sind für andere Benutzer sichtbar. Wenn Du sowohl einen Anzeigenamen als auch einen Vor- und Nachnamen eingibst, wird anderen Benutzern nur der Anzeigename angezeigt.",
   "Nickname": "Anzeigename",
   "First Name": "Vorname",
   "Last Name": "Nachname",
   "Avatar URL": "Avatar URL",
   "Profile updated": "Benutzerprofil aktualisiert",
   "Something went wrong": "Etwas ist falsch gelaufen",
-  "Could not update your profile information.": "Profilinformation konnte nicht aktualisiert werden."
+  "Could not update your profile information.": "Profilinformation konnte nicht aktualisiert werden.",
+  "Save": "Speichern",
+  "Cancel": "Abbrechen"
 }

--- a/src/i18n/de/index.ts
+++ b/src/i18n/de/index.ts
@@ -27,7 +27,7 @@ export default {
   'auth-forgot-password': authForgotPassword,
   'auth-login': authLogin,
   'auth-reset-password': authResetPassword,
-  'dashboard-account': { ...dashboardAccount },
+  'dashboard-account': { ...dashboardAccount, ...accountMenu },
   'dashboard-projects': {
     ...dashboardProjects,
     ...notifications,

--- a/src/i18n/en/dashboard-account.json
+++ b/src/i18n/en/dashboard-account.json
@@ -12,5 +12,7 @@
   "Avatar URL": "Avatar URL",
   "Profile updated": "Profile updated",
   "Something went wrong": "Something went wrong",
-  "Could not update your profile information.": "Could not update your profile information."
+  "Could not update your profile information.": "Could not update your profile information.",
+  "Save": "Save",
+  "Cancel": "Cancel"
 }

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -27,7 +27,7 @@ export default {
   'auth-forgot-password': authForgotPassword,
   'auth-login': authLogin,
   'auth-reset-password': authResetPassword,
-  'dashboard-account': { ...dashboardAccount },
+  'dashboard-account': { ...dashboardAccount, ...accountMenu },
   'dashboard-projects': {
     ...dashboardProjects,
     ...notifications,

--- a/src/pages/[lang]/account/me.astro
+++ b/src/pages/[lang]/account/me.astro
@@ -4,6 +4,7 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getTranslations } from '@i18n';
 import { getMyProfile } from '@backend/crud/profiles';
 import { AccountPreferences } from '@apps/dashboard-account/AccountPreferences';
+import { listMyInvites } from '@backend/crud';
 
 const i18n = getTranslations(Astro.request, 'dashboard-account');
 
@@ -13,10 +14,24 @@ const { error, data } = await getMyProfile(supabase);
 if (error || !data) {
   return Astro.redirect(`/${lang}/sign-in?redirect-to=${Astro.url.pathname}`);
 }
+
+const invitations = await listMyInvites(supabase);
+if (invitations.error || !invitations.data) {
+  const error = await fetch(`${Astro.url}/404`);
+  return new Response(error.body, {
+    headers: { 'Content-Type': 'text/html;charset=utf-8' },
+    status: 404,
+    statusText: 'Not Found',
+  });
+}
 ---
 
 <BaseLayout title={i18n.t['Account Preferences']}>
-  <AccountPreferences client:load i18n={i18n} profile={data} />
+  <AccountPreferences 
+    client:load 
+    i18n={i18n}
+    invitations={invitations.data}
+    profile={data} />
 </BaseLayout>
 
 <style>

--- a/src/pages/[lang]/projects/[project]/settings.astro
+++ b/src/pages/[lang]/projects/[project]/settings.astro
@@ -5,11 +5,7 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getMyProfile, listPendingInvitations } from '@backend/crud';
 import PluginRegistry from '@components/Plugins/PluginRegistry';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import {
-  getProjectExtended,
-  listMyProjectsExtended,
-  getInstalledPlugins,
-} from '@backend/helpers';
+import { getProjectExtended, getInstalledPlugins } from '@backend/helpers';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -35,8 +31,7 @@ if (project.error || !project.data) {
 }
 
 const invitations = await listPendingInvitations(supabase, projectId as string);
-
-if (project.error || invitations.error) {
+if (invitations.error || !invitations.data) {
   const error = await fetch(`${Astro.url}/404`);
   return new Response(error.body, {
     headers: { 'Content-Type': 'text/html;charset=utf-8' },
@@ -45,11 +40,11 @@ if (project.error || invitations.error) {
   });
 }
 
-const projects = await listMyProjectsExtended(supabase);
 const installedPlugins = await getInstalledPlugins(
   supabase,
   projectId as string
 );
+
 if (installedPlugins.error || !installedPlugins.data) {
   const error = await fetch(`${Astro.url}/500`);
   return new Response(error.body, { headers: error.headers, status: 500 });
@@ -62,7 +57,6 @@ if (installedPlugins.error || !installedPlugins.data) {
     project={project.data}
     invitations={invitations.data}
     me={profile.data}
-    projects={projects.data}
     availablePlugins={PluginRegistry.listAvailablePlugins()}
     installedPlugins={PluginRegistry.resolvePlugins(installedPlugins.data)}
   />


### PR DESCRIPTION
## In this PR

This PR provides a facelift to the Account Settings page.

- Added the branding TopBar component.
- Localized button labels.
- Removed the "Back" link at the top in favour of "Cancel" and "Save" buttons.
- Tweaked DE translation.
- Behavior: "Save" now saves & navigates back immediately. User no longer stays on the page after save.
- When going back (either by clicking "Cancel" or "Save") the browser now goes to the actual previous location, not to `/{lang}/projects`. (The hard-coded back link wasn't a problem previously. But after the UX changes, the user can now access the account settings page from anywhere across the app.)

There's also a bit of cleanup, removing unused code.

<img width="1552" alt="Bildschirmfoto 2024-07-25 um 09 42 13" src="https://github.com/user-attachments/assets/cc895001-5037-46bc-b503-e1e2163415f2">
