### PR TITLE
Fix for Bonn ENV var issue

### DIFF
--- a/src/backend/crud/projects.ts
+++ b/src/backend/crud/projects.ts
@@ -152,7 +152,7 @@ export const inviteUserToProject = (
             body: JSON.stringify(payload),
           })
             .then((res) => res.json())
-            .then(({ data }) => resolve(data as Invitation));
+            .then(({ data }) => resolve(data[0] as Invitation));
         }
       }
     });

--- a/src/pages/api/invite-user-to-project.ts
+++ b/src/pages/api/invite-user-to-project.ts
@@ -22,8 +22,6 @@ export const POST: APIRoute = async ({ request, cookies, url }) => {
   // Verify if the user is logged in
   const supabase = await createSupabaseServerClient(cookies);
 
-  console.log('Host: ', MAIL_HOST);
-
   const me = await getMyProfile(supabase);
 
   if (me.error || !me.data)

--- a/src/pages/api/invite-user-to-project.ts
+++ b/src/pages/api/invite-user-to-project.ts
@@ -9,9 +9,20 @@ import {
 } from '@usewaypoint/email-builder';
 import type { ApiPostInviteUserToProject } from 'src/Types';
 
+const MAIL_HOST = process.env.MAIL_HOST || import.meta.env.MAIL_HOST;
+const MAIL_PORT = process.env.MAIL_PORT || import.meta.env.MAIL_PORT;
+const MAIL_USERNAME =
+  process.env.MAIL_USERNAME || import.meta.env.MAIL_USERNAME;
+const MAIL_PASSWORD =
+  process.env.MAIL_PASSWORD || import.meta.env.MAIL_PASSWORD;
+const MAIL_FROM_ADDRESS =
+  process.env.MAIL_FROM_ADDRESS || import.meta.env.MAIL_FROM_ADDRESS;
+
 export const POST: APIRoute = async ({ request, cookies, url }) => {
   // Verify if the user is logged in
   const supabase = await createSupabaseServerClient(cookies);
+
+  console.log('Host: ', MAIL_HOST);
 
   const me = await getMyProfile(supabase);
 
@@ -152,17 +163,17 @@ export const POST: APIRoute = async ({ request, cookies, url }) => {
 
     const transporter = nodemailer.createTransport({
       // @ts-ignore
-      host: import.meta.env.MAIL_HOST,
-      port: import.meta.env.MAIL_PORT,
+      host: MAIL_HOST,
+      port: MAIL_PORT,
       tls: true,
       auth: {
-        user: import.meta.env.MAIL_USERNAME,
-        pass: import.meta.env.MAIL_PASSWORD,
+        user: MAIL_USERNAME,
+        pass: MAIL_PASSWORD,
       },
     });
 
     const mailOptions = {
-      from: import.meta.env.MAIL_FROM_ADDRESS,
+      from: MAIL_FROM_ADDRESS,
       to: user.email.toLowerCase(),
       subject: t['_you_have_been_invited_'],
       html: html,


### PR DESCRIPTION
## In this PR

Bonn is having issues with Invite Users to Project.  They were able to get email working process.env vs import.meta.env for passing ENV vars to the API.

However process.env does *not* work when running locally. This PR uses either method to try and ingest the vars.

* Additionally a bug with inviting a single user was addressed.