### PR TITLE
Exporting info.json URL to CSV

### DIFF
--- a/src/pages/[lang]/projects/[project]/export/csv.ts
+++ b/src/pages/[lang]/projects/[project]/export/csv.ts
@@ -7,6 +7,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { getTranslations } from '@i18n';
 import { sanitizeFilename } from 'src/util';
 import type {Project, Translations } from 'src/Types';
+
 import { 
   getAllDocumentLayersInProject, 
   getAllLayersInProject, 


### PR DESCRIPTION
## In this PR

When a CSV export includes image annotations, the URL for the images' `info.json` is now exported in a new column.

Note that ideally, we'd want to export the __canvas ID__ rather than the __info.json URL__. However that is not currently available in the annotation. Perhaps something we may need to revisit as part of the planned [IIIF export](https://github.com/performant-software/vico/issues/313) feature.