### PR TITLE
Change to messaging for deleting a document from the Doc Library

### DIFF
--- a/src/i18n/de/project-home.json
+++ b/src/i18n/de/project-home.json
@@ -48,7 +48,7 @@
   "Something went wrong": "Etwas ist schiefgelaufen",
   "Could not create the document.": "Das Dokument konnte nicht erstellt werden.",
   "Could not rename the document.": "Das Dokument konnte nicht umbenannt werden.",
-  "Could not delete the document.": "Could not delete the document. Perhaps it is use in a current project?",
+  "Could not delete the document.": "Konnte nicht gelöscht werden. Möglicherweise wird das Dokument noch in einem Projekt verwendet.",
   "Document Library": "Dokumentenbibliothek",
   "Select a document or upload a new one.": "Wähle ein Dokument aus der Bibliothek, oder lade ein neues hoch. Achte darauf, die urheberrechtlichen Bestimmungen deines Landes einzuhalten!",
   "Add Document": "Dokumente Importieren",

--- a/src/i18n/de/project-home.json
+++ b/src/i18n/de/project-home.json
@@ -48,7 +48,7 @@
   "Something went wrong": "Etwas ist schiefgelaufen",
   "Could not create the document.": "Das Dokument konnte nicht erstellt werden.",
   "Could not rename the document.": "Das Dokument konnte nicht umbenannt werden.",
-  "Could not delete the document.": "Das Dokument konnte nicht gelöscht werden.",
+  "Could not delete the document.": "Could not delete the document. Perhaps it is use in a current project?",
   "Document Library": "Dokumentenbibliothek",
   "Select a document or upload a new one.": "Wähle ein Dokument aus der Bibliothek, oder lade ein neues hoch. Achte darauf, die urheberrechtlichen Bestimmungen deines Landes einzuhalten!",
   "Add Document": "Dokumente Importieren",

--- a/src/i18n/en/project-home.json
+++ b/src/i18n/en/project-home.json
@@ -48,7 +48,7 @@
   "Something went wrong": "Something went wrong",
   "Could not create the document.": "Could not create the document.",
   "Could not rename the document.": "Could not rename the document.",
-  "Could not delete the document.": "Could not delete the document.",
+  "Could not delete the document.": "Could not delete the document. Perhaps it is use in a current project?",
   "Document Library": "Document Library",
   "Select a document or upload a new one.": "Select a document or upload a new one. Be sure to follow your country's copyright restrictions.",
   "Add Document": "Add Document",


### PR DESCRIPTION
## In this PR

We had a bug found on one of our instances when a user deleted a private document from the document library that was being used by a project.  I have fixed the server code that allowed it, and this PR changes the messaging on a failed delete which may inform the user as to why.

** Will need the german updated.