### PR TITLE
Bugfix: Broken CSV Exports for Baselayer Context

### DIFF
--- a/src/pages/[lang]/projects/[project]/export/csv.ts
+++ b/src/pages/[lang]/projects/[project]/export/csv.ts
@@ -78,9 +78,10 @@ const exportForProject = async (
   );
 }
 
-const exportForAssignment = async (
+const exportForContext = async (
   supabase: SupabaseClient, 
   url: URL, 
+  project: Project,
   contextId: string, 
   documentId: string | null,
   i18n: Translations
@@ -130,9 +131,11 @@ const exportForAssignment = async (
     includePrivate,
     i18n);
 
+  const assignmentName = assignment.data.name || project.name;
+
   const filename = documentId
-    ? `${sanitizeFilename(layers[0].document.name)}-assignment-${sanitizeFilename(assignment.data.name)}.csv`
-    : `${sanitizeFilename(assignment.data.name)}.csv`;
+    ? `${sanitizeFilename(layers[0].document.name)}-assignment-${sanitizeFilename(assignmentName)}.csv`
+    : `${sanitizeFilename(assignmentName)}.csv`;
 
   return new Response(    
     csv,
@@ -181,7 +184,7 @@ export const GET: APIRoute = async ({ cookies, params, request, url }) => {
   const contextId = url.searchParams.get('context');
 
   if (contextId) {
-    return exportForAssignment(supabase, url, contextId, documentId, i18n);
+    return exportForContext(supabase, url, project.data, contextId, documentId, i18n);
   } else {
     return exportForProject(supabase, url, project.data, documentId, i18n);
   }


### PR DESCRIPTION
## In this PR

This small PR fixes a bug reported by @jsmueller7 in our last meeting: the CSV export for the Baselayer Assignment returned an error. Turns out this was simply a matter of how the download filename got generated from the context name (which is `null` for the base context).