### PR TITLE
Hotfix: Empty Assignment View After Delete

### DIFF
--- a/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
@@ -55,7 +55,7 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
 
   const currentAssignment = useMemo(() => {
     if (currentAssignmentId && props.assignments) {
-      return props.assignments.find(c => c.id === currentAssignmentId);
+      return props.assignments.find(c => c.id === currentAssignmentId) || props.assignments[0];
     } else if (props.assignments && props.assignments.length > 0) {
       return props.assignments[0];
     }


### PR DESCRIPTION
## In this PR

This PR fixes a bug that lead to an empty assignments view when 
- deleting an assignment
- returning to the assignments tab

For posterity: the reason was a but in the recently introduced "persistent page state" feature. When the user changes tabs (Document vs. Assignments) as well as the selected Assignment, these values are now persisted in the browser localStorage, so that the view is restored to the same page when the user refreshes or returns from the annotation view.

If the currently selected assignment is deleted, the persisted value points to a non-existing assignment ID. This bugfix makes sure that in this case, the view falls back to it's normal initial state, with the first assignment in the list becoming selected.