### PR TITLE
Bugfix: De-duplicates Document List after Upload

### DIFF
--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -48,7 +48,9 @@ export const DocumentsView = (props: DocumentsViewProps) => {
   const [documentUpdated, setDocumentUpdated] = useState(false);
 
   const { addUploads, isIdle, uploads, dataDirty, clearDirtyFlag } = useUpload(
-    (documents) => props.setDocuments([...props.documents, ...documents])
+    (documents) => props.setDocuments([...props.documents, ...documents]
+        .reduce<Document[]>((all, document) => 
+          all.some(d => d.id === document.id) ? all : [...all, document], []))
   );
 
   const documentIds = useMemo(


### PR DESCRIPTION
## In this PR

This PR fixes a problem that caused duplicates in the Document list after uploading documents in multiple batches. (E.g. uploading one document, waiting for complete, uploading another one; instead of selecting multiple documents at once in the file picker, and uploading them as a single batch.)