### PR TITLE
Improved Download Filename Sanitization

### DIFF
--- a/src/util/export/sanitizeFilename.ts
+++ b/src/util/export/sanitizeFilename.ts
@@ -7,9 +7,12 @@ export const sanitizeFilename = (unsafe: string) => {
     replacement: '_', 
     remove: /[*+~.()'"!:@]/g, 
     lower: false,
-    strict: false, 
+    strict: true, 
     locale: 'en'
   });
 
-  return sanitize(slugified);
+  // Additional safety net to remove or replace non-ASCII characters
+  const asciiOnly = slugified.replace(/[^\x00-\x7F]/g, '_');
+
+  return sanitize(asciiOnly);
 }


### PR DESCRIPTION
## In this PR

This PR fixes a hole in the download filename sanitization function.

__Context:__ filenames for exports (annotation CSV, TEI XML exports, etc.) are derived from the name of the project, assignment or source document. The catch: __special characters__ in the download filename will break the download! For example, having the (non-ASCII) em-dash character (with Unicode value 8212) in the filename, will cause Astro to fail with an error message like this:

```
Cannot convert argument to a ByteString because the character at index 61 has a value of 8212 which is greater than 255.
```

(This message is from a download for a TEI file named `1249: The Stars are old, that stood for me—`- note the trailing em-dash!)

I already had some filename sanitization built into our download code. However it turns out that the sanitization function didn't cover all non-ASCII characters. This PR improves the sanitization function to be more aggressive and strictly replace EVERYTHING that's non-ASCII.