### PR TITLE
Dependency Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "@typescript-eslint/parser": "^8.32.1",
         "eslint": "^9.27.0",
         "eslint-plugin-react": "^7.37.5",
-        "typescript": "5.8.3"
+        "typescript": "^5.9.2"
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.25.5",
@@ -18609,9 +18609,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@typescript-eslint/parser": "^8.32.1",
     "eslint": "^9.27.0",
     "eslint-plugin-react": "^7.37.5",
-    "typescript": "5.8.3"
+    "typescript": "^5.9.2"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "^0.25.5",


### PR DESCRIPTION
## In this PR

This PR updates a number of package dependencies which appear safe (but nonetheless will require regression testing).

**Important:** the latest Recogito Studio SDK version (updated in this PR) isn't compatible with older versions of the GeoTagging plugin! Any instance of the Recogito Client that uses the latest SDK package must also install the latest version of the GeoTagging plugin (currently v0.5.0).