### PR TITLE
Fix for SSO and Keycloak redirects

### DIFF
--- a/src/apps/auth-login/Login.tsx
+++ b/src/apps/auth-login/Login.tsx
@@ -94,8 +94,7 @@ export const Login = (props: {
       })
       .then(({ data, error }) => {
         if (data?.url) {
-          localStorage.removeItem('redirect-to');
-          window.location.href = `${data.url}?next=${redirectUrl || '/'}`;
+          window.location.href = data.url;
         } else {
           console.error(error);
         }
@@ -113,8 +112,7 @@ export const Login = (props: {
       })
       .then(({ data, error }) => {
         if (data?.url) {
-          localStorage.removeItem('redirect-to');
-          window.location.href = `${data.url}?next=${redirectUrl || '/'}`;
+          window.location.href = data.url;
         } else {
           console.error(error);
         }

--- a/src/components/CheckRedirect/CheckRedirect.tsx
+++ b/src/components/CheckRedirect/CheckRedirect.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+export const CheckRedirect = () => {
+  useEffect(() => {
+    const redirectUrl = localStorage.getItem('redirect-to');
+
+    if (redirectUrl && redirectUrl.length > 0) {
+      localStorage.removeItem('redirect-to');
+      window.location.href = redirectUrl;
+    }
+  }, []);
+
+  return <div />;
+};

--- a/src/components/CheckRedirect/index.ts
+++ b/src/components/CheckRedirect/index.ts
@@ -1,0 +1,1 @@
+export * from './CheckRedirect';

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -5,6 +5,7 @@ import { getMyProfile, listMyInvites } from '@backend/crud';
 import { ProjectsHome } from '@apps/dashboard-projects';
 import { listMyProjectsExtended } from '@backend/helpers';
 import BaseLayout from '@layouts/BaseLayout.astro';
+import { CheckRedirect } from '@components/CheckRedirect';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -30,6 +31,7 @@ if (!projects.data || !invitations.data) {
 ---
 
 <BaseLayout title='Dashboard'>
+  <CheckRedirect client:only='react' />
   <ProjectsHome
     client:only='react'
     me={me.data}

--- a/src/pages/auth/callback.ts
+++ b/src/pages/auth/callback.ts
@@ -6,8 +6,6 @@ export const GET: APIRoute = async ({ request, cookies, redirect, url }) => {
   const code = requestUrl.searchParams.get('code');
   const next = requestUrl.searchParams.get('next') || '/';
 
-  console.log('In callback, url = ', url, ', next = ', next);
-
   if (code) {
     const supabase = createServerClient(
       import.meta.env.PUBLIC_SUPABASE,


### PR DESCRIPTION
# Summary

With the PKCE implementation, the old redirect methods no longer work for SSO and Keycloak logins.  We now have to use the redirect options for calling the server-side key verifications. Since clients are redirected to `/{lang}/projects` by default, this PR adds a check on that route as to whether there is an active redirects and then executes the redirect. 