### PR TITLE
Minor UI Fixes

### DIFF
--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -110,6 +110,7 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
     loadTilesWithAjax: Boolean(authToken),
     ajaxWithCredentials: authToken ? true : undefined,
     showNavigationControl: false,
+    maxZoomLevel: 100,
     minZoomLevel: 0.1,
     visibilityRatio: 0.2,
     preserveImageSizeOnResize: true

--- a/src/apps/annotation-text/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-text/Toolbar/Toolbar.tsx
@@ -144,8 +144,6 @@ export const Toolbar = (props: ToolbarProps) => {
           />
         )}
 
-        {!collapsed && <div className='anno-toolbar-divider' />}
-
         {isPDF && !collapsed && (
           <div className='anno-toolbar-group'>
             <PDFControls i18n={props.i18n} />

--- a/src/components/AnnotationDesktop/DeleteSelected/DeleteSelected.tsx
+++ b/src/components/AnnotationDesktop/DeleteSelected/DeleteSelected.tsx
@@ -59,6 +59,8 @@ export const DeleteSelected = (props: DeleteSelectedProps) => {
         />
       )}
 
+      <div className='anno-toolbar-divider' />
+
       <button
         className='delete-selected'
         aria-label={props.i18n.t['Delete selected annotation']}


### PR DESCRIPTION
## In this PR

This PR makes a few minor fixes to the annotation view.
- OpenSeadragon now allows overzooming (i.e. zooming 100x beyond the original resolution of the image)
- The toolbar no longer shows duplicate dividers. (There were dividers "surrounding" the empty area that's occupied by the delete button when a delete-able annotation is selected.)