### PR TITLE
"Copy Annotation Link" menu option

### DIFF
--- a/src/components/Annotation/AnnotationCardSection.tsx
+++ b/src/components/Annotation/AnnotationCardSection.tsx
@@ -240,34 +240,35 @@ export const AnnotationCardSection = (props: AnnotationCardSectionProps) => {
           {editable ? (
             <QuillEditorToolbar
               i18n={props.i18n} />
-          ) : canEdit ? (
+          ) : isPrivate ? (
             <div className="annotation-header-right">
-              {isPrivate ? (
-                <PrivateAnnotationActions
-                  i18n={props.i18n} 
-                  isFirst={props.index === 0}
-                  onCopyLink={onCopyLink}
-                  onDeleteAnnotation={props.onDeleteAnnotation}
-                  onDeleteSection={onDeleteSection}
-                  onEditSection={() => setEditable(true)}
-                  onMakePublic={props.onMakePublic}/>
-              ) : (
-                <PublicAnnotationActions 
-                  i18n={props.i18n} 
-                  isFirst={props.index === 0} 
-                  isMine={isMine}
-                  onCopyLink={onCopyLink}
-                  onDeleteAnnotation={props.onDeleteAnnotation}
-                  onDeleteSection={onDeleteSection}
-                  onEditSection={() => setEditable(true)} />
-              )}    
+              <PrivateAnnotationActions
+                i18n={props.i18n} 
+                isFirst={props.index === 0}
+                onCopyLink={onCopyLink}
+                onDeleteAnnotation={props.onDeleteAnnotation}
+                onDeleteSection={onDeleteSection}
+                onEditSection={() => setEditable(true)}
+                onMakePublic={props.onMakePublic}/>
             </div>
-          ) : (props.index === 0 && isReadOnly) && (
+          ) : (props.index === 0 && isReadOnly) ? (
             <div className="annotation-header-right">
               <LayerIcon 
                 i18n={props.i18n}
                 layerId={props.annotation.layer_id}
                 layerNames={props.layerNames} />
+            </div>
+          ) : (canEdit || props.index === 0) && (
+            <div className="annotation-header-right">
+              <PublicAnnotationActions 
+                canEdit={canEdit}
+                i18n={props.i18n} 
+                isFirst={props.index === 0} 
+                isMine={isMine}
+                onCopyLink={onCopyLink}
+                onDeleteAnnotation={props.onDeleteAnnotation}
+                onDeleteSection={onDeleteSection}
+                onEditSection={() => setEditable(true)} />
             </div>
           )}
         </div>

--- a/src/components/Annotation/PublicAnnotationActions.tsx
+++ b/src/components/Annotation/PublicAnnotationActions.tsx
@@ -6,6 +6,8 @@ import type { Translations } from 'src/Types';
 
 interface PublicAnnotationActionsProps {
 
+  canEdit?: boolean;
+
   i18n: Translations;
 
   isFirst: boolean;
@@ -58,36 +60,42 @@ export const PublicAnnotationActions = (props: PublicAnnotationActionsProps) => 
         <Dropdown.Portal>
           <Dropdown.Content asChild sideOffset={5} align="start" onClick={onClick}>
             <div className='dropdown-content no-icons'>
-              <Dropdown.Item
-                className='dropdown-item'
-                onSelect={props.onCopyLink}>
-                <LinkSimple size={16} />
-                <span>{t['Copy link to annotation']}</span>
-              </Dropdown.Item>
-
-              <Dropdown.Item
-                className='dropdown-item'
-                onSelect={withPrompt(props.onEditSection)}>
-                <Pencil size={16} /> 
-                {props.isFirst ? (
-                  <span>{t['Edit annotation']}</span>
-                ) : (
-                  <span>{t['Edit reply']}</span>
-                )}
-              </Dropdown.Item>
-
-              {props.isFirst ? (
+              {props.isFirst && (
                 <Dropdown.Item
                   className='dropdown-item'
-                  onSelect={withPrompt(props.onDeleteAnnotation)}>
-                  <Trash size={16} /> <span>{t['Delete annotation']}</span>
+                  onSelect={props.onCopyLink}>
+                  <LinkSimple size={16} />
+                  <span>{t['Copy link to annotation']}</span>
                 </Dropdown.Item>
-              ) : (
-                <Dropdown.Item
-                  className='dropdown-item'
-                  onSelect={withPrompt(props.onDeleteSection)}>
-                  <Trash size={16} /> <span>{t['Delete reply']}</span>
-                </Dropdown.Item>
+              )}
+
+              {props.canEdit && (
+                <>
+                  <Dropdown.Item
+                    className='dropdown-item'
+                    onSelect={withPrompt(props.onEditSection)}>
+                    <Pencil size={16} /> 
+                    {props.isFirst ? (
+                      <span>{t['Edit annotation']}</span>
+                    ) : (
+                      <span>{t['Edit reply']}</span>
+                    )}
+                  </Dropdown.Item>
+
+                  {props.isFirst ? (
+                    <Dropdown.Item
+                      className='dropdown-item'
+                      onSelect={withPrompt(props.onDeleteAnnotation)}>
+                      <Trash size={16} /> <span>{t['Delete annotation']}</span>
+                    </Dropdown.Item>
+                  ) : (
+                    <Dropdown.Item
+                      className='dropdown-item'
+                      onSelect={withPrompt(props.onDeleteSection)}>
+                      <Trash size={16} /> <span>{t['Delete reply']}</span>
+                    </Dropdown.Item>
+                  )}
+                </>
               )}
             </div>
           </Dropdown.Content>


### PR DESCRIPTION
## In this PR

This PR should address issue https://github.com/performant-software/vico/issues/349.

Some extra notes, because I believe the issue description isn't quite accurate.
- There was __no difference in behavior between popup vs. sidebar__. The issue was the same for both cases.
- There was no problem with __edit/delete options__. At least I could not reproduce a problem.

However, what __was__ broken is this:
- The three-dot context menu was only shown if you had edit permissions (creator/admin) on the annotation. Therefore,  you would not be able to access the "copy link" option - unless you were creator/admin.
- The "copy link" option was shown on all context menus, including those on replies. (Whereas we only want to show it in the top-most context menu, alongside the first comment.)

This PR makes the following fixes:
- The three-dot context menu is now __always__ shown. (Exception: read-only annotations. Probably less important, and we don't have a design for this. Right now, the "layer" icon occupies the space where otherwise the three-dot menu would be.)
- If you don't have edit permissions on the annotation, there is only a single menu option: "copy link". Creator/admins still get all options (copy link, edit comment, delete annotation).
- The "copy link" option is no longer shown in the reply-menus.