### PR TITLE
Fixes "Cannot read properties of undefined (id)" Error in Image Annotation UI

### DIFF
--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -252,9 +252,9 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     setCurrentImage(source);
   }
 
-  const onError = (error) => setToast({
+  const onError = (error: string) => setToast({
     title: t['Something went wrong'],
-    description: error.message,
+    description: error,
     type: 'error',
   });
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -228,9 +228,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
     setEmbeddedNotes(notes);
   }, []);
 
-  const onError = (error) => setToast({
+  const onError = (error: string) => setToast({
     title: t['Something went wrong'],
-    description: error.message,
+    description: error,
     type: 'error',
   });
 
@@ -336,7 +336,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
 
       <Toast
         content={toast}
-        onOpenChange={(open) => !open && setToast(null)}
+        onOpenChange={(open) => !open && setToast(undefined)}
       />
     </ToastProvider>
   );

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/useNotes.ts
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotes/useNotes.ts
@@ -21,7 +21,7 @@ export const useNotes = () => {
 
   const user = useAnnotatorUser();
 
-  const me: PresentUser | User = useMemo(() => present.find(p => p.id === user.id) || user, [user]);
+  const me: PresentUser | User = useMemo(() => present.find(p => p.id === user?.id) || user, [user]);
 
   const markAllAsRead = () => 
     setNotes(notes => notes.map(n => ({...n, unread: undefined })));

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
@@ -33,7 +33,7 @@ export const DocumentNotesList = (props: DocumentNotesListProps) => {
 
   const user = useAnnotatorUser();
 
-  const me: PresentUser | User = useMemo(() => props.present.find(p => p.id === user.id) || user, [user]);
+  const me: PresentUser | User = useMemo(() => props.present.find(p => p.id === user?.id) || user, [user]);
 
   const [selected, setSelected] = useState<string | undefined>();
 


### PR DESCRIPTION
## In this PR

This PR fixes the error reported in https://github.com/performant-software/cove-recogito/issues/146

For posterity: the reason was a 'null' error (actually in two places), caused when the "Notes" list was open while the current `user` was undefined. This doesn't normally happen when the interface loads. But it _does_ happen if "Notes" are open while the Annotorious instance (re-)initializes – which happens when changing the page in a multipage document. 