### PR TITLE
Handle null and non-array selectors in pdf export

### DIFF
--- a/src/pages/[lang]/projects/[project]/export/pdf.ts
+++ b/src/pages/[lang]/projects/[project]/export/pdf.ts
@@ -83,11 +83,20 @@ const writePDFAnnotations = async (pdf: Uint8Array, annotations: SupabaseAnnotat
     return `<html><body>${richText}</body></html>`;
   }
 
-  annotations
-    .filter(annotation => 
-      (annotation.target.selector as PDFSelector[]).every(s => (s.quadpoints || []).length > 0))
-    .forEach(annotation => {
-      (annotation.target.selector as PDFSelector[]).forEach(selector => {
+  annotations.forEach((annotation) => {
+    if (!annotation.target.selector) return;
+    const selectors = Array.isArray(annotation.target.selector)
+      ? annotation.target.selector
+      : [annotation.target.selector];
+
+    selectors
+      .filter(
+        (s): s is PDFSelector =>
+          Array.isArray(s.quadpoints) &&
+          s.quadpoints.length > 0 &&
+          typeof s.pageNumber === 'number'
+      )
+      .forEach((selector) => {
         factory.createHighlightAnnotation({
           page: selector.pageNumber - 1,
           richtextString: toRichText(annotation),
@@ -95,10 +104,10 @@ const writePDFAnnotations = async (pdf: Uint8Array, annotations: SupabaseAnnotat
           creationDate: annotation.target.created,
           color: { r: 255, g: 255, b: 0 },
           quadPoints: selector.quadpoints,
-          opacity: 0.5
+          opacity: 0.5,
         });
       });
-    });
+  });
 
   return factory.write();
 }


### PR DESCRIPTION
### In this PR

Fixes a bug users were encountering where `annotations.filter(annotation => (annotation.target.selector as PDFSelector[]).every` was throwing an error on `.every` when the selector was `null`.

This PR just puts in some safeguards to handle `null` selectors, as well as some other potential problems (single selector, missing/NaN page number).

I'm not sure what might have caused the selector to become null, so that may require some digging if we want to diagnose. This PR just allows the PDF export to happen regardless. FWIW, the record was this one: https://unc.covecollective.org/en/annotate/99e259df-3724-4ac3-a0ee-ecb7802a6fda/5f486654-e902-4884-b728-a9843b795603