### PR TITLE
PDF Export: Additional Error Handling

### DIFF
--- a/src/pages/[lang]/projects/[project]/export/pdf.ts
+++ b/src/pages/[lang]/projects/[project]/export/pdf.ts
@@ -59,19 +59,22 @@ const writePDFAnnotations = (pdf: Uint8Array, annotations: SupabaseAnnotation[])
     return `<html><body>${richText}</body></html>`;
   }
 
-  annotations.forEach(annotation => {
-    (annotation.target.selector as PDFSelector[]).forEach(selector => {
-      factory.createHighlightAnnotation({
-        page: selector.pageNumber - 1,
-        richtextString: toRichText(annotation),
-        author: annotation.target.creator?.name,
-        creationDate: annotation.target.created,
-        color: { r: 255, g: 255, b: 0 },
-        quadPoints: selector.quadpoints,
-        opacity: 0.5
+  annotations
+    .filter(annotation => 
+      (annotation.target.selector as PDFSelector[]).every(s => (s.quadpoints || []).length > 0))
+    .forEach(annotation => {
+      (annotation.target.selector as PDFSelector[]).forEach(selector => {
+        factory.createHighlightAnnotation({
+          page: selector.pageNumber - 1,
+          richtextString: toRichText(annotation),
+          author: annotation.target.creator?.name,
+          creationDate: annotation.target.created,
+          color: { r: 255, g: 255, b: 0 },
+          quadPoints: selector.quadpoints,
+          opacity: 0.5
+        });
       });
     });
-  });
 
   return factory.write();
 }


### PR DESCRIPTION
## In this PR

This PR adds an extra safeguard against broken PDF annotations.

The [issue reported here](https://github.com/performant-software/cove-recogito/issues/176#event-18061051493) was caused by an annotation without a text selection (causing the `quadpoints` field in the annotation to be empty). The annotation is also visible in the annotation view sidebar. We need to investigate **how and why** such annotations get created in the first place. This PR simply prevents the export from crashing if such an annotation is in the document.