### PR TITLE
"Notes" Sidebar Bugfixes

### DIFF
--- a/src/components/Annotation/AnnotationCardSection.tsx
+++ b/src/components/Annotation/AnnotationCardSection.tsx
@@ -125,7 +125,11 @@ export const AnnotationCardSection = (props: AnnotationCardSectionProps) => {
     }    
   }, [annotation, comment, index, present, tags]);
 
-  const isMine = creator?.id === me.id;
+  // Note that 'me' being undefined caused problems in the past, so we're 
+  // just being a little defensive here. Context: me is usually derived from 
+  // the (initialized) Annotorious user, which means it will be undefined 
+  // until annotations are loaded.
+  const isMine = creator?.id === me?.id;
 
   // Comments are editable if they are mine, or I'm a layer admin
   const canEdit = !isReadOnly && (isMine || props.policies?.get('layers').has('INSERT')) && !isProjectLocked;

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/DocumentNotes.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/DocumentNotes.tsx
@@ -62,13 +62,11 @@ export const DocumentNotes = (props: DocumentNotesProps) => {
   const [channel, setChannel] = useState<RealtimeChannel | undefined>();
 
   useEffect(() => {
-    if (embeddedNotes) setNotes(current => ([...current, ...embeddedNotes]));
-  }, [embeddedNotes]);
-
-  useEffect(() => {
     if (documentLayerIds) {
       fetchNotes(documentLayerIds)
-        .then(notes => setNotes(current => ([...current, ...notes])))
+        .then(notes => {
+          setNotes([...notes, ...(embeddedNotes || [])])
+        })
         .catch(onError);
 
       // Set up realtime channel
@@ -109,7 +107,7 @@ export const DocumentNotes = (props: DocumentNotesProps) => {
         setChannel(undefined);
       }
     }
-  }, [documentLayerIds, props.present]);
+  }, [embeddedNotes, documentLayerIds, props.present]);
 
   return (
     <DocumentNotesContext.Provider value={{ 

--- a/src/components/AnnotationDesktop/DocumentNotes/SortSelector/Sorting.ts
+++ b/src/components/AnnotationDesktop/DocumentNotes/SortSelector/Sorting.ts
@@ -1,11 +1,18 @@
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import type { DocumentNote } from '../Types';
 
 export type Sorter = (a: DocumentNote, b: DocumentNote) => number;
 
-const Newest = (a: DocumentNote, b: DocumentNote) =>
-  b.created_at.getTime() - a.created_at.getTime();
+const Newest = (a: DocumentNote | SupabaseAnnotation, b: DocumentNote | SupabaseAnnotation) => {
+  const createdA = 'created_at' in a ? a.created_at : a.target.created;
+  const createdB = 'created_at' in b ? b.created_at : b.target.created;
+  return createdA && createdB ? createdB.getTime() - createdA.getTime() : 0;
+}
 
-const Oldest = (a: DocumentNote, b: DocumentNote) =>
-  a.created_at.getTime() - b.created_at.getTime();
+const Oldest = (a: DocumentNote | SupabaseAnnotation, b: DocumentNote | SupabaseAnnotation) => {
+  const createdA = 'created_at' in a ? a.created_at : a.target.created;
+  const createdB = 'created_at' in b ? b.created_at : b.target.created;
+  return createdA && createdB ? createdA.getTime() - createdB.getTime() : 0;
+}
 
 export const Sorting = { Newest, Oldest };

--- a/src/pages/[lang]/projects/[project]/export/pdf.ts
+++ b/src/pages/[lang]/projects/[project]/export/pdf.ts
@@ -170,9 +170,9 @@ const exportForAssignment = async (
   );
 }
 
-export const GET: APIRoute = async ({ params, cookies, url }) => {
+export const GET: APIRoute = async ({ request, params, cookies, url }) => {
   // Verify if the user is logged in
-  const supabase = await createSupabaseServerClient(cookies);
+  const supabase = await createSupabaseServerClient(request, cookies);
 
   const projectId = params.project!;
 


### PR DESCRIPTION
### In this PR

This PR fixes a set of bugs discovered recently on the Pelagios instance.

With this PR:
- The Notes list no longer displays duplicates.
- Sorting the Notes list no longer causes a crash if the document includes embedded notes.
- If the initial page configuration is set to `rtab=notes`, the interface no longer crashes. (This was due to a Nullpointer caused by a race condition, where the Notes list was rendered before the annotation interface was fully initialized.)