### PR TITLE
Import of IIIF Annotations as Read-Only Layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@allmaps/iiif-parser": "1.0.0-beta.40",
+        "@allmaps/iiif-parser": "1.0.0-beta.42",
         "@annotorious/annotorious": "3.3.3",
         "@annotorious/react": "3.3.3",
         "@astrojs/netlify": "^6.2.5",
@@ -106,20 +106,13 @@
       }
     },
     "node_modules/@allmaps/iiif-parser": {
-      "version": "1.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@allmaps/iiif-parser/-/iiif-parser-1.0.0-beta.40.tgz",
-      "integrity": "sha512-92pk/zoiNGpqOR4WooFkCIZnEwUjAu4fOsi5LnMLeydxbV8sKGBmbN3BWg9Imlqcf7/qW0sl8QM4aJcepvAsJw==",
+      "version": "1.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@allmaps/iiif-parser/-/iiif-parser-1.0.0-beta.42.tgz",
+      "integrity": "sha512-h3ag7Xw/H4POtoDtZG7qA7bPjp7bQvAjjGi+WLiUlB32x989cKx3wFpbjKkpcp3MyKsrS0WaHfmqaXcrqBN/rQ==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@allmaps/types": "^1.0.0-beta.15",
-        "zod": "^3.22.4"
+        "zod": "^3.24.1"
       }
-    },
-    "node_modules/@allmaps/types": {
-      "version": "1.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@allmaps/types/-/types-1.0.0-beta.15.tgz",
-      "integrity": "sha512-iA2dxCUQbzj3mvKT5fz9nENtmMD3BtD9+uuDTRw2JuACBqA6GJkbDJz9wyxHHSYcCy4JL3xuTy0ucRHLZZkGfg==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -4667,60 +4660,60 @@
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.2.1.tgz",
-      "integrity": "sha512-FhsdxMWYu/C11sFisEp7FMGBtX/OSSbnXZDMBhGuUDBNTdsoZlMSgQv5f90rwvzWAdWIW6VobD+G3IrazxA6dQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.2.2.tgz",
+      "integrity": "sha512-yvlSKVMLjddAGBa2Yu+vUZxuu3sClOWW1AG+UtJkvejYuGM5BVL35s6Ijiwb75O9QdEx6IkMxinHZSi8ZyrBaA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.2.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.2.1.tgz",
-      "integrity": "sha512-eMdcUzN3FMQYxOmRf2rmU8frikzoSHbQDFH2hIuXsrMO+IBOCI9BeeRkCiBkcLDHeRKbOCtYMJK3D6U32ooU9Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.2.2.tgz",
+      "integrity": "sha512-tlDKfhWpF4jKLUyVAnmL+ggIC+0VyteNsUpBzh1iwWLZu4i+PelIRr0TNur6pRRo5UZIv3ss/PLMuwahg9S2hg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.2.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.1.0"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-      "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
+      "integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1",
+        "@shikijs/types": "3.2.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
-      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
+      "integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.2.2"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
-      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
+      "integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.2.1"
+        "@shikijs/types": "3.2.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-      "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
+      "integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -6406,9 +6399,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001712",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
-      "integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
+      "version": "1.0.30001713",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -7133,9 +7126,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.134",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.134.tgz",
-      "integrity": "sha512-zSwzrLg3jNP3bwsLqWHmS5z2nIOQ5ngMnfMZOWWtXnqqQkPVyOipxK98w+1beLw1TB+EImPNcG8wVP/cLVs2Og==",
+      "version": "1.5.135",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.135.tgz",
+      "integrity": "sha512-8gXUdEmvb+WCaYUhA0Svr08uSeRjM2w3x5uHOc1QbaEVzJXB8rgm5eptieXzyKoVEtinLvW6MtTcurA65PeS1Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -12352,17 +12345,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.2.1.tgz",
-      "integrity": "sha512-VML/2o1/KGYkEf/stJJ+s9Ypn7jUKQPomGLGYso4JJFMFxVDyPNsjsI3MB3KLjlMOeH44gyaPdXC6rik2WXvUQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.2.2.tgz",
+      "integrity": "sha512-0qWBkM2t/0NXPRcVgtLhtHv6Ak3Q5yI4K/ggMqcgLRKm4+pCs3namgZlhlat/7u2CuqNtlShNs9lENOG6n7UaQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.2.1",
-        "@shikijs/engine-javascript": "3.2.1",
-        "@shikijs/engine-oniguruma": "3.2.1",
-        "@shikijs/langs": "3.2.1",
-        "@shikijs/themes": "3.2.1",
-        "@shikijs/types": "3.2.1",
+        "@shikijs/core": "3.2.2",
+        "@shikijs/engine-javascript": "3.2.2",
+        "@shikijs/engine-oniguruma": "3.2.2",
+        "@shikijs/langs": "3.2.2",
+        "@shikijs/themes": "3.2.2",
+        "@shikijs/types": "3.2.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -13518,9 +13511,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@allmaps/iiif-parser": "1.0.0-beta.42",
-        "@annotorious/annotorious": "3.3.3",
-        "@annotorious/react": "3.3.3",
+        "@annotorious/annotorious": "^3.3.3",
+        "@annotorious/react": "^3.3.3",
         "@astrojs/netlify": "^6.2.5",
         "@astrojs/node": "^9.1.3",
         "@astrojs/react": "^4.2.3",
@@ -1443,9 +1443,9 @@
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.6.tgz",
-      "integrity": "sha512-9GLOPbW8jTeboR2ar9uMMUDUZjpTLscUvOjNvRw2EgppgoLHLUh/P/OW9evULosnvDjhYf2Gwk/gMOP9KvXD2A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.7.tgz",
+      "integrity": "sha512-5V9pwFeiv+95Jlowq/7oiGISSrdXMTs2jfoSy8k+WM6oI/Skm1WWjPdJWeporN2O4UGcsaCJdirKffKayMoPgw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,10 +94,10 @@
         "@types/react-dom": "^18.3.6",
         "@types/react-window": "1.8.8",
         "@types/uuid": "10.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.14.0",
-        "@typescript-eslint/parser": "^8.14.0",
-        "eslint": "^9.15.0",
-        "eslint-plugin-react": "^7.37.2",
+        "@typescript-eslint/eslint-plugin": "^8.29.1",
+        "@typescript-eslint/parser": "^8.29.1",
+        "eslint": "^9.24.0",
+        "eslint-plugin-react": "^7.37.5",
         "typescript": "5.8.3"
       },
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "node copy-pdf-worker.js"
   },
   "dependencies": {
-    "@allmaps/iiif-parser": "1.0.0-beta.40",
+    "@allmaps/iiif-parser": "1.0.0-beta.42",
     "@annotorious/annotorious": "3.3.3",
     "@annotorious/react": "3.3.3",
     "@astrojs/netlify": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@allmaps/iiif-parser": "1.0.0-beta.42",
-    "@annotorious/annotorious": "3.3.3",
-    "@annotorious/react": "3.3.3",
+    "@annotorious/annotorious": "^3.3.3",
+    "@annotorious/react": "^3.3.3",
     "@astrojs/netlify": "^6.2.5",
     "@astrojs/node": "^9.1.3",
     "@astrojs/react": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -97,10 +97,10 @@
     "@types/react-dom": "^18.3.6",
     "@types/react-window": "1.8.8",
     "@types/uuid": "10.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.14.0",
-    "@typescript-eslint/parser": "^8.14.0",
-    "eslint": "^9.15.0",
-    "eslint-plugin-react": "^7.37.2",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-react": "^7.37.5",
     "typescript": "5.8.3"
   },
   "optionalDependencies": {

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -113,8 +113,9 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
     setInitialAnnotations(annotations);
 
     // Add annotations embedded in the manifest, if any
-    if (props.embeddedAnnotations && props.embeddedAnnotations.length > 0)
+    if (props.embeddedAnnotations && props.embeddedAnnotations.length > 0) {
       anno.setAnnotations(props.embeddedAnnotations, false);
+    }
 
     props.onLoad();
   }

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -33,6 +33,8 @@ interface AnnotatedImageProps {
 
   channelId: string;
 
+  embeddedAnnotations?: any[];
+
   i18n: Translations;
 
   isLocked: boolean;
@@ -109,6 +111,11 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
     // `@recogito/annotorious-supabase` library (used by the SupabasePlugin
     // component) takes care of the filtering.
     setInitialAnnotations(annotations);
+
+    // Add annotations embedded in the manifest, if any
+    if (props.embeddedAnnotations && props.embeddedAnnotations.length > 0)
+      anno.setAnnotations(props.embeddedAnnotations, false);
+
     props.onLoad();
   }
 

--- a/src/apps/annotation-image/IIIF/IIIFThumbnailStrip.tsx
+++ b/src/apps/annotation-image/IIIF/IIIFThumbnailStrip.tsx
@@ -4,7 +4,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { IIIFThumbnail } from './IIIFThumbnail';
 import type { IIIFImage } from './useIIIF';
 import type { ActiveUsers } from './useMultiPagePresence';
-import { getCanvasLabel } from 'src/util';
+import { getResourceLabel } from 'src/util';
 import type { Translations } from 'src/Types';
 
 import './IIIFThumbnailStrip.css';
@@ -40,7 +40,7 @@ export const IIIFThumbnailStrip = (props: IIIFThumbnailStripProps) => {
 
   const Row = ({ index, style }: { index: number, style: React.CSSProperties}) => {   
     const canvas = props.canvases[index];
-    const label = getCanvasLabel(canvas.label, props.i18n.lang);
+    const label = getResourceLabel(canvas.label, props.i18n.lang);
     
     return (
       <div 

--- a/src/apps/annotation-image/IIIF/useIIIF.ts
+++ b/src/apps/annotation-image/IIIF/useIIIF.ts
@@ -133,8 +133,6 @@ export const useIIIF = (document: DocumentWithContext) => {
 
   const embeddedAnnotations = useMemo(() => {
     if (!embeddedAnnotationData) return;
-  
-    console.log('yay');
 
     const id = typeof currentImage === 'string' ? currentImage : currentImage?.uri;
     if (!id) return;

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -327,7 +327,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               document={document}
               i18n={props.i18n}
               iiifCanvases={canvases}
-              layers={documentLayers}
+              layers={layers}
               layerNames={layerNames}
               me={props.me}
               metadata={metadata}

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -75,6 +75,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     isPresentationManifest,
     manifestError,
     metadata,
+    embeddedAnnotations,
     currentImage,
     setCurrentImage,
   } = useIIIF(document);
@@ -335,6 +336,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                   activeLayer={activeLayer}
                   authToken={authToken}
                   channelId={props.channelId}
+                  embeddedAnnotations={embeddedAnnotations}
                   i18n={props.i18n}
                   currentImage={currentImage}
                   isLocked={isLocked}

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -8,9 +8,9 @@ import { FilterPanel } from '@components/AnnotationDesktop';
 import { IIIFThumbnailStrip, type IIIFImage } from '../IIIF';
 import type { ActiveUsers } from '../IIIF/useMultiPagePresence';
 import type {
-  DocumentLayer,
   DocumentWithContext,
   IIIFMetadata,
+  Layer,
   MyProfile,
   Translations,
 } from 'src/Types';
@@ -28,7 +28,7 @@ interface LeftDrawerProps {
 
   iiifCanvases: Canvas[];
 
-  layers?: DocumentLayer[];
+  layers?: Layer[];
 
   layerNames: Map<string, string>;
 

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -27,7 +27,6 @@ interface Change {
 }
 
 // Helpers
-// Helpers
 const normalizeId = (id?: string | null) =>
   id?.startsWith('#') ? id.substring(1) : id;
 

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -154,8 +154,8 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
       a.layer_id && !activeLayers.has(a.layer_id)
         ? readOnlyStyle(state, z)
         : typeof activeLayerStyle === 'function'
-        ? activeLayerStyle(a, state, z)
-        : activeLayerStyle;
+          ? activeLayerStyle(a, state, z)
+          : activeLayerStyle;
   }, [activeLayerStyle, documentLayers]);
 
   useEffect(() => {

--- a/src/apps/project-home/upload/dialogs/useIIIFValidation.ts
+++ b/src/apps/project-home/upload/dialogs/useIIIFValidation.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IIIF } from '@allmaps/iiif-parser';
-import { getCanvasLabel } from 'src/util';
+import { getResourceLabel } from 'src/util';
 import type { Translations } from 'src/Types';
 
 /**
@@ -57,7 +57,7 @@ export const validateIIIF = (url: string, i18n: Translations): Promise<Validatio
               } as ValidationResult;
             } else if (parsed.type === 'manifest') {
               // Presentation API v1/2/3
-              const label = getCanvasLabel(parsed.label, i18n.lang);
+              const label = getResourceLabel(parsed.label, i18n.lang);
               return {
                 isValid: true,
                 result: {

--- a/src/components/Annotation/LayerIcon.tsx
+++ b/src/components/Annotation/LayerIcon.tsx
@@ -19,8 +19,6 @@ export const LayerIcon = (props: LayerIconProps) => {
 
   const { t } = props.i18n;
 
-  console.log('popup', props.layerId, props.layerNames);
-
   const label = useMemo(() => 
     props.layerId ? props.layerNames.get(props.layerId) || t['Baselayer'] : t['Baselayer'], []);
 
@@ -33,11 +31,13 @@ export const LayerIcon = (props: LayerIconProps) => {
           </div>
         </Tooltip.Trigger>
 
-        <Tooltip.Content 
-          className="tooltip-content"
-          side="top">
-          {label}
-        </Tooltip.Content>
+        <Tooltip.Portal>
+          <Tooltip.Content 
+            className="tooltip-content"
+            side="top">
+            {label}
+          </Tooltip.Content>
+        </Tooltip.Portal>
       </Tooltip.Root>
     </Tooltip.Provider>
   )

--- a/src/components/Annotation/LayerIcon.tsx
+++ b/src/components/Annotation/LayerIcon.tsx
@@ -19,6 +19,8 @@ export const LayerIcon = (props: LayerIconProps) => {
 
   const { t } = props.i18n;
 
+  console.log('popup', props.layerId, props.layerNames);
+
   const label = useMemo(() => 
     props.layerId ? props.layerNames.get(props.layerId) || t['Baselayer'] : t['Baselayer'], []);
 

--- a/src/components/AnnotationDesktop/FilterPanel/AnnotationLayers/AnnotationLayers.css
+++ b/src/components/AnnotationDesktop/FilterPanel/AnnotationLayers/AnnotationLayers.css
@@ -37,6 +37,12 @@
   gap: 0.5rem;
 }
 
+.filters-annotationlayers li label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .filters-annotationlayers .checkbox-root {
   align-items: center;
   background-color: white;
@@ -44,6 +50,7 @@
   border-radius: var(--border-radius);
   color: #fff;
   display: flex;
+  flex-shrink: 0;
   height: 16px;
   justify-content: center;
   width: 16px;

--- a/src/util/iiif/getCanvasLabel.ts
+++ b/src/util/iiif/getCanvasLabel.ts
@@ -1,10 +1,9 @@
 import type { LanguageString } from '@allmaps/iiif-parser';
 
-export const getCanvasLabel = (dict: LanguageString | undefined, lang: string) => {
-  if (!dict)
-    return;
+export const getCanvasLabel = (dict: LanguageString | undefined, lang?: string) => {
+  if (!dict) return;
 
-  const localized = dict[lang];
+  const localized = lang ? dict[lang] : undefined;
   if (localized) {
     return localized[0];
   } else {

--- a/src/util/iiif/getResourceLabel.ts
+++ b/src/util/iiif/getResourceLabel.ts
@@ -1,6 +1,6 @@
 import type { LanguageString } from '@allmaps/iiif-parser';
 
-export const getCanvasLabel = (dict: LanguageString | undefined, lang?: string) => {
+export const getResourceLabel = (dict: LanguageString | undefined, lang?: string) => {
   if (!dict) return;
 
   const localized = lang ? dict[lang] : undefined;

--- a/src/util/iiif/index.ts
+++ b/src/util/iiif/index.ts
@@ -1,2 +1,2 @@
-export * from './getCanvasLabel';
+export * from './getResourceLabel';
 export * from './parseManifestAnnotations';

--- a/src/util/iiif/index.ts
+++ b/src/util/iiif/index.ts
@@ -1,1 +1,2 @@
 export * from './getCanvasLabel';
+export * from './parseManifestAnnotations';

--- a/src/util/iiif/parseManifestAnnotations.ts
+++ b/src/util/iiif/parseManifestAnnotations.ts
@@ -1,23 +1,22 @@
+import { v4 as uuidv4 } from 'uuid';
 import type { Manifest } from '@allmaps/iiif-parser';
-import { parseW3CImageAnnotation } from '@annotorious/annotorious';
+import { parseW3CImageAnnotation, type AnnotationBody } from '@annotorious/annotorious';
+import type { SupabaseAnnotation } from '@recogito/studio-sdk';
 
-/*
-const crosswalkBodies = (bodies: AnnotationBody[]) => {
+const crosswalkBodies = (bodies: AnnotationBody[]): AnnotationBody[] => {
   const keepPurposes = new Set(['commenting', 'replying', 'describing']);
 
   const crosswalkPurpose = (purpose?: string) =>
     (!purpose || purpose === 'describing') ? 'commenting' : purpose;
 
   const toKeep = bodies.filter(b => typeof b.value === 'string' && (!b.purpose || keepPurposes.has(b.purpose)));
-
   return toKeep.map(b => ({
     id: b.id || uuidv4(),
     purpose: crosswalkPurpose(b.purpose), 
     created: b.created,
-    value: JSON.stringify(generateJSON(b.value!, extensions))
-  }));
+    value: b.value
+  } as AnnotationBody));
 }
-  */
 
 export const parseManifestAnnotations = (manifest: Manifest) => {
 
@@ -27,12 +26,13 @@ export const parseManifestAnnotations = (manifest: Manifest) => {
       const items = ('items' in page ? page.items as any[] : []) || [];
 
       // TODO crosswalk items to SupabaseAnnotations
-      const crosswalked = items.map(item => {
-        return {
+      const crosswalked = items.map(item => ({
           layer_id: 'manifest',
           ...parseW3CImageAnnotation(item).parsed
-        }
-      });
+      })).map(a => ({
+        ...a,
+        bodies: crosswalkBodies(a.bodies || [])
+      } as SupabaseAnnotation));
 
       return [...all, ...crosswalked];
     }, []);

--- a/src/util/iiif/parseManifestAnnotations.ts
+++ b/src/util/iiif/parseManifestAnnotations.ts
@@ -1,0 +1,60 @@
+import type { Manifest } from '@allmaps/iiif-parser';
+import { parseW3CImageAnnotation } from '@annotorious/annotorious';
+
+/*
+const crosswalkBodies = (bodies: AnnotationBody[]) => {
+  const keepPurposes = new Set(['commenting', 'replying', 'describing']);
+
+  const crosswalkPurpose = (purpose?: string) =>
+    (!purpose || purpose === 'describing') ? 'commenting' : purpose;
+
+  const toKeep = bodies.filter(b => typeof b.value === 'string' && (!b.purpose || keepPurposes.has(b.purpose)));
+
+  return toKeep.map(b => ({
+    id: b.id || uuidv4(),
+    purpose: crosswalkPurpose(b.purpose), 
+    created: b.created,
+    value: JSON.stringify(generateJSON(b.value!, extensions))
+  }));
+}
+  */
+
+export const parseManifestAnnotations = (manifest: Manifest) => {
+
+  const annotations = manifest.canvases.reduce<Record<string, any[]>>((agg, canvas) => {
+    // Aggregate annotations from all annotation pages on this canvas
+    const onThisCanvas = (canvas.annotations || []).reduce<any[]>((all, page) => {
+      const items = ('items' in page ? page.items as any[] : []) || [];
+
+      // TODO crosswalk items to SupabaseAnnotations
+      const crosswalked = items.map(item => {
+        return {
+          // layer_id: 'manifest',
+          ...parseW3CImageAnnotation(item).parsed
+        }
+      });
+
+      return [...all, ...crosswalked];
+    }, []);
+
+    if (onThisCanvas.length > 0) {
+      agg[canvas.uri] = onThisCanvas;
+      return agg;
+    } else {
+      return agg;
+    }
+  }, {});
+
+  /*
+  export interface EmbeddedLayer {
+    id: string;
+  
+    name?: string;
+  
+    is_active?: boolean;
+  }
+  */
+
+  return annotations;
+
+}

--- a/src/util/iiif/parseManifestAnnotations.ts
+++ b/src/util/iiif/parseManifestAnnotations.ts
@@ -34,7 +34,7 @@ export const parseManifestAnnotations = (manifest: Manifest) => {
       const items = ('items' in page ? page.items as any[] : []) || [];
 
       const crosswalked = items.map(item => ({
-          layer_id: 'manifest',
+          layer_id: manifest.uri,
           ...parseW3CImageAnnotation(item).parsed
       })).map(a => ({
         ...a,

--- a/src/util/iiif/parseManifestAnnotations.ts
+++ b/src/util/iiif/parseManifestAnnotations.ts
@@ -1,9 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Manifest } from '@allmaps/iiif-parser';
 import { parseW3CImageAnnotation, type AnnotationBody, type ImageAnnotation } from '@annotorious/annotorious';
-import type { SupabaseAnnotation } from '@recogito/studio-sdk';
 import type { EmbeddedLayer } from 'src/Types';
-import { getCanvasLabel } from './getCanvasLabel';
+import { getResourceLabel } from './getResourceLabel';
 
 const crosswalkBodies = (bodies: AnnotationBody[]): AnnotationBody[] => {
   const keepPurposes = new Set(['commenting', 'replying', 'describing']);
@@ -24,7 +23,7 @@ export const parseManifestAnnotations = (manifest: Manifest) => {
 
   const layer: EmbeddedLayer = {
     id: manifest.uri,
-    name: getCanvasLabel(manifest.label),
+    name: getResourceLabel(manifest.label),
     is_active: false // Read-only
   }
 

--- a/src/util/iiif/parseManifestAnnotations.ts
+++ b/src/util/iiif/parseManifestAnnotations.ts
@@ -29,7 +29,7 @@ export const parseManifestAnnotations = (manifest: Manifest) => {
       // TODO crosswalk items to SupabaseAnnotations
       const crosswalked = items.map(item => {
         return {
-          // layer_id: 'manifest',
+          layer_id: 'manifest',
           ...parseW3CImageAnnotation(item).parsed
         }
       });


### PR DESCRIPTION
## In this PR

**Important:** this PR builds on top of PR #370, which should be merged first!

This PR adds a first version of the ATRIUM-funded feature "Read-only import of annotations for images", which parses existing annotations in IIIF Presentation Manifests, and displays them as a read-only layer.