### PR TITLE
Annotation View Fixes

### DIFF
--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.css
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.css
@@ -16,4 +16,5 @@
 
 .anno-drawer.ia-left-drawer aside .tabcontent {
   flex: 1;
+  overflow-x: hidden;
 }

--- a/src/components/AnnotationDesktop/FilterPanel/Creators/useCreators.ts
+++ b/src/components/AnnotationDesktop/FilterPanel/Creators/useCreators.ts
@@ -1,14 +1,18 @@
 import { useMemo } from 'react';
 import { type PresentUser, useAnnotations } from '@annotorious/react';
-import { enumerateCreators } from '@components/AnnotationDesktop';
+import { enumerateCreators, useFilterSettingsState } from '@components/AnnotationDesktop';
 
 export const useCreators = (present: PresentUser[]) => {
 
   const annotations = useAnnotations(250);
 
+  const { layerSettings } = useFilterSettingsState();
+
+  const visibleLayers = layerSettings?.state;
+
   const creators = useMemo(() => (
-    enumerateCreators(present, annotations)
-  ), [present, annotations]);
+    enumerateCreators(present, annotations, visibleLayers)
+  ), [present, annotations, visibleLayers]);
 
   return creators;
 

--- a/src/components/AnnotationDesktop/FilterPanel/Tags/useTags.ts
+++ b/src/components/AnnotationDesktop/FilterPanel/Tags/useTags.ts
@@ -1,12 +1,17 @@
-import { useAnnotations, type AnnotationBody } from '@annotorious/react';
+import { useAnnotations } from '@annotorious/react';
 import { enumerateTags } from '@components/AnnotationDesktop/utils';
 import { useMemo } from 'react';
+import { useFilterSettingsState } from '../FilterState';
 
 export const useTags = () => {
 
   const annotations = useAnnotations(250);
 
-  const tags = useMemo(() => enumerateTags(annotations), [annotations]);
+  const { layerSettings } = useFilterSettingsState();
+
+  const visibleLayers = layerSettings?.state;
+
+  const tags = useMemo(() => enumerateTags(annotations, visibleLayers), [annotations, visibleLayers]);
 
   return tags;
 

--- a/src/components/AnnotationDesktop/utils.ts
+++ b/src/components/AnnotationDesktop/utils.ts
@@ -17,8 +17,13 @@ export const getDisplayName = (user?: PresentUser | User) => {
 }
 
 /** Determines the list of unique creators in the given annotation list **/
-export const enumerateCreators = (present: PresentUser[], annotations: SupabaseAnnotation[]) =>
-  annotations.reduce<User[]>((enumerated, a) => {
+export const enumerateCreators = (present: PresentUser[], annotations: SupabaseAnnotation[], visibleLayers?: string[]) => {
+  const layerIds = visibleLayers ? new Set(visibleLayers) : undefined;
+
+  return annotations.reduce<User[]>((enumerated, a) => {
+    // If there is a layer filter, ignore annotations outside of visible layers
+    if (layerIds && a.layer_id && !layerIds.has(a.layer_id)) return enumerated;
+    
     const presentCreator = present.find(p => p.id === a.target.creator?.id);
     if (presentCreator) {
       const exists = enumerated.find(u => u.id === presentCreator.id);
@@ -33,10 +38,16 @@ export const enumerateCreators = (present: PresentUser[], annotations: SupabaseA
       }
     }
   }, []);
+}
 
 /** Determines the list of unique tags in the given annotation list **/
-export const enumerateTags = (annotations: SupabaseAnnotation[]) => 
-  annotations.reduce<AnnotationBody[]>((enumerated, annotation) => {
+export const enumerateTags = (annotations: SupabaseAnnotation[], visibleLayers?: string[]) => {
+  const layerIds = visibleLayers ? new Set(visibleLayers) : undefined;
+
+  return annotations.reduce<AnnotationBody[]>((enumerated, annotation) => {
+    // If there is a layer filter, ignore annotations outside of visible layers
+    if (layerIds && annotation.layer_id && !layerIds.has(annotation.layer_id)) return enumerated;
+    
     const tags = annotation.bodies.filter(b => b.purpose === 'tagging');
     return [...enumerated, ...tags];
   }, [])
@@ -48,3 +59,4 @@ export const enumerateTags = (annotations: SupabaseAnnotation[]) =>
       return firstOccurrences;
     }
   }, [] as string[]);
+}


### PR DESCRIPTION
## In this PR

Two tiny fixes to the annotation view:
- Issue #266: __Creator__ and __Tag__ filters are now aware of the current layer filter.
- The IIIF thumbnail sidebar flickered, while caught in an endless loop showing & hiding the horizontal scrollbars. (See below.) This did not happen on all screen resolutions and browser window sizes. Frankly, I wasn't able to fully diagnose the issue. But it must be related to the JS-based sizing that's done by the virtual window library we're using to render only the visible portion of the thumbnail strip.

https://github.com/user-attachments/assets/8a3c39e6-850b-4d5a-b33c-f99034c92cd0

