### PR TITLE
Order collections alphabetically in Document Library

### DIFF
--- a/src/components/DocumentLibrary/DocumentLibrary.tsx
+++ b/src/components/DocumentLibrary/DocumentLibrary.tsx
@@ -265,7 +265,7 @@ export const DocumentLibrary = (props: DocumentLibraryProps) => {
       const resp = await supabase
         .from('collections')
         .select('id, name')
-        .order('created_at');
+        .order('name');
 
       if (!resp.error && resp.data) {
         const arr = [];


### PR DESCRIPTION
### In this PR

Small update to API call for collections list in the document library, to order them alphabetically, rather than by created date.