### PR TITLE
Prevent managing externally managed collections

### DIFF
--- a/src/apps/collection-management/CollectionManagement.tsx
+++ b/src/apps/collection-management/CollectionManagement.tsx
@@ -8,7 +8,7 @@ import { TopBar } from '@components/TopBar';
 import {
   archiveCollection,
   createCollection,
-  getCollections,
+  getInstanceCollections,
   updateCollection,
 } from '@backend/crud';
 import { CollectionDialog } from './CollectionDialog/CollectionDialog';
@@ -61,7 +61,7 @@ export const CollectionManagement = (props: CollectionManagementProps) => {
         });
         return;
       } else {
-        getCollections(supabase).then(({ error, data }) => {
+        getInstanceCollections(supabase).then(({ error, data }) => {
           if (error) {
             setToast({
               title: t['Something went wrong'],

--- a/src/backend/crud/collections.ts
+++ b/src/backend/crud/collections.ts
@@ -13,7 +13,7 @@ export const getCollection = (
     .single()
     .then(({ error, data }) => ({ error, data: data as Collection }));
 
-export const getCollections = (
+export const getInstanceCollections = (
   supabase: SupabaseClient,
 ): Response<Collection[]> =>
   supabase
@@ -22,6 +22,7 @@ export const getCollections = (
       *,
       document_count:documents(count)
     `)
+    .is('extension_id', null)
     .then(({ error, data }) => {
       return { error, data: data as Collection[] };
     });

--- a/src/pages/[lang]/collections/index.astro
+++ b/src/pages/[lang]/collections/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import { getCollections } from '@backend/crud';
+import { getInstanceCollections } from '@backend/crud';
 import { getMyProfile } from '@backend/crud/profiles';
 import { CollectionManagement } from '@apps/collection-management';
 
@@ -23,7 +23,7 @@ if (!data.isOrgAdmin) {
 const me = data;
 
 const { error: collectionsError, data: collections } =
-  await getCollections(supabase);
+  await getInstanceCollections(supabase);
 
 if (collectionsError) {
   console.log(collectionsError);


### PR DESCRIPTION
### In this PR

Per meeting 10/15:
- Prevent any collection with a non-null `extension_id` from showing up in the collection management UI
- Rename this CRUD function to `getInstanceCollections` to make this filter more explicit