### PR TITLE
TEI Dowload: Exporting Tags as Taxonomy Element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recogito-client",
-  "version": "1.0.0.beta.6",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recogito-client",
-      "version": "1.0.0.beta.6",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@allmaps/iiif-parser": "1.0.0-beta.40",
@@ -55,6 +55,7 @@
         "formik": "2.4.6",
         "linkedom": "0.18.5",
         "moment": "^2.30.1",
+        "nanoid": "^5.0.9",
         "nodemailer": "^6.9.16",
         "openseadragon": "4.0.0",
         "papaparse": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "formik": "2.4.6",
     "linkedom": "0.18.5",
     "moment": "^2.30.1",
+    "nanoid": "^5.0.9",
     "nodemailer": "^6.9.16",
     "openseadragon": "4.0.0",
     "papaparse": "5.4.1",

--- a/public/tei.css
+++ b/public/tei.css
@@ -2,6 +2,10 @@ tei-standoff {
   display: none;
 }
 
+tei-taxonomy {
+  display: none;
+}
+
 tei-div[subtype="chapter"]::before {
   content: "Chapter " attr(n);
 }

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -114,10 +114,10 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
           responsible: users.find(u => u.id === normalizeId(noteEl.getAttribute('resp')))
         }) as Note);
 
-        const tags: string[] = Array.from(el.querySelectorAll('rs[ana]'))
-          .reduce<string[]>((all, el) => [...all, ...el.getAttribute('ana')!.split(' ')], [])
-          .map(resolveTag);
-
+        const tags: string[] = el.hasAttribute('ana') 
+          ? el.getAttribute('ana')!.split(' ').map(resolveTag)
+          : [];
+          
         const created = changes.find(c => c.status === 'created');
         const updated = changes.find(c => c.status === 'modified');
 

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -80,9 +80,7 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
 
     const standoffElements = doc.querySelectorAll('TEI > standOff');
 
-    console.log('parsing taxonomies');
     const taxonomyLookup = parseTaxonomies(doc.querySelectorAll('taxonomy'));
-    console.log(taxonomyLookup);
 
     // Helper
     const resolveTag = (id: string) => taxonomyLookup[id.startsWith('#') ? id.substring(1) : id] || id;

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -32,10 +32,40 @@ interface Change {
 
 }
 
-// Shorthands
+// Helpers
 const normalizeId = (id?: string | null) => id?.startsWith('#') ? id.substring(1) : id;
 
 const parseDate = (date?: string | null) => date ? new Date(date) : undefined;
+
+const parseTaxonomies = (elements: NodeListOf<Element>) => {
+  const lookupTable: Record<string, string> = {};
+
+  // We don't export nested taxonomies yet, but may in the future!
+  const walkCategories = (categoryEl: Element) => {
+    const childCategories = Array.from(categoryEl.children)
+      .filter(child => child.tagName.toLowerCase() === 'category');
+
+    if (childCategories.length === 0) {
+      // Leaf node -> this is a tag
+      const id = categoryEl.getAttribute('xml:id');
+      const label = categoryEl.querySelector('catDesc');
+        
+      if (id && label)
+            lookupTable[id] = label.textContent?.trim() || id;
+      
+      return;
+    }
+
+    childCategories.forEach(walkCategories);
+  }
+
+  // Start traversal from the root taxonomy element
+  Array.from(elements).forEach(element => {
+    walkCategories(element);
+  });
+
+  return lookupTable;
+}
 
 export const useEmbeddedTEIAnnotations = (xml?: string) => {
 
@@ -49,6 +79,13 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
     const doc = parser.parseFromString(xml, 'text/xml');
 
     const standoffElements = doc.querySelectorAll('TEI > standOff');
+
+    console.log('parsing taxonomies');
+    const taxonomyLookup = parseTaxonomies(doc.querySelectorAll('taxonomy'));
+    console.log(taxonomyLookup);
+
+    // Helper
+    const resolveTag = (id: string) => taxonomyLookup[id.startsWith('#') ? id.substring(1) : id] || id;
 
     const annotationLists = Array.from(standoffElements).reduce<AnnotationList[]>((lists, standoffEl, idx) => {
       const layerId =  standoffElements.length > 1 ? `tei_standoff_${idx + 1}` : 'tei_standoff';
@@ -80,7 +117,8 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
         }) as Note);
 
         const tags: string[] = Array.from(el.querySelectorAll('rs[ana]'))
-          .reduce<string[]>((all, el) => [...all, ...el.getAttribute('ana')!.split(' ')],[]);
+          .reduce<string[]>((all, el) => [...all, ...el.getAttribute('ana')!.split(' ')], [])
+          .map(resolveTag);
 
         const created = changes.find(c => c.status === 'created');
         const updated = changes.find(c => c.status === 'modified');

--- a/src/apps/annotation-text/LeftDrawer/LeftDrawer.css
+++ b/src/apps/annotation-text/LeftDrawer/LeftDrawer.css
@@ -2,6 +2,7 @@
   flex-grow: 0;   
   flex-shrink: 0; 
   flex-basis: 0;
+  overflow-x: hidden;
   position: relative;
   scroll-padding: 40px;
   z-index: 9;
@@ -11,5 +12,5 @@
   position: absolute;
   top: 5px;
   left: 0;
-  width: 240px;
+  width: 280px;
 }

--- a/src/apps/annotation-text/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-text/LeftDrawer/LeftDrawer.tsx
@@ -23,7 +23,7 @@ export const LeftDrawer = (props: LeftDrawerProps) => {
 
   const transition = useTransition([props.open], {
     from: { flexBasis: 0, opacity: 0 },
-    enter: { flexBasis: 240, opacity: 1 },
+    enter: { flexBasis: 280, opacity: 1 },
     leave: { flexBasis: 0, opacity: 0 },
     config: {
       duration: 350,

--- a/src/components/Annotation/TagList.css
+++ b/src/components/Annotation/TagList.css
@@ -9,6 +9,10 @@
   padding: 0 0 10px 0; 
 }
 
+.annotation .taglist button {
+  height: auto;
+}
+
 .annotation .taglist.editable {
   padding-bottom: 0;
 }

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -214,9 +214,7 @@ export const mergeAnnotations = (xml: string, annotations: SupabaseAnnotation[])
     // If there are any tags, create one rs element and add them as the ana attribute
     const tags = a.bodies.filter(b => b.purpose === 'tagging' && b.value);
     if (tags.length > 0) {
-      const rsEl = document.createElement('rs');
-      rsEl.setAttribute('ana', tags.map(b => `#${taxonomy[b.value!]}`).join(' '))
-      annotationEl.appendChild(rsEl);
+      annotationEl.setAttribute('ana',tags.map(b => `#${taxonomy[b.value!]}`).join(' '));
     }
 
     // Append respStmt elements for each contributing user

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -6,7 +6,7 @@ import type { User } from '@annotorious/react';
 import { quillToPlainText } from '../serializeQuillComment';
 
 // Helper
-const generateRandomRoomId = (alreadyInUse: Set<string>) => {
+const generateRandomId = (alreadyInUse: Set<string>) => {
   const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvw', 14);
 
   let tries = 0;
@@ -75,7 +75,7 @@ const createTaxonomy = (annotations: SupabaseAnnotation[], document: any) => {
   const existingTaxonomyIds = new Set([...existingTaxonomies].map(el => el.getAttribute('xml:id')));
 
   // TODO verify if the generated ID already exists in the header
-  const taxonomyId = generateRandomRoomId(existingTaxonomyIds);
+  const taxonomyId = generateRandomId(existingTaxonomyIds);
 
   const distinctTags = new Set(annotations.reduce<string[]>((all, annotation) => {
     const tagBodies = (annotation.bodies || []).filter(b => b.purpose === 'tagging' && b.value);

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -73,8 +73,6 @@ const createTaxonomy = (annotations: SupabaseAnnotation[], document: any) => {
   const existingTaxonomies = teiHeader ? teiHeader.querySelectorAll('taxonomy') : [];
 
   const existingTaxonomyIds = new Set([...existingTaxonomies].map(el => el.getAttribute('xml:id')));
-
-  // TODO verify if the generated ID already exists in the header
   const taxonomyId = generateRandomId(existingTaxonomyIds);
 
   const distinctTags = new Set(annotations.reduce<string[]>((all, annotation) => {


### PR DESCRIPTION
## In this PR

This PR changes the way tags are exported in the TEI download. 

__The problem:__ for each annotation, tags used to be exported as an `<rs>` element with an `@ana` attribute that simply joined the tag labels. Therefore, tags that included whitespace would break the export:

`<rs ana="TagA TagB My Tag With Whitespace"/>`

__This PR makes the following changes:__

- A `taxonomy` element is created in the `teiHeader`, which lists all distinct tags in the document, and assigns them (random) IDs.
- The `@ana` attribute now references the IDs instead of the tag labels.
- The `@ana` attribute is now on the annotation directly, not on an extra `rs` element.

__Additional Notes:__

- If there is no `teiHeader` in the document, a header is created and inserted automatically.
- If there are existing `taxonomy` elements in the document, a new `taxonomy` is appended after them.
- The new taxonomy gets a (random) `xml:id` assigned during export. The export verifies that this ID is unique, and not used by another `taxonomy` in the document yet.
- Tag ids have the form `{taxonomy-id}.{random-tag-id}`.
- In the annotation view, when annotations are parsed from the embedded layers, their tag labels are resolved against the taxonomies in the document.
- A new rule was added to the CSS stylesheet to hide TEI `taxonomy` elements in the annotation view.

