### PR TITLE
localStorage Persistence for Document Homepage State

### DIFF
--- a/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { GraduationCap } from '@phosphor-icons/react';
 import { archiveAssignment, getAssignment } from '@backend/helpers';
 import type { AvailableLayers } from '@backend/Types';
@@ -10,6 +10,7 @@ import { AssignmentDetail } from './AssignmentDetail';
 import { AssignmentsList } from './AssignmentsList';
 import { AssignmentWizard, contextToAssignmentSpec } from './Wizard';
 import type { AssignmentSpec } from './Wizard';
+import { useLocalStorageBackedState } from 'src/util/hooks';
 import type {
   Context,
   Document,
@@ -40,28 +41,31 @@ interface AssignmentsViewProps {
   setAssignments(assignemnts: Context[]): void;
 }
 
-export const AssignmentsView = (props: AssignmentsViewProps) => {
+export const AssignmentsView = (props: AssignmentsViewProps) => {  
   const { t } = props.i18n;
 
   const { project } = props;
 
   const [editing, setEditing] = useState<AssignmentSpec | undefined>();
 
-  const [currentAssignment, setCurrentAssignment] = useState<
-    Context | undefined
-  >();
+  const [currentAssignmentId, setCurrentAssignmentId] = useLocalStorageBackedState<string | undefined>(
+    `selected-assignment-${props.project.id}`, 
+    props.assignments && props.assignments.length > 0 ? props.assignments[0].id : undefined
+  );
+
+  const currentAssignment = useMemo(() => {
+    if (currentAssignmentId && props.assignments) {
+      return props.assignments.find(c => c.id === currentAssignmentId);
+    } else if (props.assignments && props.assignments.length > 0) {
+      return props.assignments[0];
+    }
+  }, [currentAssignmentId, props.assignments]);
 
   const NEW_ASSIGNMENT = {
     project_id: project.id,
     documents: [],
     team: [],
   };
-
-  useEffect(() => {
-    if (props.assignments && props.assignments.length > 0) {
-      setCurrentAssignment(props.assignments[0]);
-    }
-  }, [props.assignments]);
 
   const onAssignmentSaved = (spec: AssignmentSpec) => {
     const assignment = assignmentSpecToContext(spec);
@@ -123,9 +127,8 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
     });
   };
 
-  const handleAssignmentSelected = (assignment: Context) => {
-    setCurrentAssignment(assignment);
-  };
+  const handleAssignmentSelected = (assignment: Context) =>
+    setCurrentAssignmentId(assignment.id);
 
   return (
     <div className='project-assignments'>

--- a/src/apps/project-home/ProjectHome.tsx
+++ b/src/apps/project-home/ProjectHome.tsx
@@ -9,6 +9,7 @@ import { useAssignments } from '@backend/hooks';
 import type { AvailableLayers } from '@backend/Types';
 import { DocumentsView } from './DocumentsView';
 import { AssignmentsView } from './AssignmentsView';
+import { useLocalStorageBackedState } from 'src/util/hooks';
 import type {
   Context,
   Document,
@@ -48,9 +49,13 @@ export const ProjectHome = (props: ProjectHomeProps) => {
 
   const [toast, setToast] = useState<ToastContent | null>(null);
 
-  const [tab, setTab] = useState<'documents' | 'assignments' | undefined>();
   const [documents, setDocuments] = useState<Document[]>(props.documents);
+
   const [project, setProject] = useState(props.project);
+
+  const [tab, setTab] = useLocalStorageBackedState<'documents' | 'assignments' | undefined>(
+    `tab-${props.project.id}`, undefined
+  );
 
   const { assignments, setAssignments } = useAssignments(project);
 

--- a/src/util/hooks/useLocalStorageBackedState.ts
+++ b/src/util/hooks/useLocalStorageBackedState.ts
@@ -6,7 +6,7 @@ export const useLocalStorageBackedState = <T>(key: string, defaultValue: T) => {
 
   useEffect(() => {
     const saved = localStorage.getItem(key);
-
+    
     if (saved) {
       try {
         setValue(JSON.parse(saved) as T);
@@ -17,7 +17,10 @@ export const useLocalStorageBackedState = <T>(key: string, defaultValue: T) => {
   }, [key]);
 
   useEffect(() => {
-    localStorage.setItem(key, JSON.stringify(value));
+    if (value === undefined)
+      localStorage.removeItem(key);
+    else
+      localStorage.setItem(key, JSON.stringify(value));
   }, [value]);
 
   return [value, setValue] as const;


### PR DESCRIPTION
## In this PR

This PR makes the following two state variables in the Project Home view persistent via localStorage:
- Current tab (either "Documents" or "Assignments")
- Currently selected Assignment

If the user reloads the page, or returns from the annotation view, they will end up at the same tab, and with the same Assignment selected as they last left the page.

__Note:__ it's not a perfect solution though. If you leave the Project Home page via the "Back to Projects" link, you will later return to the persisted state. From a user perspective, you'd probably expect to enter into the initial state ("Documents" tab). In the long run, we should probably persist the state through URL params instead. This way, we can:
- Maintain state when reloading the page,
- Have a clean state when linking from the dashboard,
- Link back to a specific state from the annotation view.