### PR TITLE
Bugfix: Fixes Missing 'Quill' Format Flag in Notes

### DIFF
--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/postgres/pgCrud.ts
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/postgres/pgCrud.ts
@@ -45,6 +45,7 @@ export const fetchNotes = (layerIds: string[]): Promise<DocumentNote[]> =>
             last_name,
             avatar:avatar_url
           ),
+          format,
           purpose,
           value,
           layer_id
@@ -107,6 +108,7 @@ export const insertNote = (note: DocumentNote) => {
         annotation_id: b.annotation,
         created_at: b.created,
         created_by: b.creator.id,
+        format: b.format,
         purpose: b.purpose,
         value: b.value,
         layer_id: b.layer_id

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/useNotes.ts
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/useNotes.ts
@@ -46,6 +46,7 @@ export const useNotes = () => {
         created: new Date(),
         creator: me,      
         purpose: 'commenting',        
+        format: 'Quill',
         value: JSON.stringify(text),
         layer_id: activeLayerId
       }, ...tags.map(tag => ({


### PR DESCRIPTION
## In this PR

This PR fixes the missing `format: "Quill"` flag for Notes annotations, which caused the CSV export to break. See also:
https://github.com/performant-software/vico/issues/323