### PR TITLE
Reduce fetch size

### DIFF
--- a/src/components/DocumentLibrary/DocumentLibrary.tsx
+++ b/src/components/DocumentLibrary/DocumentLibrary.tsx
@@ -63,7 +63,7 @@ export interface DocumentLibraryProps {
   isAdmin: boolean | undefined;
 }
 
-const DOCUMENTS_PER_FETCH = 1000;
+const DOCUMENTS_PER_FETCH = 500;
 
 export const DocumentLibrary = (props: DocumentLibraryProps) => {
   const { t } = props.i18n;


### PR DESCRIPTION
# Summary

We are seeing DB timeouts on an instance which appears to be tied to retrieving thje documents for the library.  This just reduces the documents per fetch to try and address this.