### PR TITLE
String vs. Object Tags: Filter & Color Coding

### DIFF
--- a/src/backend/helpers/pluginHelpers.ts
+++ b/src/backend/helpers/pluginHelpers.ts
@@ -42,7 +42,7 @@ export const deleteInstalledPlugin = (
 export const updatePluginSettings = (
   supabase: SupabaseClient,
   project_id: string,
-  plugin_id: string,
+  plugin_name: string,
   plugin_settings: any
 ) =>
   supabase
@@ -52,5 +52,5 @@ export const updatePluginSettings = (
     })
     .match({
       project_id,
-      plugin_id
+      plugin_name
     });

--- a/src/backend/hooks/useTagVocabulary.ts
+++ b/src/backend/hooks/useTagVocabulary.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAnnotationStore } from '@annotorious/react';
-import type { Annotation, StoreChangeEvent } from '@annotorious/react';
+import type { Annotation, AnnotationBody, StoreChangeEvent } from '@annotorious/react';
 import { getProjectTagVocabulary } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
 import type { VocabularyTerm } from 'src/Types';
@@ -21,10 +21,14 @@ export const useTagVocabulary = (projectId: string) => {
       });
   }, []);
 
+  const getValue = (b: AnnotationBody) => b.value!.startsWith('{') 
+    ? JSON.parse(b.value!).label 
+    : b.value;
+
   const getUniqueTags = (annotations: Annotation[]): string[] => {
     const tagBodies = annotations.reduce((tags, annotation) => {
-      const t = annotation.bodies.filter(b => b.purpose === 'tagging');
-      return [...tags, ...t.map(b => b.value!)];
+      const t = annotation.bodies.filter(b => b.purpose === 'tagging' && b.value);
+      return [...tags, ...t.map(getValue)];
     }, [] as string[]);
 
     return Array.from(new Set(tagBodies));

--- a/src/components/Annotation/AnnotationCard.tsx
+++ b/src/components/Annotation/AnnotationCard.tsx
@@ -56,10 +56,6 @@ export interface AnnotationCardProps {
 
 }
 
-const getCreator = (annotation: SupabaseAnnotation) =>
-  annotation.target?.creator || 
-    (annotation.bodies.length > 0 ? annotation.bodies[0].creator : undefined);
-
 /**
  * Per convention, we only support tags created along with the first comment.
  * But they could be anywhere in the ordered list of bodies, because the

--- a/src/components/AnnotationDesktop/ColorCoding/colorCodings/useColorByFirstTag.ts
+++ b/src/components/AnnotationDesktop/ColorCoding/colorCodings/useColorByFirstTag.ts
@@ -33,7 +33,9 @@ export const useColorByFirstTag = (vocabulary: VocabularyTerm[] = []): ColorCodi
       const firstTag = annotation.bodies.find(b => b.purpose === 'tagging')?.value;
 
       if (firstTag) {
-        return getColor(firstTag);
+        // For backwards-compatibility: support object and string tags
+        const label = firstTag.startsWith('{') ? JSON.parse(firstTag).label : firstTag;
+        return getColor(label);
       } else {
         return NO_TAG;
       }
@@ -41,7 +43,7 @@ export const useColorByFirstTag = (vocabulary: VocabularyTerm[] = []): ColorCodi
   }, [getColor]);
 
   const legend = useMemo(() => {
-    return tags.map(tag => ({ color: getColor(tag) as Color, label: tag }));
+    return tags.map(tag => ({ color: getColor(tag.label) as Color, label: tag.label }));
   }, [tags.join('-')]);
 
   return useMemo(() => ({ name: 'tag', style, legend }), [style, legend]); 

--- a/src/components/AnnotationDesktop/FilterPanel/Tags/Tags.tsx
+++ b/src/components/AnnotationDesktop/FilterPanel/Tags/Tags.tsx
@@ -26,8 +26,11 @@ export const Tags = (props: TagsProps) => {
       ? selected.filter(s => s !== tag) : [...selected, tag]);
   
     if (next.size > 0) {
+      // For backwards-compatibility: support object and string tags
+      const getKey = (value: string) =>value.startsWith('{') ? JSON.parse(value).label : value;
+    
       const filter = (a: Annotation) =>
-        a.bodies.some(b => b.purpose === 'tagging' && b.value && next.has(b.value));
+        a.bodies.some(b => b.purpose === 'tagging' && b.value && next.has(getKey(b.value)));
 
       setTagSettings({ state: [...next], filter });
     } else {
@@ -42,13 +45,13 @@ export const Tags = (props: TagsProps) => {
       </h2>
 
       <ul>
-        {tags.map(tag => (
-          <li key={tag}>
+        {tags.map((tag, idx) => (
+          <li key={`${tag.id || tag.label}-${idx}`}>
             <Toggle.Root 
               className="toggle"
-              pressed={selected.includes(tag)}
-              onPressedChange={() => onToggle(tag)}>
-              {tag}
+              pressed={selected.includes(tag.label)}
+              onPressedChange={() => onToggle(tag.label)}>
+              {tag.label}
             </Toggle.Root>
           </li>
         ))}


### PR DESCRIPTION
## In this PR

When introducing the reconciliation plugin, we changed how tags are represented internally: Previously, tags were simply a string. Now they can be either a string, or an object `{ label: "a label", id: "an-id-or-uri" }`.

This PR fixes tag rendering in the __filter panel__ and the __color coding legend__, which both used to render raw JSON instead of the label.
