### PR TITLE
COVE: linking between annotations in the same page

### DIFF
--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -4,6 +4,8 @@ import { AnnotationPopup, SelectionURLState, UndoStack, useFilter } from '@compo
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { SupabasePlugin } from '@components/SupabasePlugin';
 import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
+import { useExtensions } from '@recogito/studio-sdk';
+import { ExtensionMount } from '@components/Plugins';
 import { getImageURL, type IIIFImage } from '../IIIF';
 import type { DocumentLayer, Policies, Translations, VocabularyTerm } from 'src/Types';
 import type {
@@ -20,8 +22,6 @@ import {
   UserSelectAction,
   useAnnotator
 } from '@annotorious/react';
-import { useExtensions } from '@recogito/studio-sdk';
-import { ExtensionMount } from '@components/Plugins';
 
 const SUPABASE: string = import.meta.env.PUBLIC_SUPABASE;
 
@@ -69,7 +69,7 @@ interface AnnotatedImageProps {
 
   onConnectionError(): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onPageActivity?(event: { source: string, user: User }): void;
 

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -102,7 +102,7 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
       const source = props.currentImage.uri;
       return { source, tilesource };
     }
-  }, [props.currentImage])
+  }, [props.currentImage]);
 
   const anno = useAnnotator<AnnotoriousOpenSeadragonAnnotator>();
 

--- a/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
+++ b/src/apps/annotation-image/AnnotatedImage/AnnotatedImage.tsx
@@ -69,6 +69,8 @@ interface AnnotatedImageProps {
 
   onConnectionError(): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onPageActivity?(event: { source: string, user: User }): void;
 
   onSaveError(): void;
@@ -79,7 +81,17 @@ interface AnnotatedImageProps {
 
 export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImageProps>((props, ref) => {
 
-  const { authToken, i18n, isLocked, layers, layerNames, policies, present, tagVocabulary } = props;
+  const { 
+    authToken, 
+    i18n, 
+    isLocked, 
+    layers, 
+    layerNames, 
+    policies, 
+    present, 
+    tagVocabulary,
+    onNavigateTo
+  } = props;
 
   const { source, tilesource } = useMemo(() => {
     if (typeof props.currentImage === 'string') {
@@ -248,7 +260,8 @@ export const AnnotatedImage = forwardRef<OpenSeadragon.Viewer, AnnotatedImagePro
               layerNames={layerNames}
               policies={policies}
               present={present}
-              tagVocabulary={tagVocabulary} />)} />
+              tagVocabulary={tagVocabulary} 
+              onNavigateTo={onNavigateTo} />)} />
       )}
     </OpenSeadragonAnnotator>
   )

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -234,7 +234,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
   const onRightTabChanged = (tab: 'ANNOTATIONS' | 'NOTES') =>
     setRightPanelTab(tab);
 
-  const onNavigateTo = (annotationId: string) => {
+  const onNavigateTo = (annotation: SupabaseAnnotation) => {
     const vw = Math.max(
       window.document.documentElement.clientWidth || 0,
       window.innerWidth || 0
@@ -245,11 +245,11 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
       window.innerHeight || 0
     );
 
-    anno.fitBounds(annotationId, {
+    anno.fitBounds(annotation, {
       padding: [vh / 2, vw / 2 + 600, vh / 2, (vw - 600) / 2],
     });
 
-    anno.state.selection.setSelected(annotationId);
+    anno.state.selection.setSelected(annotation.id);
   }
 
   const beforeSelectAnnotation = (a?: ImageAnnotation) => {
@@ -257,7 +257,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
       // Don't fit the view if the annotation is already selected
       if (anno.state.selection.isSelected(a)) return;
 
-      onNavigateTo(a.id);
+      onNavigateTo(a);
     }
   };
 

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -20,9 +20,9 @@ import type { ImageAnnotationProps } from './ImageAnnotation';
 import { LeftDrawer } from './LeftDrawer';
 import { RightDrawer } from './RightDrawer';
 import { Toolbar } from './Toolbar';
-import { useIIIF, useMultiPagePresence, ManifestErrorDialog } from './IIIF';
+import { useIIIF, useMultiPagePresence, ManifestErrorDialog, type IIIFImage } from './IIIF';
 import { deduplicateLayers } from 'src/util/deduplicateLayers';
-import type { Document, DocumentLayer, EmbeddedLayer } from 'src/Types';
+import type { Document, DocumentLayer } from 'src/Types';
 import type {
   AnnotationState,
   AnnotoriousOpenSeadragonAnnotator,
@@ -261,12 +261,21 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
     }
   };
 
-  const onGoToImage = (source: string) => {
+  const onGoToImage = (source: IIIFImage | string, clearSelection = false) => {
     // When navigating via the thumbnail strip, clear the selection from the
     // hash, otherwise we'll get looped right back.
-    clearSelectionURLHash();
-    setCurrentImage(source);
+    if (clearSelection)
+      clearSelectionURLHash();
+
+    if (typeof source === 'string') {
+      const canvas = canvases.find(c => c.uri === source);
+      setCurrentImage(canvas || source);
+    } else {
+      setCurrentImage(source);
+    }
   };
+
+
 
   const onError = (error: string) =>
     setToast({
@@ -340,7 +349,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               metadata={metadata}
               open={leftPanelOpen}
               present={present}
-              onChangeImage={onGoToImage}
+              onChangeImage={source => onGoToImage(source, true)}
               onError={onError}
               onUpdated={onUpdated}
             />
@@ -366,7 +375,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                   tagVocabulary={tagVocabulary}
                   tool={tool}
                   usePopup={usePopup}
-                  onChangeImage={setCurrentImage}
+                  onChangeImage={source => onGoToImage(source, false)}
                   onChangePresent={setPresent}
                   onConnectionError={() => setConnectionError(true)}
                   onNavigateTo={onNavigateTo}

--- a/src/apps/annotation-image/ImageAnnotationDesktop.tsx
+++ b/src/apps/annotation-image/ImageAnnotationDesktop.tsx
@@ -234,23 +234,30 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
   const onRightTabChanged = (tab: 'ANNOTATIONS' | 'NOTES') =>
     setRightPanelTab(tab);
 
+  const onNavigateTo = (annotationId: string) => {
+    const vw = Math.max(
+      window.document.documentElement.clientWidth || 0,
+      window.innerWidth || 0
+    );
+
+    const vh = Math.max(
+      window.document.documentElement.clientHeight || 0,
+      window.innerHeight || 0
+    );
+
+    anno.fitBounds(annotationId, {
+      padding: [vh / 2, vw / 2 + 600, vh / 2, (vw - 600) / 2],
+    });
+
+    anno.state.selection.setSelected(annotationId);
+  }
+
   const beforeSelectAnnotation = (a?: ImageAnnotation) => {
     if (a && !usePopup && anno) {
       // Don't fit the view if the annotation is already selected
       if (anno.state.selection.isSelected(a)) return;
 
-      const vw = Math.max(
-        window.document.documentElement.clientWidth || 0,
-        window.innerWidth || 0
-      );
-      const vh = Math.max(
-        window.document.documentElement.clientHeight || 0,
-        window.innerHeight || 0
-      );
-
-      anno.fitBounds(a, {
-        padding: [vh / 2, vw / 2 + 600, vh / 2, (vw - 600) / 2],
-      });
+      onNavigateTo(a.id);
     }
   };
 
@@ -362,6 +369,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
                   onChangeImage={setCurrentImage}
                   onChangePresent={setPresent}
                   onConnectionError={() => setConnectionError(true)}
+                  onNavigateTo={onNavigateTo}
                   onPageActivity={
                     canvases.length > 1 ? onPageActivity : undefined
                   }
@@ -384,6 +392,7 @@ export const ImageAnnotationDesktop = (props: ImageAnnotationProps) => {
               beforeSelectAnnotation={beforeSelectAnnotation}
               onTabChanged={onRightTabChanged}
               tab={rightPanelTab}
+              onNavigateTo={onNavigateTo}
             />
           </main>
         </div>

--- a/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
+++ b/src/apps/annotation-image/LeftDrawer/LeftDrawer.tsx
@@ -40,7 +40,7 @@ interface LeftDrawerProps {
 
   present: PresentUser[];
 
-  onChangeImage(url: string): void;
+  onChangeImage(image: IIIFImage): void;
 
   onError(error: string): void;
 

--- a/src/apps/annotation-image/RightDrawer/RightDrawer.tsx
+++ b/src/apps/annotation-image/RightDrawer/RightDrawer.tsx
@@ -30,6 +30,8 @@ interface RightDrawerProps {
 
   beforeSelectAnnotation(a?: ImageAnnotation): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onTabChanged(tab: 'ANNOTATIONS' | 'NOTES'): void;
 
   tab: 'ANNOTATIONS' | 'NOTES';
@@ -89,7 +91,8 @@ export const RightDrawer = (props: RightDrawerProps) => {
               me={me}
               policies={props.policies}
               tagVocabulary={props.tagVocabulary}
-              beforeSelect={props.beforeSelectAnnotation} />
+              beforeSelect={props.beforeSelectAnnotation} 
+              onNavigateTo={props.onNavigateTo}/>
           ) : (
             <DocumentNotesList 
               i18n={props.i18n}
@@ -98,7 +101,8 @@ export const RightDrawer = (props: RightDrawerProps) => {
               layerNames={props.layerNames}
               present={props.present}
               policies={props.policies} 
-              tagVocabulary={props.tagVocabulary} />
+              tagVocabulary={props.tagVocabulary} 
+              onNavigateTo={props.onNavigateTo} />
           )}
         </div>
       </aside>

--- a/src/apps/annotation-image/RightDrawer/RightDrawer.tsx
+++ b/src/apps/annotation-image/RightDrawer/RightDrawer.tsx
@@ -1,7 +1,7 @@
 import { Chats } from '@phosphor-icons/react';
 import { animated, easings, useTransition } from '@react-spring/web';
 import type { DrawingStyleExpression, ImageAnnotation, PresentUser } from '@annotorious/react';
-import { isMe } from '@recogito/annotorious-supabase';
+import { isMe, type SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { useFilter } from '@components/AnnotationDesktop/FilterPanel';
 import { AnnotationList, DocumentNotesList, DocumentNotesTabButton } from '@components/AnnotationDesktop';
 import type { DocumentLayer, Policies, Translations, VocabularyTerm } from 'src/Types';
@@ -30,7 +30,7 @@ interface RightDrawerProps {
 
   beforeSelectAnnotation(a?: ImageAnnotation): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onTabChanged(tab: 'ANNOTATIONS' | 'NOTES'): void;
 

--- a/src/apps/annotation-image/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-image/Toolbar/Toolbar.tsx
@@ -85,7 +85,7 @@ export const Toolbar = (props: ToolbarProps) => {
 
   const back = `/${props.i18n.lang}/projects/${project_id}`;
 
-  const extensions = useExtensions('annotation.image.toolbar');
+  const extensions = useExtensions('annotation:image:toolbar');
 
   const colorCoding = useColorCoding();
 

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
@@ -56,13 +56,24 @@ interface AnnotatedTextProps {
 
   onLoad(): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onLoadEmbeddedLayers(layers: EmbeddedLayer[], notes: DocumentNote[]): void;
 
 }
 
 export const AnnotatedText = (props: AnnotatedTextProps) => {
 
-  const { i18n, isLocked, layers, layerNames, policies, present, tagVocabulary } = props;
+  const { 
+    i18n, 
+    isLocked, 
+    layers, 
+    layerNames, 
+    policies, 
+    present, 
+    tagVocabulary,
+    onNavigateTo
+  } = props;
 
   const contentType = props.document.content_type;
 
@@ -168,7 +179,8 @@ export const AnnotatedText = (props: AnnotatedTextProps) => {
                 layerNames={layerNames}
                 present={present}
                 policies={policies}
-                tagVocabulary={tagVocabulary} />
+                tagVocabulary={tagVocabulary} 
+                onNavigateTo={onNavigateTo} />
               )}
             />
           )}

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedText.tsx
@@ -3,6 +3,7 @@ import { useExtensions } from '@recogito/studio-sdk';
 import { useAnnotator, type PresentUser } from '@annotorious/react';
 import { TextAnnotationPopup, TextAnnotator } from '@recogito/react-text-annotator';
 import type { HighlightStyleExpression, RecogitoTextAnnotator } from '@recogito/react-text-annotator';
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { SelectionURLState, UndoStack, type DocumentNote } from '@components/AnnotationDesktop';
 import type { PrivacyMode } from '@components/PrivacySelector';
 import { SupabasePlugin } from '@components/SupabasePlugin';
@@ -56,7 +57,7 @@ interface AnnotatedTextProps {
 
   onLoad(): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onLoadEmbeddedLayers(layers: EmbeddedLayer[], notes: DocumentNote[]): void;
 

--- a/src/apps/annotation-text/RightDrawer/RightDrawer.tsx
+++ b/src/apps/annotation-text/RightDrawer/RightDrawer.tsx
@@ -4,7 +4,7 @@ import { AnnotationList, DocumentNotesList, DocumentNotesTabButton } from '@comp
 import { useFilter } from '@components/AnnotationDesktop/FilterPanel/FilterState';
 import { Chats } from '@phosphor-icons/react';
 import { animated, easings, useSpring, useTransition } from '@react-spring/web';
-import { isMe } from '@recogito/annotorious-supabase';
+import { isMe, type SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import type { PDFAnnotation } from '@recogito/react-pdf-annotator';
 import type { HighlightStyleExpression } from '@recogito/react-text-annotator';
 import type { Layer, Policies, Translations, VocabularyTerm } from 'src/Types';
@@ -35,7 +35,7 @@ interface RightDrawerProps {
 
   beforeSelectAnnotation(a?: Annotation): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onTabChanged(tab: 'ANNOTATIONS' | 'NOTES'): void;
 

--- a/src/apps/annotation-text/RightDrawer/RightDrawer.tsx
+++ b/src/apps/annotation-text/RightDrawer/RightDrawer.tsx
@@ -35,6 +35,8 @@ interface RightDrawerProps {
 
   beforeSelectAnnotation(a?: Annotation): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onTabChanged(tab: 'ANNOTATIONS' | 'NOTES'): void;
 
   tab: 'ANNOTATIONS' | 'NOTES';
@@ -115,7 +117,8 @@ export const RightDrawer = (props: RightDrawerProps) => {
                   present={props.present} 
                   sorting={props.sorting}
                   tagVocabulary={props.tagVocabulary}
-                  beforeSelect={props.beforeSelectAnnotation} />
+                  beforeSelect={props.beforeSelectAnnotation}
+                  onNavigateTo={props.onNavigateTo} />
                 ) : (
                   <DocumentNotesList 
                     i18n={props.i18n}
@@ -124,7 +127,8 @@ export const RightDrawer = (props: RightDrawerProps) => {
                     layerNames={props.layerNames}
                     present={props.present}
                     policies={props.policies} 
-                    tagVocabulary={props.tagVocabulary} />
+                    tagVocabulary={props.tagVocabulary}
+                    onNavigateTo={props.onNavigateTo} />
                 )}
             </div>
           </aside>

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -201,6 +201,11 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
   const onRightTabChanged = (tab: 'ANNOTATIONS' | 'NOTES') =>
     setRightPanelTab(tab);
 
+  const onNavigateTo = (annotationId: string) => {
+    anno.state.selection.setSelected(annotationId);
+    anno.scrollIntoView(annotationId);
+  }
+
   const beforeSelectAnnotation = (a?: TextAnnotation) => {
     if (a && !usePopup && anno) {
       // Don't scroll if the annotation is already selected
@@ -330,6 +335,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
                 onSaveError={() => setConnectionError(true)}
                 onLoad={() => setLoading(false)}
                 onLoadEmbeddedLayers={onLoadEmbeddedLayers}
+                onNavigateTo={onNavigateTo}
                 styleSheet={props.styleSheet}
               />
             )}
@@ -346,6 +352,7 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
               style={style}
               tagVocabulary={tagVocabulary}
               beforeSelectAnnotation={beforeSelectAnnotation}
+              onNavigateTo={onNavigateTo}
               onTabChanged={onRightTabChanged}
               tab={rightPanelTab}
             />

--- a/src/apps/annotation-text/TextAnnotationDesktop.tsx
+++ b/src/apps/annotation-text/TextAnnotationDesktop.tsx
@@ -201,9 +201,9 @@ export const TextAnnotationDesktop = (props: TextAnnotationProps) => {
   const onRightTabChanged = (tab: 'ANNOTATIONS' | 'NOTES') =>
     setRightPanelTab(tab);
 
-  const onNavigateTo = (annotationId: string) => {
-    anno.state.selection.setSelected(annotationId);
-    anno.scrollIntoView(annotationId);
+  const onNavigateTo = (annotation: SupabaseAnnotation) => {
+    anno.state.selection.setSelected(annotation.id);
+    anno.scrollIntoView(annotation.id);
   }
 
   const beforeSelectAnnotation = (a?: TextAnnotation) => {

--- a/src/apps/annotation-text/Toolbar/Toolbar.tsx
+++ b/src/apps/annotation-text/Toolbar/Toolbar.tsx
@@ -74,7 +74,7 @@ export const Toolbar = (props: ToolbarProps) => {
 
   const back = `/${props.i18n.lang}/projects/${project_id}`;
 
-  const extensions = useExtensions('annotation.text.toolbar');
+  const extensions = useExtensions('annotation:text:toolbar');
 
   const colorCoding = useColorCoding();
 

--- a/src/components/Annotation/AnnotationCard.tsx
+++ b/src/components/Annotation/AnnotationCard.tsx
@@ -54,6 +54,8 @@ export interface AnnotationCardProps {
 
   onBulkDeleteBodies(bodies: AnnotationBody[]): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onSubmit(): void;
 
   onUpdateBody(oldValue: AnnotationBody, newValue: AnnotationBody): void;
@@ -215,6 +217,7 @@ export const AnnotationCard = (props: AnnotationCardProps) => {
           onDeleteAnnotation={props.onDeleteAnnotation}
           onDeleteBody={props.onDeleteBody}
           onMakePublic={onMakePublic} 
+          onNavigateTo={props.onNavigateTo}
           onSubmit={onSubmit}
           onUpdateAnnotation={props.onUpdateAnnotation} 
           onUpdateBody={props.onUpdateBody} />  
@@ -242,6 +245,7 @@ export const AnnotationCard = (props: AnnotationCardProps) => {
                 onDeleteBody={props.onDeleteBody}
                 onBulkDeleteBodies={props.onBulkDeleteBodies}
                 onMakePublic={() => onMakePublic()}
+                onNavigateTo={props.onNavigateTo}
                 onSubmit={onSubmit}
                 onUpdateAnnotation={props.onUpdateAnnotation}
                 onUpdateBody={props.onUpdateBody} />
@@ -284,6 +288,7 @@ export const AnnotationCard = (props: AnnotationCardProps) => {
                   onDeleteBody={props.onDeleteBody}
                   onBulkDeleteBodies={props.onBulkDeleteBodies}
                   onMakePublic={() => onMakePublic()}
+                  onNavigateTo={props.onNavigateTo}
                   onSubmit={props.onSubmit}
                   onUpdateAnnotation={props.onUpdateAnnotation}
                   onUpdateBody={props.onUpdateBody} />
@@ -314,6 +319,7 @@ export const AnnotationCard = (props: AnnotationCardProps) => {
                   onDeleteBody={props.onDeleteBody}
                   onBulkDeleteBodies={props.onBulkDeleteBodies}
                   onMakePublic={() => onMakePublic()}
+                  onNavigateTo={props.onNavigateTo}
                   onSubmit={props.onSubmit}
                   onUpdateAnnotation={props.onUpdateAnnotation}
                   onUpdateBody={props.onUpdateBody} />
@@ -345,6 +351,7 @@ export const AnnotationCard = (props: AnnotationCardProps) => {
                 me={me}
                 placeholder={props.i18n.t['Reply']}
                 beforeSubmit={beforeReply} 
+                onNavigateTo={props.onNavigateTo}
                 onSubmit={onReply} />
             </animated.div>
           )))}

--- a/src/components/Annotation/AnnotationCard.tsx
+++ b/src/components/Annotation/AnnotationCard.tsx
@@ -54,7 +54,7 @@ export interface AnnotationCardProps {
 
   onBulkDeleteBodies(bodies: AnnotationBody[]): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onSubmit(): void;
 

--- a/src/components/Annotation/AnnotationCardSection.tsx
+++ b/src/components/Annotation/AnnotationCardSection.tsx
@@ -60,6 +60,8 @@ export interface AnnotationCardSectionProps {
 
   onMakePublic(): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onSubmit(): void;
 
   onUpdateAnnotation(updated: SupabaseAnnotation): void;
@@ -303,6 +305,7 @@ export const AnnotationCardSection = (props: AnnotationCardSectionProps) => {
               readOnly={!editable}
               value={commentValue}
               onChange={setCommentValue}
+              onNavigateTo={props.onNavigateTo}
             />
           </div>
         )}

--- a/src/components/Annotation/AnnotationCardSection.tsx
+++ b/src/components/Annotation/AnnotationCardSection.tsx
@@ -60,7 +60,7 @@ export interface AnnotationCardSectionProps {
 
   onMakePublic(): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onSubmit(): void;
 

--- a/src/components/Annotation/EmptyAnnotation.tsx
+++ b/src/components/Annotation/EmptyAnnotation.tsx
@@ -49,6 +49,8 @@ interface EmptyAnnotationProps {
 
   onMakePublic(): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onSubmit(): void;
 
   onUpdateAnnotation(updated: SupabaseAnnotation): void;
@@ -143,6 +145,7 @@ export const EmptyAnnotation = (props: EmptyAnnotationProps) => {
             i18n={props.i18n}
             value={value}
             onChange={setValue}
+            onNavigateTo={props.onNavigateTo}
             placeholder={t['Add a comment']}
           />
         </div>

--- a/src/components/Annotation/EmptyAnnotation.tsx
+++ b/src/components/Annotation/EmptyAnnotation.tsx
@@ -49,7 +49,7 @@ interface EmptyAnnotationProps {
 
   onMakePublic(): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onSubmit(): void;
 

--- a/src/components/Annotation/ReplyField.tsx
+++ b/src/components/Annotation/ReplyField.tsx
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ArrowRight } from '@phosphor-icons/react';
 import { Delta } from 'quill/core';
 import type { AnnotationBody, PresentUser, User } from '@annotorious/react';
+import { AuthorAvatar } from './AuthorAvatar';
 import type {
   SupabaseAnnotation,
   SupabaseAnnotationBody,
@@ -12,7 +13,6 @@ import {
   QuillEditorRoot,
   QuillEditorToolbar,
 } from '@components/QuillEditor';
-import { AuthorAvatar } from './AuthorAvatar';
 import type { Translations } from 'src/Types';
 
 import './ReplyField.css';
@@ -32,7 +32,7 @@ interface ReplyFieldProps {
 
   beforeSubmit?(body: AnnotationBody): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onSubmit(body: AnnotationBody): void;
 }

--- a/src/components/Annotation/ReplyField.tsx
+++ b/src/components/Annotation/ReplyField.tsx
@@ -32,6 +32,8 @@ interface ReplyFieldProps {
 
   beforeSubmit?(body: AnnotationBody): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onSubmit(body: AnnotationBody): void;
 }
 
@@ -78,6 +80,7 @@ export const ReplyField = (props: ReplyFieldProps) => {
             placeholder={props.placeholder}
             value={value}
             onChange={setValue}
+            onNavigateTo={props.onNavigateTo}
           />
 
           <button

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -48,6 +48,8 @@ interface AnnotationListProps<T extends Anno> {
 
   beforeSelect(a: SupabaseAnnotation | undefined): void;
 
+  onNavigateTo(annotationId: string): void;
+
 }
 
 export const AnnotationList = <T extends Anno>(props: AnnotationListProps<T>) => {
@@ -209,6 +211,7 @@ export const AnnotationList = <T extends Anno>(props: AnnotationListProps<T>) =>
               onBulkDeleteBodies={onBulkDeleteBodies}
               onUpdateBody={onUpdateBody}
               onDeleteAnnotation={() => onDeleteAnnotation(annotation)} 
+              onNavigateTo={props.onNavigateTo}
               onSubmit={() => onSubmit(annotation)} />
           </li>
         ))}

--- a/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
+++ b/src/components/AnnotationDesktop/AnnotationList/AnnotationList.tsx
@@ -48,7 +48,7 @@ interface AnnotationListProps<T extends Anno> {
 
   beforeSelect(a: SupabaseAnnotation | undefined): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
 }
 

--- a/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
+++ b/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
@@ -28,7 +28,7 @@ interface AnnotationPopupProps {
 
   tagVocabulary?: VocabularyTerm[];
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
 }
 

--- a/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
+++ b/src/components/AnnotationDesktop/AnnotationPopup/AnnotationPopup.tsx
@@ -28,6 +28,8 @@ interface AnnotationPopupProps {
 
   tagVocabulary?: VocabularyTerm[];
 
+  onNavigateTo(annotationId: string): void;
+
 }
 
 export const AnnotationPopup = (props: AnnotationPopupProps) => {
@@ -91,6 +93,7 @@ export const AnnotationPopup = (props: AnnotationPopupProps) => {
         onBulkDeleteBodies={onBulkDeleteBodies}
         onUpdateBody={onUpdateBody}
         onDeleteAnnotation={() => onDeleteAnnotation(selected)} 
+        onNavigateTo={props.onNavigateTo}
         onSubmit={onSaveAnnotation} />
     </div>
   )

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import type { Delta } from 'quill/core';
 import { useAnnotatorUser } from '@annotorious/react';
 import type { User, AnnotationBody, PresentUser } from '@annotorious/react';
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import type { Layer, Policies, Translations, VocabularyTerm } from 'src/Types';
 import { useNotes } from '../DocumentNotes';
 import { type Sorter, Sorting, SortSelector } from '../SortSelector';
@@ -27,7 +28,7 @@ interface DocumentNotesListProps {
 
   tagVocabulary?: VocabularyTerm[];
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
 }
 

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesList.tsx
@@ -27,6 +27,8 @@ interface DocumentNotesListProps {
 
   tagVocabulary?: VocabularyTerm[];
 
+  onNavigateTo(annotationId: string): void;
+
 }
 
 export const DocumentNotesList = (props: DocumentNotesListProps) => {
@@ -102,6 +104,7 @@ export const DocumentNotesList = (props: DocumentNotesListProps) => {
           me={me}
           tagVocabulary={props.tagVocabulary}
           present={props.present}
+          onNavigateTo={props.onNavigateTo}
           onSubmit={createNote} 
           onCancel={() => setNewNote(undefined)} />
       )}
@@ -129,6 +132,7 @@ export const DocumentNotesList = (props: DocumentNotesListProps) => {
               onDeleteBody={deleteBody}
               onUpdateBody={updateBody}
               onDeleteNote={() => deleteNote(note.id)} 
+              onNavigateTo={props.onNavigateTo}
               onBulkDeleteBodies={onBulkDeleteBodies} />
           </li>
         ))}

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesListItem.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesListItem.tsx
@@ -33,6 +33,8 @@ interface DocumentNotesListItemProps {
 
   onDeleteBody(body: DocumentNoteBody): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onUpdateBody(oldValue: DocumentNoteBody, newValue: DocumentNoteBody): void;
 
 }
@@ -67,6 +69,7 @@ export const DocumentNotesListItem = (props: DocumentNotesListItemProps) => {
       onUpdateBody={props.onUpdateBody}
       onUpdateAnnotation={() => {}}
       onDeleteAnnotation={props.onDeleteNote} 
+      onNavigateTo={props.onNavigateTo}
       onSubmit={() => {}} />
   )
 

--- a/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesListItem.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/DocumentNotesList/DocumentNotesListItem.tsx
@@ -2,6 +2,7 @@ import type { Annotation, AnnotationBody, PresentUser } from '@annotorious/react
 import type { Policies, Translations, VocabularyTerm } from 'src/Types';
 import type { DocumentNote, DocumentNoteBody } from '../Types';
 import { AnnotationCard } from '@components/Annotation';
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 
 interface DocumentNotesListItemProps {
 
@@ -33,7 +34,7 @@ interface DocumentNotesListItemProps {
 
   onDeleteBody(body: DocumentNoteBody): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onUpdateBody(oldValue: DocumentNoteBody, newValue: DocumentNoteBody): void;
 

--- a/src/components/AnnotationDesktop/DocumentNotes/NewNote/EmptyNote.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/NewNote/EmptyNote.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import type { Delta } from 'quill/core';
 import type { PresentUser, User } from '@annotorious/react';
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { ArrowRight } from '@phosphor-icons/react';
 import { QuillEditor, QuillEditorRoot, QuillEditorToolbar } from '@components/QuillEditor';
 import type { Translations, VocabularyTerm } from 'src/Types';
 import { AuthorAvatar } from '@components/Annotation/AuthorAvatar';
 import { TagList } from './TagList';
+
 
 interface EmptyNoteProps {
 
@@ -21,7 +23,7 @@ interface EmptyNoteProps {
 
   onCancel(): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
   onSubmit(content: Delta, tags: VocabularyTerm[], isPrivate?: boolean): void;
 

--- a/src/components/AnnotationDesktop/DocumentNotes/NewNote/EmptyNote.tsx
+++ b/src/components/AnnotationDesktop/DocumentNotes/NewNote/EmptyNote.tsx
@@ -21,6 +21,8 @@ interface EmptyNoteProps {
 
   onCancel(): void;
 
+  onNavigateTo(annotationId: string): void;
+
   onSubmit(content: Delta, tags: VocabularyTerm[], isPrivate?: boolean): void;
 
 }
@@ -72,6 +74,7 @@ export const EmptyNote = (props: EmptyNoteProps) => {
             i18n={props.i18n}
             value={value}
             onChange={setValue}
+            onNavigateTo={props.onNavigateTo}
             placeholder={t['Add a comment']} />
         </div>
 

--- a/src/components/QuillEditor/QuillEditor.tsx
+++ b/src/components/QuillEditor/QuillEditor.tsx
@@ -3,6 +3,7 @@ import Quill from 'quill';
 import { Delta } from 'quill/core';
 import type { Op, QuillOptions } from 'quill/core';
 import { useAnnotations } from '@annotorious/react';
+import type { SupabaseAnnotation } from '@recogito/annotorious-supabase';
 import { useQuillEditor } from './QuillEditorRoot';
 import { getAnnotationIdFromLink, getAnnotationShortLink, isAnnotationLink, splitStringBy } from './utils';
 import type { Translations } from 'src/Types';
@@ -29,7 +30,7 @@ interface QuillEditorProps {
 
   onChange?(value: Delta): void;
 
-  onNavigateTo(annotationId: string): void;
+  onNavigateTo(annotation: SupabaseAnnotation): void;
 
 }
 
@@ -39,7 +40,7 @@ export const QuillEditor = (props: QuillEditorProps) => {
 
   const { quill, setQuill } = useQuillEditor();
 
-  const annotations = useAnnotations();
+  const annotations = useAnnotations<SupabaseAnnotation>();
 
   const isBase64Image = (op: Op) => {
     if (typeof op.insert !== 'object') 
@@ -141,12 +142,14 @@ export const QuillEditor = (props: QuillEditorProps) => {
       if (!link) return; // Not a link
 
       const annotationId = getAnnotationIdFromLink(link.href);
-      if (annotationId && annotations.some(a => a.id === annotationId)) {
-        // Intercept
-        evt.preventDefault();
-        evt.stopPropagation();
+      if (annotationId) {
+        const annotation = annotations.find(a => a.id === annotationId);
+        if (annotation) {
+          evt.preventDefault();
+          evt.stopPropagation();
 
-        props.onNavigateTo(annotationId);
+          props.onNavigateTo(annotation);
+        }
       }
     }
 

--- a/src/components/QuillEditor/utils.ts
+++ b/src/components/QuillEditor/utils.ts
@@ -37,6 +37,24 @@ export const isAnnotationLink = (str: string) => {
   }
 }
 
+export const getAnnotationIdFromLink = (url: string) => {
+  if (!isAnnotationLink(url)) return;
+
+  try {
+    const hash = new URL(url).hash.slice(1);
+    
+    const params = new URLSearchParams(hash);
+    
+    const selected = params.get('selected');    
+    if (selected) {
+      const isUUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+      return isUUID.test(selected) ? selected : undefined;
+    }
+  } catch {
+    // 
+  }
+}
+
 export const getAnnotationShortLink = (str: string) => {
   const hash = new URL(str).hash.slice(1);
   const params = new URLSearchParams(hash);


### PR DESCRIPTION
## In this PR

This PR improves support for links to annotations inside comments. Previously, a link to an annotation would **always** open a new tab. With this PR, link behavior will differ depending on whether the link is to an annotation on the same page or not:
- If on the same page, the linked annotation will be selected.
- In text mode, the interface scrolls to the annotation.
- In image mode, the interface zooms to the annotation.

**Limitation:** clicking a link to an annotation in the same IIIF document, but on a different **page**, will still open a new tab. (This is, unfortunately, a trickier problem to solve.)

Note: this PR also fixes a bug in the IIIF image view which caused the interface to break when an initial selection pointed to an annotation that was not on the first page of the IIIF.