### PR TITLE
Annotation View Fixes

### DIFF
--- a/src/components/Annotation/AnnotationCard.tsx
+++ b/src/components/Annotation/AnnotationCard.tsx
@@ -62,32 +62,11 @@ const getCreator = (annotation: SupabaseAnnotation) =>
 
 /**
  * Per convention, we only support tags created along with the first comment.
- * This means:
- * - only the creator of the annotation can be the creator of tags,
- * - but they could be anywhere in the ordered list of bodies, because the
- *   creator might have added them later, while editing the initial comment.
- * 
- * Apply some basic sanity checking here! 
+ * But they could be anywhere in the ordered list of bodies, because the
+ * creator (or an admin user) might have added them later, when editing the initial comment.
  */
-const getTags = (annotation: SupabaseAnnotation) => {
-  const allTags = annotation
-    .bodies.filter(b => b.purpose === 'tagging');
-  
-  const creator = getCreator(annotation);
-  if (creator) {
-    const byCreator = allTags
-      .filter(b => b.creator?.id === creator?.id);
-
-    if (allTags.length !== byCreator.length)
-      console.warn('Integrity warning: annotation has tags not created by annotation creator', annotation);
-
-    return byCreator;
-  } else {
-    // Edge case: embedded Annotations (TEI!) could be without
-    // creator. In this case, just add all tags.
-    return allTags;
-  }
-}
+const getTags = (annotation: SupabaseAnnotation) =>
+  annotation.bodies.filter(b => b.purpose === 'tagging');
 
 export const AnnotationCard = (props: AnnotationCardProps) => {
 

--- a/src/components/Annotation/AnnotationCardSection.tsx
+++ b/src/components/Annotation/AnnotationCardSection.tsx
@@ -91,10 +91,6 @@ export const AnnotationCardSection = (props: AnnotationCardSectionProps) => {
 
     if (bodiesForThisSection.length > 0) {
       // Normal case - section has a comment or tag(s)
-      const creatorIds = new Set(bodiesForThisSection.map(b => b.creator?.id));
-      if (creatorIds.size > 1)
-        console.warn('Integrity problem: content in this section has multiple creators', annotation);
-
       const createdAt = bodiesForThisSection[0].created || 
         // Unusual, but may be the case for embedded annotations - if
         // the body doesn't have a timestamp, then fall back to the target creation

--- a/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
+++ b/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
@@ -78,6 +78,7 @@ export const AnnotationPopup = (props: AnnotationPopupProps) => {
         isProjectLocked={props.isProjectLocked}
         isReadOnly={isReadOnly}
         layerNames={props.layerNames}
+        policies={props.policies}
         present={props.present}
         showReplyField={!isReadOnly}
         tagVocabulary={props.tagVocabulary} 


### PR DESCRIPTION
## In this PR

This PR fixes issue 356: https://github.com/performant-software/vico/issues/356 (admin policy wasn't passed down in the annotation popup).

In addition, the PR removes two broken "integrity warnings" which would log a message when:
- the annotation had tags from someone else then the annotation's creator
- an annotation section had multiple contributors (e.g. different users for initial comment and tags)

Both cases can happen if an admin user edits someone else's annotation, and are actually legitimate.