### PR TITLE
DocumentCardActions: Extension API

### DIFF
--- a/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/src/components/DocumentCard/DocumentCardActions.tsx
@@ -294,8 +294,8 @@ export const DocumentCardActions = (props: DocumentCardActionsProps) => {
                 extension={extension}
                 pluginConfig={config}
                 projectId={props.context.project_id}
-                contextId={props.context.id}
-                documentId={props.document.id}
+                context={props.context}
+                document={props.document}
               />
             ))}
 


### PR DESCRIPTION
## In this PR

A tiny tweak to the extension mount in the `DocumentCardActions`. Extensions on this extension point now receive the `document` and the `context` rather than just the document & context IDs.

A fix to the SDK that provides the correct typing for this interface will follow shortly.