### PR TITLE
IIIF Manifest Export: Menu Tweak

### DIFF
--- a/src/components/DocumentCard/DocumentCardActions.tsx
+++ b/src/components/DocumentCard/DocumentCardActions.tsx
@@ -271,9 +271,11 @@ export const DocumentCardActions = (props: DocumentCardActionsProps) => {
               </Portal>
             </Sub>
 
-            {props.document.meta_data?.protocol === 'IIIF_PRESENTATION' && (
+            {props.document.meta_data?.protocol?.startsWith('IIIF') && (
               <Sub>
-                <SubTrigger className="dropdown-subtrigger">
+                <SubTrigger 
+                  className="dropdown-subtrigger"
+                  disabled={props.document.meta_data.protocol !== 'IIIF_PRESENTATION'}>
                   <DownloadSimple size={16} /> <span>{t['Export IIIF Manifest']}</span>
                   <div className="right-slot">
                     <CaretRight size={14} />


### PR DESCRIPTION
## In this PR

(As discussed in our last meeting) this little tweak keeps the "Export IIIF Manifest" option in the dropdown menu for all images, but shows it as disabled if the image is not a presentation (v2 or v3) manifest.