### PR TITLE
Fix for availableLayers not updating when assignment is deleted

### DIFF
--- a/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
+++ b/src/apps/project-home/AssignmentsView/AssignmentsView.tsx
@@ -48,14 +48,20 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
 
   const [editing, setEditing] = useState<AssignmentSpec | undefined>();
 
-  const [currentAssignmentId, setCurrentAssignmentId] = useLocalStorageBackedState<string | undefined>(
-    `selected-assignment-${props.project.id}`, 
-    props.assignments && props.assignments.length > 0 ? props.assignments[0].id : undefined
-  );
+  const [currentAssignmentId, setCurrentAssignmentId] =
+    useLocalStorageBackedState<string | undefined>(
+      `selected-assignment-${props.project.id}`,
+      props.assignments && props.assignments.length > 0
+        ? props.assignments[0].id
+        : undefined
+    );
 
   const currentAssignment = useMemo(() => {
     if (currentAssignmentId && props.assignments) {
-      return props.assignments.find(c => c.id === currentAssignmentId) || props.assignments[0];
+      return (
+        props.assignments.find((c) => c.id === currentAssignmentId) ||
+        props.assignments[0]
+      );
     } else if (props.assignments && props.assignments.length > 0) {
       return props.assignments[0];
     }
@@ -99,11 +105,6 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
     });
 
   const onDeleteAssignment = (assignment: Context) => {
-    // Optimistic update: remove assignment from the list
-    props.setAssignments(
-      (props.assignments || []).filter((a) => a.id !== assignment.id)
-    );
-
     archiveAssignment(supabase, assignment.id as string).then((data) => {
       if (!data) {
         // Roll back
@@ -118,6 +119,9 @@ export const AssignmentsView = (props: AssignmentsViewProps) => {
           type: 'error',
         });
       } else {
+        props.setAssignments(
+          (props.assignments || []).filter((a) => a.id !== assignment.id)
+        );
         props.setToast({
           title: t['Deleted'],
           description: t['Assignment deleted successfully.'],

--- a/src/pages/[lang]/projects/[project]/index.astro
+++ b/src/pages/[lang]/projects/[project]/index.astro
@@ -40,8 +40,6 @@ if (project.error || !project.data) {
   });
 }
 
-console.log('Project: ', project.data);
-
 const user = project.data.users.find((u) => u.user.id === profile.data.id);
 
 if (!user && !profile.data.isOrgAdmin) {


### PR DESCRIPTION
## In this PR

When assignments are deleted, new assignments who the deleted assignment as an available layer. If that is chosen, the assignment is broken.  This PR moves the setAssignments call, which updates the availableLayers state, after the delete. This does require eliminating the previous optimistic update of assignments, but seems the safest and most expedient approach.