### PR TITLE
Allow collection overflow in doc library to scroll

### DIFF
--- a/src/components/DocumentLibrary/DocumentLibrary.css
+++ b/src/components/DocumentLibrary/DocumentLibrary.css
@@ -60,12 +60,22 @@
 }
 
 .doc-lib-header section.doc-lib-header-bottom {
-  padding: 10px 0px 20px 0px;
+  padding: 10px 0px 0px 0px;
   display: flex;
   flex-direction: column;
 }
 
+.doc-lib-header section.doc-lib-header-bottom.collections {
+  max-height: 400px;
+}
+
+.doc-lib-header section.doc-lib-header-bottom.collections > ul {
+  max-height: 100%;
+  overflow-y: scroll;
+}
+
 .doc-lib-header section.doc-lib-header-bottom:not(.collections) {
+  padding-bottom: 20px;
   border-bottom: 1px solid var(--gray-200);
 }
 


### PR DESCRIPTION
### In this PR

- Give collections sidebar section in the doc library a maximum height matching the scrollable documents list
- Scroll vertical overflow in the list of collections (keeping the "Collections" header visible)
- Remove bottom padding from the collections sidebar section