### PR TITLE
Archiving documents from the document library

### DIFF
--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -17,7 +17,7 @@ import type {
 import { useState, useMemo } from 'react';
 import type { FileRejection } from 'react-dropzone';
 import { supabase } from '@backend/supabaseBrowserClient';
-import { setDocumentPrivacy } from '@backend/crud';
+import { archiveDocument, setDocumentPrivacy } from '@backend/crud';
 import { useDocumentList } from '@apps/project-home/useDocumentList';
 import { validateIIIF } from '@apps/project-home/upload/dialogs/useIIIFValidation';
 import type { ToastContent } from '@components/Toast';
@@ -164,6 +164,27 @@ export const DocumentsView = (props: DocumentsViewProps) => {
     );
   };
 
+  // This actually archives the document
+  const onDeleteDocumentFromLibrary = (document: Document) => {
+    archiveDocument(supabase, document.id).then(({ data }) => {
+      if (data) {
+        props.setToast({
+          title: t['Deleted'],
+          description: t['Document deleted successfully.'],
+          type: 'success',
+        });
+
+        setDocumentUpdated(true);
+      } else {
+        props.setToast({
+          title: t['Something went wrong'],
+          description: t['Could not delete the document.'],
+          type: 'error',
+        });
+      }
+    });
+  };
+
   const onTogglePrivate = (document: Document) => {
     setDocumentPrivacy(supabase, document.id, !document.is_private).then(() =>
       setDocumentUpdated(true)
@@ -264,7 +285,7 @@ export const DocumentsView = (props: DocumentsViewProps) => {
           disabledIds={documentIds}
           onUpdated={onUpdateDocument}
           onError={onError}
-          onDelete={onDeleteDocument}
+          onDeleteFromLibrary={onDeleteDocumentFromLibrary}
           onTogglePrivate={onTogglePrivate}
           isAdmin={props.isAdmin}
         />

--- a/src/backend/crud/documents.ts
+++ b/src/backend/crud/documents.ts
@@ -87,6 +87,29 @@ export const setDocumentPrivacy = (
     .single()
     .then(({ error, data }) => ({ error, data: data as Document }));
 
+export const archiveDocument = (
+  supabase: SupabaseClient,
+  documentId: string
+): Response<boolean> =>
+  supabase
+    .rpc('archive_document_rpc', {
+      _document_id: documentId,
+    })
+    .then(({ data }) => {
+      if (data) {
+        return {
+          error: null,
+          data: true,
+        };
+      }
+      return {
+        error: {
+          message: 'Failed to archive document',
+        } as PostgrestError,
+        data: false,
+      };
+    });
+
 export const getDocument = (
   supabase: SupabaseClient,
   documentId: string

--- a/src/components/DocumentLibrary/ConfirmDeleteDialog.tsx
+++ b/src/components/DocumentLibrary/ConfirmDeleteDialog.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from '@phosphor-icons/react';
+import { Button } from '@components/Button';
+import type { Translations } from 'src/Types';
+
+interface ConfirmDeleteDialogProps {
+  i18n: Translations;
+
+  open: boolean;
+
+  busy?: boolean;
+
+  title: string;
+
+  description: string;
+
+  cancelLabel: string | ReactNode;
+
+  confirmLabel: string | ReactNode;
+
+  onConfirm(): void;
+
+  onClose(): void;
+}
+
+import './DocumentLibrary.css';
+
+export const ConfirmDeleteDialog = (props: ConfirmDeleteDialogProps) => {
+  return (
+    <Dialog.Root open={props.open}>
+      <Dialog.Portal>
+        <Dialog.Overlay className='dialog-overlay doc-lib-confirm-overlay'>
+          <Dialog.Content className='dialog-content doc-lib-confirm-content'>
+            <Dialog.Title className='dialog-title'>{props.title}</Dialog.Title>
+
+            <Dialog.Description className='dialog-description'>
+              {props.description}
+            </Dialog.Description>
+
+            <footer className='dialog-footer'>
+              <Button
+                busy={props.busy}
+                className='danger'
+                onClick={props.onConfirm}
+              >
+                {props.confirmLabel}
+              </Button>
+              <button onClick={props.onClose}>{props.cancelLabel}</button>
+            </footer>
+            <button
+              className='unstyled icon-only dialog-close'
+              aria-label={props.i18n.t['Close']}
+              onClick={props.onClose}
+            >
+              <X />
+            </button>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/components/DocumentLibrary/DocumentActions.tsx
+++ b/src/components/DocumentLibrary/DocumentActions.tsx
@@ -118,7 +118,11 @@ export const DocumentActions = (props: DocumentActionsProps) => {
         open={confirming}
         i18n={props.i18n}
         title={t['Are you sure?']}
-        description={t['Are you sure you want to delete this document?']}
+        description={
+          t[
+            'Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed.'
+          ]
+        }
         cancelLabel={t['Cancel']}
         confirmLabel={
           <>

--- a/src/components/DocumentLibrary/DocumentActions.tsx
+++ b/src/components/DocumentLibrary/DocumentActions.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import * as Dropdown from '@radix-ui/react-dropdown-menu';
-import { ConfirmedAction } from '@components/ConfirmedAction';
+import { ConfirmDeleteDialog } from './ConfirmDeleteDialog';
 import type { Translations } from 'src/Types';
 import {
   DotsThreeVertical,
@@ -35,8 +35,17 @@ export const DocumentActions = (props: DocumentActionsProps) => {
 
   const [confirming, setConfirming] = useState(false);
 
+  const handleDelete = () => {
+    setConfirming(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    setConfirming(false);
+    props.onDelete!();
+  };
+
   return (
-    <ConfirmedAction.Root open={confirming} onOpenChange={setConfirming}>
+    <>
       <Root>
         <Trigger asChild>
           <button className='unstyled icon-only'>
@@ -46,7 +55,7 @@ export const DocumentActions = (props: DocumentActionsProps) => {
 
         <Portal>
           <Content
-            className='dropdown-content no-icons'
+            className='dropdown-content no-icons doc-lib-dropdown'
             sideOffset={5}
             align='start'
           >
@@ -71,12 +80,12 @@ export const DocumentActions = (props: DocumentActionsProps) => {
                     </span>
                   </Item>
                 )}
-                <ConfirmedAction.Trigger>
-                  <Item className='dropdown-item'>
+                {props.isPrivate && (
+                  <Item className='dropdown-item' onSelect={handleDelete}>
                     <Trash size={16} className='destructive' />{' '}
                     <span>{t['Delete document']}</span>
                   </Item>
-                </ConfirmedAction.Trigger>
+                )}
               </>
             ) : (
               <>
@@ -105,7 +114,8 @@ export const DocumentActions = (props: DocumentActionsProps) => {
         </Portal>
       </Root>
 
-      <ConfirmedAction.Dialog
+      <ConfirmDeleteDialog
+        open={confirming}
         i18n={props.i18n}
         title={t['Are you sure?']}
         description={t['Are you sure you want to delete this document?']}
@@ -115,8 +125,9 @@ export const DocumentActions = (props: DocumentActionsProps) => {
             <Trash size={16} /> <span>{t['Delete document']}</span>
           </>
         }
-        onConfirm={props.onDelete!}
+        onConfirm={handleDeleteConfirm}
+        onClose={() => setConfirming(false)}
       />
-    </ConfirmedAction.Root>
+    </>
   );
 };

--- a/src/components/DocumentLibrary/DocumentLibrary.css
+++ b/src/components/DocumentLibrary/DocumentLibrary.css
@@ -136,3 +136,11 @@
   padding: 25px;
   z-index: 9999;
 }
+
+.doc-lib-confirm-overlay {
+  z-index: 10000 !important;
+}
+
+.doc-lib-confirm-content {
+  z-index: 10100 !important;
+}

--- a/src/components/DocumentLibrary/DocumentLibrary.tsx
+++ b/src/components/DocumentLibrary/DocumentLibrary.tsx
@@ -56,7 +56,7 @@ export interface DocumentLibraryProps {
   UploadActions: React.ReactNode;
   onDocumentsSelected(documentIds: string[]): void;
   onUpdated(document: Document): void;
-  onDelete(document: Document): void;
+  onDeleteFromLibrary?(document: Document): void;
   onTogglePrivate(document: Document): void;
   onError(error: string): void;
   isAdmin: boolean | undefined;
@@ -341,7 +341,9 @@ export const DocumentLibrary = (props: DocumentLibraryProps) => {
           <DocumentActions
             i18n={props.i18n}
             onDelete={() =>
-              currentDocument ? props.onDelete(currentDocument) : {}
+              props.onDeleteFromLibrary
+                ? props.onDeleteFromLibrary(item as Document)
+                : {}
             }
             showPrivate={true}
             isPrivate={item.is_private}
@@ -388,7 +390,9 @@ export const DocumentLibrary = (props: DocumentLibraryProps) => {
           <DocumentActions
             i18n={props.i18n}
             onDelete={() =>
-              currentDocument ? props.onDelete(currentDocument) : {}
+              currentDocument && props.onDeleteFromLibrary
+                ? props.onDeleteFromLibrary(currentDocument)
+                : {}
             }
             isAdmin={item.created_by === props.user.id}
             onEditMetadata={() => {

--- a/src/i18n/de/project-home.json
+++ b/src/i18n/de/project-home.json
@@ -20,7 +20,7 @@
   "Deleted": "Entfernt",
   "Document deleted successfully.": "Das Dokument wurde erfolgreich aus dem Projekt entfernt.",
   "Are you sure?": "Bist Du sicher?",
-  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project? Only documents that are not used by active projects can be deleted.",
+  "Are you sure you want to delete this document?": "Bist Du sicher dass Du dieses Dokument aus dem Projekt entfernen willst? Dokumente können nur entfernt werden, wenn sie in in keinem aktiven Projekt verwendet werden.",
   "Edit Document Metadata": "Dokumentmetadaten",
   "Title": "Titel",
   "Author": "Autor",
@@ -72,5 +72,5 @@
   "Latest Revision": "Neueste Version",
   "Show More": "Mehr...",
   "Show Less": "Weniger...",
-  "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed.": "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed."
+  "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed.": "Bist Du sicher dass Du dieses Dokument entfernen möchtest? Dokumente können nur entfernt werden, wenn sie in in keinem aktiven Projekt verwendet werden."
 }

--- a/src/i18n/de/project-home.json
+++ b/src/i18n/de/project-home.json
@@ -20,7 +20,7 @@
   "Deleted": "Entfernt",
   "Document deleted successfully.": "Das Dokument wurde erfolgreich aus dem Projekt entfernt.",
   "Are you sure?": "Bist Du sicher?",
-  "Are you sure you want to delete this document?": "Bist Du sicher dass Du dieses Dokument aus dem Projekt entfernen willst?",
+  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project? Only documents that are not used by active projects can be deleted.",
   "Edit Document Metadata": "Dokumentmetadaten",
   "Title": "Titel",
   "Author": "Autor",

--- a/src/i18n/de/project-home.json
+++ b/src/i18n/de/project-home.json
@@ -71,5 +71,6 @@
   "Select Revision": "Version auswählen",
   "Latest Revision": "Neueste Version",
   "Show More": "Mehr...",
-  "Show Less": "Weniger..."
+  "Show Less": "Weniger...",
+  "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed.": "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed."
 }

--- a/src/i18n/en/project-home.json
+++ b/src/i18n/en/project-home.json
@@ -20,7 +20,7 @@
   "Deleted": "Removed",
   "Document deleted successfully.": "Document removed successfully.",
   "Are you sure?": "Are you sure?",
-  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project? Only documents that are not used by active projects can be deleted.",
+  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project?",
   "Edit Document Metadata": "Edit Document Metadata",
   "Title": "Title",
   "Author": "Author",
@@ -70,5 +70,6 @@
   "Select Revision": "Select Revision",
   "Latest Revision": "Latest Revision",
   "Show More": "Show More",
-  "Show Less": "Show Less"
+  "Show Less": "Show Less",
+  "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed.": "Are you sure you want to remove the document from the document library? Only documents that are not used by active projects can be removed."
 }

--- a/src/i18n/en/project-home.json
+++ b/src/i18n/en/project-home.json
@@ -20,7 +20,7 @@
   "Deleted": "Removed",
   "Document deleted successfully.": "Document removed successfully.",
   "Are you sure?": "Are you sure?",
-  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project?",
+  "Are you sure you want to delete this document?": "Are you sure you want to remove the document from this project? Only documents that are not used by active projects can be deleted.",
   "Edit Document Metadata": "Edit Document Metadata",
   "Title": "Title",
   "Author": "Author",


### PR DESCRIPTION
## In this PR

The remove document functionality in the document library did not actually do anything. This PR fixes that.

You can now remove (archive) documents that meet the following criterion:
- You are the owner of the document (created_by = you)
- Document is not used in any active projects.

addresses:  https://github.com/performant-software/vico/issues/303
