### PR TITLE
Rudimentary Rollback After Failed File Upload

### DIFF
--- a/src/apps/project-home/upload/useUpload.ts
+++ b/src/apps/project-home/upload/useUpload.ts
@@ -71,7 +71,6 @@ export const useUpload = (onImport: (document: Document) => void) => {
           supabase,
           i.name,
           i.projectId,
-          i.contextId,
           (progress) => onProgress(id, progress, 'uploading'),
           i.file,
           i.url,
@@ -80,8 +79,7 @@ export const useUpload = (onImport: (document: Document) => void) => {
           setDataDirty(true);
           onSuccess(id, document);
         })
-      )
-      .catch((error) => {
+      ).catch((error) => {
         onError(id, error);
       });
 

--- a/src/backend/helpers/projectHelpers.ts
+++ b/src/backend/helpers/projectHelpers.ts
@@ -204,7 +204,7 @@ export const getProjectExtended = (
 
         const groupIds = project.groups.map((g) => g.id);
 
-        console.log('Project: ', JSON.stringify(project, null, 2));
+        // console.log('Project: ', JSON.stringify(project, null, 2));
 
         return getProjectGroupMembers(supabase, groupIds).then(
           ({ error, data }) => {

--- a/src/backend/storage/supabase.ts
+++ b/src/backend/storage/supabase.ts
@@ -38,9 +38,15 @@ export const uploadFile = (
           onProgress && onProgress(progress);
         });
 
+        uppy.on('error', error => {
+          reject(error);
+        });
+
         uppy.upload().then(result => {
           resolve(result);
-        });
+        }).catch(error => {
+          reject(error);
+        })
       }
     }
   });


### PR DESCRIPTION
## In this PR

This PR adds a basic rollback mechanism that removes a document record, in case a subsequent file upload fails. It's not perfect though and could be improved, I think:

* In case of a failed upload, the `removeDocumentsFromProject` is called.
* This, in turn, uses the `archive_project_documents_rpc` RPC.
* Therefore, both the document record as well as other data (e.g. a row in `project_documents`, maybe more?) remain in the DB.
