### PR TITLE
Annotation View: Active Layer + Color Coding

### DIFF
--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -84,11 +84,17 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
       throw 'Fatal: document has no layers.';
 
     // Crash hard if there is no active layer
-    const activeLayer = documentLayers.find(l => l.is_active);
-    if (!activeLayer)
-      throw 'Fatal: missing active layer.';
+    const activeLayers = documentLayers.filter(l => l.is_active);
+    if (activeLayers.length === 0)
+      throw 'Fatal: active layer missing.';
 
-    return activeLayer;
+    // Crash hard if there is more than one active layer
+    if (activeLayers.length > 1) {
+      console.error(activeLayers);
+      throw `Fatal: more than one active layer (found ${activeLayers.length})`;
+    }
+
+    return activeLayers[0];
   }, [documentLayers]);
 
   const [tool, setTool] = useState<string | undefined>();

--- a/src/apps/annotation-image/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-image/Toolbar/Toolbar.tsx
@@ -183,6 +183,7 @@ export const Toolbar = (props: ToolbarProps) => {
         )}
 
         <ColorCodingSelector 
+          document={props.document}
           i18n={props.i18n} 
           present={props.present} 
           layers={props.layers}

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -58,13 +58,21 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
   const layerNames = useLayerNames(props.document, embeddedLayers);
 
-  const activeLayer = useMemo(
-    () =>
-      documentLayers && documentLayers.length > 0
-        ? documentLayers.find((l) => l.is_active) || documentLayers[0]
-        : undefined,
-    [documentLayers]
-  );
+  const activeLayer = useMemo(() => {
+    // Waiting for layers to load
+    if (!documentLayers) return;
+
+    // Crash hard if there is no layer (the error boundary will handle the UI message!)
+    if (documentLayers.length === 0)
+      throw 'Fatal: document has no layers.';
+
+    // Crash hard if there is no active layer
+    const activeLayer = documentLayers.find(l => l.is_active);
+    if (!activeLayer)
+      throw 'Fatal: missing active layer.';
+
+    return activeLayer;
+  }, [documentLayers]);
 
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -67,11 +67,17 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
       throw 'Fatal: document has no layers.';
 
     // Crash hard if there is no active layer
-    const activeLayer = documentLayers.find(l => l.is_active);
-    if (!activeLayer)
-      throw 'Fatal: missing active layer.';
+    const activeLayers = documentLayers.filter(l => l.is_active);
+    if (activeLayers.length === 0)
+      throw 'Fatal: active layer missing.';
 
-    return activeLayer;
+    // Crash hard if there is more than one active layer
+    if (activeLayers.length > 1) {
+      console.error(activeLayers);
+      throw `Fatal: more than one active layer (found ${activeLayers.length})`;
+    }
+
+    return activeLayers[0];
   }, [documentLayers]);
 
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);

--- a/src/apps/annotation-text/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-text/Toolbar/Toolbar.tsx
@@ -145,6 +145,7 @@ export const Toolbar = (props: ToolbarProps) => {
         )}
 
         <ColorCodingSelector 
+          document={props.document}
           i18n={props.i18n} 
           present={props.present} 
           layers={props.layers}

--- a/src/components/AnnotationDesktop/ColorCoding/ColorCodingSelector.tsx
+++ b/src/components/AnnotationDesktop/ColorCoding/ColorCodingSelector.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import * as Select from '@radix-ui/react-select';
 import type { PresentUser } from '@annotorious/react';
 import { CaretDown, Check, Palette } from '@phosphor-icons/react';
-import type { DocumentLayer, Translations, VocabularyTerm } from 'src/Types';
+import { useLocalStorageBackedState } from '@util/hooks';
+import type { DocumentLayer, DocumentWithContext, Translations, VocabularyTerm } from 'src/Types';
 import { useColorCodingState } from './ColorState';
 import { 
   useColorByCreator,
@@ -14,6 +15,8 @@ import {
 import './ColorCodingSelector.css';
 
 interface ColorCodingSelectorProps {
+
+  document: DocumentWithContext;
 
   i18n: Translations;
 
@@ -33,7 +36,11 @@ export const ColorCodingSelector = (props: ColorCodingSelectorProps) => {
 
   const { t } = props.i18n;
 
-  const [current, setCurrent] = useState<Coding | undefined>();
+  const persistenceKey = useMemo(() => 
+    `colorcoding-${props.document.context.id}-${props.document.id}`, 
+  [props.document])
+
+  const [current, setCurrent] = useLocalStorageBackedState<Coding | undefined>(persistenceKey, undefined);
 
   // TODO: this is actually super in-efficient! Doesn't make much
   // difference for now, but should be improved. Instead of hooks 
@@ -69,8 +76,8 @@ export const ColorCodingSelector = (props: ColorCodingSelectorProps) => {
 
   return (
     <Select.Root 
-      onValueChange={value => setCurrent(value as Coding)}
-      defaultValue="none">
+      value={current || 'none'}
+      onValueChange={value => setCurrent(value as Coding)}>
       <Select.Trigger 
         className="select-trigger color-coding-selector-trigger" 
         aria-label="Annotation color by">


### PR DESCRIPTION
## In this PR

This PR addresses two issues in the annotation view, raised in this week's call with the client:
- __Active layer:__ if no active layer is present in the current context/document, the annotation view used to silently fall back to the first available layer. Since this should never happen, the fallback was removed. Additionally, a check was introduced that verifies that: i) there are >0 layers, ii) there is exactly one active layer. If the check does not pass, a fatal error is thrown with a user-readable message.
- __Persistence for the color-coding setting:__ as requested by the client, the color-coding setting is now persisted to local storage. (Persistence is specific to the current context/document.)