### PR TITLE
Fixed broken export TEI base layer export

### DIFF
--- a/src/pages/[lang]/projects/[project]/export/tei.ts
+++ b/src/pages/[lang]/projects/[project]/export/tei.ts
@@ -85,7 +85,7 @@ const exportForAssignment = async (supabase: SupabaseClient, url: URL, contextId
 
   const filename = document.name.endsWith('.xml')
     ? `${sanitizeFilename(document.name.slice(0, -4))}-${sanitizeFilename(assignment.data.name || '_base')}.xml`
-    : `${sanitizeFilename(document.name)}-${sanitizeFilename(assignment.data.name)}.xml`;
+    : `${sanitizeFilename(document.name)}-${sanitizeFilename(assignment.data.name || '_base')}.xml`;
 
   return new Response(    
     merged,

--- a/src/util/export/sanitizeFilename.ts
+++ b/src/util/export/sanitizeFilename.ts
@@ -3,7 +3,7 @@ import slugify from 'slugify';
 
 /** Make sure we don't have unsafe or unicode characters in download filenames **/
 export const sanitizeFilename = (unsafe: string) => {
-  const slugified = slugify(unsafe, {
+  const slugified = slugify(unsafe || '', {
     replacement: '_', 
     remove: /[*+~.()'"!:@]/g, 
     lower: false,


### PR DESCRIPTION
## In this PR

This PR fixes a bug that would case TEI base layer assignment exports to break if the TEI filename did not end with `.xml`...