### PR TITLE
Pull secrets for Trigger from 1pw in multi-tenant setups (#443)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,9 +59,17 @@ INVITE_CRYPTO_KEY=<base64 encoded 256-bit cryptographic key>
 # PUBLIC_HELP_REDIRECT="https://help.example.com"
 
 # Trigger.dev
-# TRIGGER_SERVER_URL=http://localhost:3040/
+TRIGGER_SERVER_URL=http://localhost:3040/
 TRIGGER_SECRET_KEY=<your secret key>
 TRIGGER_PROJECT_ID=proj_abcdefg
+# Define these for a multi-tenant setup
+# MULTI_TENANT=true
+## 1password Service Account token
+# OP_SERVICE_ACCOUNT_TOKEN=<1pw-token>
+## 1Password Vault name
+# OP_VAULT_NAME=COVE
+## 1Password Item name
+# OP_ITEM_NAME=COVE Studio
 
 # Define these if you are using the NER Plugin
 # TASK_PAYLOAD_OFFLOAD_THRESHOLD=5242880

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ In `.env`, set:
 - `TRIGGER_SECRET_KEY` from your trigger project's `API keys` tab
 - and optionally `TRIGGER_SERVER_URL` if using self-hosted Trigger.
 
-Note that the following environment variables are also required for the Trigger tasks to work (can be added manually to the trigger project after deploy):
+
+#### Self-hosted or single instance
+
+For a self-hosted instance, or a single instance without multiple tenants, the following environment variables are also required for the Trigger tasks to work (can be added manually to the trigger project after deploy):
 ```
-PUBLIC_SUPABASE or SUPABASE_SERVERCLIENT_URL
-PUBLIC_SUPABASE_API_KEY
 SUPABASE_SERVICE_KEY
 IIIF_KEY
-IIIF_URL
-IIIF_PROJECT_ID
 ```
 
 You can then deploy import/export tasks to the Trigger.dev server by executing the following command at the root of this project repo:
@@ -43,6 +42,31 @@ You can then deploy import/export tasks to the Trigger.dev server by executing t
 ~~~
 npx trigger.dev@latest deploy -c ./trigger.config.ts
 ~~~
+
+#### Multi-tenant
+
+For a multi-tenant setup, the Trigger project only needs to be deployed once and it will be reused for all tenants; and instead of sending the above .env vars to Trigger, you set the following:
+
+```
+MULTI_TENANT=true
+OP_SERVICE_ACCOUNT_TOKEN=<1password-service-account-token>
+```
+
+(Currently, only [1Password Service Accounts](https://developer.1password.com/docs/service-accounts/) are supported for managing multi-tenant secrets.)
+
+Then run:
+
+~~~
+npx trigger.dev@latest deploy -c ./trigger.config.ts
+~~~
+
+On each individual tenant, ensure the following environment variables are defined (in recogito-client):
+```
+OP_VAULT_NAME
+OP_ITEM_NAME
+```
+
+And ensure `SUPABASE_SERVICE_KEY` and `IIIF_KEY` are both available in that 1password vault/item.
 
 ### NER plugin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.7.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@1password/sdk": "^0.3.1",
         "@allmaps/iiif-parser": "^1.0.0-beta.45",
         "@annotorious/annotorious": "^3.7.12",
         "@annotorious/react": "^3.7.12",
@@ -52,7 +53,7 @@
         "@supabase/ssr": "0.7.0",
         "@supabase/supabase-js": "^2.58.0",
         "@table-library/react-table-library": "^4.1.15",
-        "@trigger.dev/sdk": "4.3.2",
+        "@trigger.dev/sdk": "4.3.3",
         "@uppy/core": "5.0.2",
         "@uppy/xhr-upload": "5.0.1",
         "accept-language-parser": "^1.5.0",
@@ -95,7 +96,7 @@
         "@astrojs/ts-plugin": "^1.10.4",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.36.0",
-        "@trigger.dev/build": "4.3.2",
+        "@trigger.dev/build": "4.3.3",
         "@types/accept-language-parser": "^1.5.8",
         "@types/adm-zip": "^0.5.7",
         "@types/crypto-js": "4.2.2",
@@ -116,6 +117,21 @@
         "@rollup/rollup-darwin-x64": "^4.52.3",
         "@rollup/rollup-linux-x64-gnu": "^4.52.3"
       }
+    },
+    "node_modules/@1password/sdk": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.3.1.tgz",
+      "integrity": "sha512-20zbQfqsjcECT0gvnAw4zONJDt3XQgNH946pZR0NV1Qxukyaz/DKB0cBnBNCCEWZg93Bah8poaR6gJCyuNX14w==",
+      "license": "MIT",
+      "dependencies": {
+        "@1password/sdk-core": "0.3.1"
+      }
+    },
+    "node_modules/@1password/sdk-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.3.1.tgz",
+      "integrity": "sha512-zFkbRznmE47kpke10OpO/9R0AF5csNWS+naFbadgXuFX1LlxY+2C28NSKbCXhLTqmcuWifBfPdZQ728GJ1i5xg==",
+      "license": "MIT"
     },
     "node_modules/@allmaps/iiif-parser": {
       "version": "1.0.0-beta.45",
@@ -217,18 +233,18 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.8.tgz",
-      "integrity": "sha512-uFNyFWadnULWK2cOw4n0hLKeu+xaVWeuECdP10cQ3K2fkybtTlhb7J7TcScdjmS8Yps7oje9S/ehYMfZrhrgCg==",
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.10.tgz",
+      "integrity": "sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.7.4",
+        "@astrojs/internal-helpers": "0.7.5",
         "@astrojs/prism": "3.3.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
         "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -236,14 +252,20 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.13.0",
-        "smol-toml": "^1.4.2",
+        "shiki": "^3.19.0",
+        "smol-toml": "^1.5.2",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.1",
+        "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
       }
+    },
+    "node_modules/@astrojs/markdown-remark/node_modules/@astrojs/internal-helpers": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
+      "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/netlify": {
       "version": "6.6.0",
@@ -1389,12 +1411,12 @@
       "license": "MIT"
     },
     "node_modules/@capsizecss/unpack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-3.0.0.tgz",
-      "integrity": "sha512-+ntATQe1AlL7nTOYjwjj6w3299CgRot48wL761TUGYpYgAou3AaONZazp0PKZyCyWhudWsjhq1nvRHOvbMzhTA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+      "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
       "license": "MIT",
       "dependencies": {
-        "fontkit": "^2.0.2"
+        "fontkitten": "^1.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -8991,60 +9013,60 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.15.0.tgz",
-      "integrity": "sha512-8TOG6yG557q+fMsSVa8nkEDOZNTSxjbbR8l6lF2gyr6Np+jrPlslqDxQkN6rMXCECQ3isNPZAGszAfYoJOPGlg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.21.0.tgz",
+      "integrity": "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.15.0",
+        "@shikijs/types": "3.21.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.15.0.tgz",
-      "integrity": "sha512-ZedbOFpopibdLmvTz2sJPJgns8Xvyabe2QbmqMTz07kt1pTzfEvKZc5IqPVO/XFiEbbNyaOpjPBkkr1vlwS+qg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.21.0.tgz",
+      "integrity": "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.15.0",
+        "@shikijs/types": "3.21.0",
         "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.3"
+        "oniguruma-to-es": "^4.3.4"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.15.0.tgz",
-      "integrity": "sha512-HnqFsV11skAHvOArMZdLBZZApRSYS4LSztk2K3016Y9VCyZISnlYUYsL2hzlS7tPqKHvNqmI5JSUJZprXloMvA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz",
+      "integrity": "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.15.0",
+        "@shikijs/types": "3.21.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.15.0.tgz",
-      "integrity": "sha512-WpRvEFvkVvO65uKYW4Rzxs+IG0gToyM8SARQMtGGsH4GDMNZrr60qdggXrFOsdfOVssG/QQGEl3FnJ3EZ+8w8A==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.21.0.tgz",
+      "integrity": "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.15.0"
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.15.0.tgz",
-      "integrity": "sha512-8ow2zWb1IDvCKjYb0KiLNrK4offFdkfNVPXb1OZykpLCzRU6j+efkY+Y7VQjNlNFXonSw+4AOdGYtmqykDbRiQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.21.0.tgz",
+      "integrity": "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.15.0"
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.15.0.tgz",
-      "integrity": "sha512-BnP+y/EQnhihgHy4oIAN+6FFtmfTekwOLsQbRw9hOKwqgNy8Bdsjq8B05oAt/ZgvIWWFrshV71ytOrlPfYjIJw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.21.0.tgz",
+      "integrity": "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -9792,15 +9814,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@table-library/react-table-library": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/@table-library/react-table-library/-/react-table-library-4.1.15.tgz",
@@ -9841,14 +9854,14 @@
       "license": "MIT"
     },
     "node_modules/@trigger.dev/build": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/build/-/build-4.3.2.tgz",
-      "integrity": "sha512-MYr2+Sphd9Zeu44q5eLRp+jXj0Km5r9QGjtnmRKFDxK79MbGoL65M8yFXNmMkJmzsBQHcA5USSIJR3QJJnV7kQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@trigger.dev/build/-/build-4.3.3.tgz",
+      "integrity": "sha512-57U2nb8n9RERqFktmamSqriAgK4+e3985fwYi0EHtQ1/WDmQ0KYdiK0FEGN1ls5/vcZxbyfH/cifIA2fW0vHEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@prisma/config": "^6.10.0",
-        "@trigger.dev/core": "4.3.2",
+        "@trigger.dev/core": "4.3.3",
         "mlly": "^1.7.1",
         "pkg-types": "^1.1.3",
         "resolve": "^1.22.8",
@@ -9902,9 +9915,9 @@
       }
     },
     "node_modules/@trigger.dev/core": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/core/-/core-4.3.2.tgz",
-      "integrity": "sha512-CToEt1w1jOmpvwOh/gqgC3UKHw36nrHSxaMYRnv5csXFOMgH2BksD/fZ2M/R2Q8kNehlQGagFWoussGmItxZqw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@trigger.dev/core/-/core-4.3.3.tgz",
+      "integrity": "sha512-HPPxbesDiEEuA1U/Qi1RWXVMkQNDCNyB7zhd3cIYd6T0KUTIt6i7ZdaqSRDhkAxva2hpaWXQsQIYwr5Jnsyohw==",
       "license": "MIT",
       "dependencies": {
         "@bugsnag/cuid": "^3.1.1",
@@ -10073,14 +10086,14 @@
       "license": "MIT"
     },
     "node_modules/@trigger.dev/sdk": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.3.2.tgz",
-      "integrity": "sha512-XbzWBHoVFwvW1uyEbiEmztF86gvLgt0OO/aUqgeOixBAsTXRFxI/zd/scBMHK8vE9jB1D2biI8x5of6gRPEK4g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@trigger.dev/sdk/-/sdk-4.3.3.tgz",
+      "integrity": "sha512-aNKbmn6O8XfAJsQ3j9A8tVUm6nr+5SktHxUs804i7S4BG//b0YX0yhrKwPUe8rUGmFCYxmb3B43OOtZ0MsPyfA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/semantic-conventions": "1.36.0",
-        "@trigger.dev/core": "4.3.2",
+        "@trigger.dev/core": "4.3.3",
         "chalk": "^5.2.0",
         "cronstrue": "^2.21.0",
         "debug": "^4.3.4",
@@ -10095,7 +10108,7 @@
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "ai": "^4.2.0 || ^5.0.0",
+        "ai": "^4.2.0 || ^5.0.0 || ^6.0.0",
         "zod": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -10240,15 +10253,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
-    },
-    "node_modules/@types/fontkit": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.8.tgz",
-      "integrity": "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -11443,65 +11447,66 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.15.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.15.3.tgz",
-      "integrity": "sha512-wUO/isJrcUoduRoKacKB9jpO6TxTlPV1zw8UqQx39jSNY7z9IxusJAiib3AiNvqK+dCWhqXx+OnExCCwELmcUw==",
+      "version": "5.16.15",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.15.tgz",
+      "integrity": "sha512-+X1Z0NTi2pa5a0Te6h77Dgc44fYj63j1yx6+39Nvg05lExajxSq7b1Uj/gtY45zoum8fD0+h0nak+DnHighs3A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@astrojs/compiler": "^2.12.2",
-        "@astrojs/internal-helpers": "0.7.4",
-        "@astrojs/markdown-remark": "6.3.8",
+        "@astrojs/compiler": "^2.13.0",
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/markdown-remark": "6.3.10",
         "@astrojs/telemetry": "3.3.0",
-        "@capsizecss/unpack": "^3.0.0",
+        "@capsizecss/unpack": "^4.0.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.2.0",
+        "@rollup/pluginutils": "^5.3.0",
         "acorn": "^8.15.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
         "boxen": "8.0.1",
-        "ci-info": "^4.3.0",
+        "ci-info": "^4.3.1",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^1.0.1",
-        "cookie": "^1.0.2",
+        "cookie": "^1.1.1",
         "cssesc": "^3.0.0",
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.3.2",
-        "diff": "^5.2.0",
+        "devalue": "^5.6.2",
+        "diff": "^8.0.3",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^1.7.0",
         "esbuild": "^0.25.0",
         "estree-walker": "^3.0.3",
         "flattie": "^1.1.1",
-        "fontace": "~0.3.0",
+        "fontace": "~0.4.0",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
         "import-meta-resolve": "^4.2.0",
-        "js-yaml": "^4.1.0",
-        "magic-string": "^0.30.18",
-        "magicast": "^0.3.5",
+        "js-yaml": "^4.1.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.1",
         "mrmime": "^2.0.1",
         "neotraverse": "^0.6.18",
         "p-limit": "^6.2.0",
-        "p-queue": "^8.1.0",
-        "package-manager-detector": "^1.3.0",
-        "picocolors": "^1.1.1",
+        "p-queue": "^8.1.1",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
         "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
         "rehype": "^13.0.2",
-        "semver": "^7.7.2",
-        "shiki": "^3.12.0",
-        "smol-toml": "^1.4.2",
-        "tinyexec": "^1.0.1",
-        "tinyglobby": "^0.2.14",
+        "semver": "^7.7.3",
+        "shiki": "^3.21.0",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
         "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.6.0",
+        "unifont": "~0.7.3",
         "unist-util-visit": "^5.0.0",
-        "unstorage": "^1.17.0",
+        "unstorage": "^1.17.4",
         "vfile": "^6.0.3",
         "vite": "^6.4.1",
         "vitefu": "^1.1.1",
@@ -11509,7 +11514,7 @@
         "yargs-parser": "^21.1.1",
         "yocto-spinner": "^0.2.3",
         "zod": "^3.25.76",
-        "zod-to-json-schema": "^3.24.6",
+        "zod-to-json-schema": "^3.25.1",
         "zod-to-ts": "^1.2.0"
       },
       "bin": {
@@ -11528,6 +11533,12 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro/node_modules/@astrojs/internal-helpers": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.5.tgz",
+      "integrity": "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==",
+      "license": "MIT"
+    },
     "node_modules/astro/node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -11544,6 +11555,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/astro/node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/async": {
@@ -11859,15 +11881,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/brotli": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -12353,15 +12366,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -12526,12 +12530,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-es": {
@@ -12970,9 +12978,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -13274,9 +13282,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.4.2.tgz",
-      "integrity": "sha512-MwPZTKEPK2k8Qgfmqrd48ZKVvzSQjgW0lXLxiIBA8dQjtf/6mw6pggHNLcyDKyf+fI6eXxlQwPsfaCMTU5U+Bw==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -13292,16 +13300,10 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dfa": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
-      "license": "MIT"
-    },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -14815,30 +14817,24 @@
       "license": "MIT"
     },
     "node_modules/fontace": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.3.1.tgz",
-      "integrity": "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.0.tgz",
+      "integrity": "sha512-moThBCItUe2bjZip5PF/iZClpKHGLwMvR79Kp8XpGRBrvoRSnySN4VcILdv3/MJzbhvUA5WeiUXF5o538m5fvg==",
       "license": "MIT",
       "dependencies": {
-        "@types/fontkit": "^2.0.8",
-        "fontkit": "^2.0.4"
+        "fontkitten": "^1.0.0"
       }
     },
-    "node_modules/fontkit": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
-      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+    "node_modules/fontkitten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.2.tgz",
+      "integrity": "sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==",
       "license": "MIT",
       "dependencies": {
-        "@swc/helpers": "^0.5.12",
-        "brotli": "^1.3.2",
-        "clone": "^2.1.2",
-        "dfa": "^1.2.0",
-        "fast-deep-equal": "^3.1.3",
-        "restructure": "^3.0.0",
-        "tiny-inflate": "^1.0.3",
-        "unicode-properties": "^1.4.0",
-        "unicode-trie": "^2.0.0"
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/for-each": {
@@ -15168,9 +15164,9 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -15295,9 +15291,9 @@
       "license": "MIT"
     },
     "node_modules/h3": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.4.tgz",
-      "integrity": "sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.5.tgz",
+      "integrity": "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
@@ -15305,9 +15301,9 @@
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
-        "node-mock-http": "^1.0.2",
+        "node-mock-http": "^1.0.4",
         "radix3": "^1.1.2",
-        "ufo": "^1.6.1",
+        "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
       }
     },
@@ -15515,15 +15511,15 @@
       }
     },
     "node_modules/hast-util-to-parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz",
-      "integrity": "sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
         "devlop": "^1.0.0",
-        "property-information": "^6.0.0",
+        "property-information": "^7.0.0",
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
@@ -15531,16 +15527,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-parse5/node_modules/property-information": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/hast-util-to-text": {
@@ -16666,9 +16652,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16810,12 +16796,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -17075,15 +17061,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -17218,17 +17204,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/map-obj": {
@@ -17457,9 +17432,9 @@
       }
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -18439,9 +18414,9 @@
       "license": "MIT"
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -18459,9 +18434,9 @@
       }
     },
     "node_modules/node-mock-http": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.3.tgz",
-      "integrity": "sha512-jN8dK25fsfnMrVsEhluUTPkBFY+6ybu7jSB1n+ri/vOGjJxU8J9CZhpSGkHXSkFjtUhbmoncG/YG9ta5Ludqog==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -18496,9 +18471,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
-      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
+      "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -18789,9 +18764,9 @@
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
-      "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
       "license": "MIT",
       "dependencies": {
         "oniguruma-parser": "^0.12.1",
@@ -18996,9 +18971,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.5.0.tgz",
-      "integrity": "sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
     "node_modules/pako": {
@@ -19253,6 +19228,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -19411,9 +19392,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.27.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
-      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -19615,9 +19596,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -20278,9 +20259,9 @@
       }
     },
     "node_modules/regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
-      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -20553,12 +20534,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/restructure": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
-      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
-      "license": "MIT"
     },
     "node_modules/retext": {
       "version": "9.0.0",
@@ -20990,17 +20965,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.15.0.tgz",
-      "integrity": "sha512-kLdkY6iV3dYbtPwS9KXU7mjfmDm25f5m0IPNFnaXO7TBPcvbUOY72PYXSuSqDzwp+vlH/d7MXpHlKO/x+QoLXw==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.21.0.tgz",
+      "integrity": "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.15.0",
-        "@shikijs/engine-javascript": "3.15.0",
-        "@shikijs/engine-oniguruma": "3.15.0",
-        "@shikijs/langs": "3.15.0",
-        "@shikijs/themes": "3.15.0",
-        "@shikijs/types": "3.15.0",
+        "@shikijs/core": "3.21.0",
+        "@shikijs/engine-javascript": "3.21.0",
+        "@shikijs/engine-oniguruma": "3.21.0",
+        "@shikijs/langs": "3.21.0",
+        "@shikijs/themes": "3.21.0",
+        "@shikijs/types": "3.21.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -21123,9 +21098,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
-      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -21702,9 +21677,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -22124,9 +22099,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
     "node_modules/uhyphen": {
@@ -22181,32 +22156,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
-    "node_modules/unicode-properties": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "unicode-trie": "^2.0.0"
-      }
-    },
-    "node_modules/unicode-trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "pako": "^0.2.5",
-        "tiny-inflate": "^1.0.0"
-      }
-    },
-    "node_modules/unicode-trie/node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT"
-    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -22239,14 +22188,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.6.0.tgz",
-      "integrity": "sha512-5Fx50fFQMQL5aeHyWnZX9122sSLckcDvcfFiBf3QYeHa7a1MKJooUy52b67moi2MJYkrfo/TWY+CoLdr/w0tTA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.3.tgz",
+      "integrity": "sha512-b0GtQzKCyuSHGsfj5vyN8st7muZ6VCI4XD4vFlr7Uy1rlWVYxC3npnfk8MyreHxJYrz1ooLDqDzFe9XqQTlAhA==",
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^3.0.0",
-        "ofetch": "^1.4.1",
-        "ohash": "^2.0.0"
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -22406,19 +22355,19 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.2.tgz",
-      "integrity": "sha512-cKEsD6iBWJgOMJ6vW1ID/SYuqNf8oN4yqRk8OYqaVQ3nnkJXOT1PSpaMh2QfzLs78UN5kSNRD2c/mgjT8tX7+w==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.4.tgz",
+      "integrity": "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
-        "chokidar": "^4.0.3",
+        "chokidar": "^5.0.0",
         "destr": "^2.0.5",
-        "h3": "^1.15.4",
-        "lru-cache": "^10.4.3",
+        "h3": "^1.15.5",
+        "lru-cache": "^11.2.0",
         "node-fetch-native": "^1.6.7",
-        "ofetch": "^1.5.0",
-        "ufo": "^1.6.1"
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
       },
       "peerDependencies": {
         "@azure/app-configuration": "^1.8.0",
@@ -22427,14 +22376,14 @@
         "@azure/identity": "^4.6.0",
         "@azure/keyvault-secrets": "^4.9.0",
         "@azure/storage-blob": "^12.26.0",
-        "@capacitor/preferences": "^6.0.3 || ^7.0.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
         "@deno/kv": ">=0.9.0",
         "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
         "@planetscale/database": "^1.19.0",
         "@upstash/redis": "^1.34.3",
         "@vercel/blob": ">=0.27.1",
         "@vercel/functions": "^2.2.12 || ^3.0.0",
-        "@vercel/kv": "^1.0.1",
+        "@vercel/kv": "^1 || ^2 || ^3",
         "aws4fetch": "^1.0.20",
         "db0": ">=0.2.1",
         "idb-keyval": "^6.2.1",
@@ -22501,11 +22450,42 @@
         }
       }
     },
+    "node_modules/unstorage/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/unstorage/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/unstorage/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/untun": {
       "version": "0.1.3",
@@ -23527,12 +23507,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-to-ts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "node copy-pdf-worker.js"
   },
   "dependencies": {
+    "@1password/sdk": "^0.3.1",
     "@allmaps/iiif-parser": "^1.0.0-beta.45",
     "@annotorious/annotorious": "^3.7.12",
     "@annotorious/react": "^3.7.12",
@@ -55,7 +56,7 @@
     "@supabase/ssr": "0.7.0",
     "@supabase/supabase-js": "^2.58.0",
     "@table-library/react-table-library": "^4.1.15",
-    "@trigger.dev/sdk": "4.3.2",
+    "@trigger.dev/sdk": "4.3.3",
     "@uppy/core": "5.0.2",
     "@uppy/xhr-upload": "5.0.1",
     "accept-language-parser": "^1.5.0",
@@ -98,7 +99,7 @@
     "@astrojs/ts-plugin": "^1.10.4",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.36.0",
-    "@trigger.dev/build": "4.3.2",
+    "@trigger.dev/build": "4.3.3",
     "@types/accept-language-parser": "^1.5.8",
     "@types/adm-zip": "^0.5.7",
     "@types/crypto-js": "4.2.2",

--- a/src/pages/api/run-job.ts
+++ b/src/pages/api/run-job.ts
@@ -3,6 +3,14 @@ import { configure, tasks } from '@trigger.dev/sdk';
 import type { runJob } from '@trigger/runJob';
 import type { APIRoute } from 'astro';
 
+interface EnvVars {
+  publicSupabaseUrl: string;
+  publicSupabaseApiKey: string;
+  iiifProjectId: string;
+  iiifUrl: string;
+  vaultTenantPath?: string;
+}
+
 configure({
   secretKey:
     process?.env.TRIGGER_SECRET_KEY || import.meta.env.TRIGGER_SECRET_KEY,
@@ -14,7 +22,9 @@ export const POST: APIRoute = async ({ cookies, request }) => {
   // Verify if the user is logged in
   const supabase = await createSupabaseServerClient(request, cookies);
   if (!supabase) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+    });
   }
 
   // User must be an Org Admin to use this endpoint
@@ -23,17 +33,24 @@ export const POST: APIRoute = async ({ cookies, request }) => {
   const userResp = await supabase.auth.getUser();
 
   if (userResp.error) {
-    return new Response(JSON.stringify({ error: 'Failed to get user' }), { status: 500 });
+    return new Response(JSON.stringify({ error: 'Failed to get user' }), {
+      status: 500,
+    });
   }
 
   const user = userResp.data;
   const id = user.user.id;
 
   // Is the user an Org Admin?
-  const orgAdminResp = await supabase.rpc('is_admin_organization', { user_id: id });
+  const orgAdminResp = await supabase.rpc('is_admin_organization', {
+    user_id: id,
+  });
 
   if (orgAdminResp.error) {
-    return new Response(JSON.stringify({ error: 'Failed to get org admin response' }), { status: 500 });
+    return new Response(
+      JSON.stringify({ error: 'Failed to get org admin response' }),
+      { status: 500 }
+    );
   }
 
   if (!orgAdminResp.data) {
@@ -47,7 +64,9 @@ export const POST: APIRoute = async ({ cookies, request }) => {
   const sessionResp = await supabase.auth.getSession();
 
   if (sessionResp.error) {
-    return new Response(JSON.stringify({ error: 'Failed to get session' }), { status: 500 });
+    return new Response(JSON.stringify({ error: 'Failed to get session' }), {
+      status: 500,
+    });
   }
 
   if (!sessionResp.data) {
@@ -57,7 +76,38 @@ export const POST: APIRoute = async ({ cookies, request }) => {
   }
 
   const token = sessionResp.data.session?.access_token || '';
-  const handle = await tasks.trigger<typeof runJob>('run-job', { jobId, token, ...rest });
+
+  // pass non-secret, tenant-specific environment variables to trigger
+  const envVars: EnvVars = {
+    publicSupabaseUrl:
+      process?.env.SUPABASE_SERVERCLIENT_URL ||
+      import.meta.env.SUPABASE_SERVERCLIENT_URL ||
+      process?.env.PUBLIC_SUPABASE ||
+      import.meta.env.PUBLIC_SUPABASE,
+    publicSupabaseApiKey:
+      process?.env.PUBLIC_SUPABASE_API_KEY ||
+      import.meta.env.PUBLIC_SUPABASE_API_KEY,
+    iiifProjectId:
+      process?.env.IIIF_PROJECT_ID || import.meta.env.IIIF_PROJECT_ID,
+    iiifUrl: process?.env.IIIF_URL || import.meta.env.IIIF_URL,
+  };
+
+  // if multi-tenant, pass tenant path (1pw vault name + item name)
+  const OP_VAULT_NAME =
+    process?.env.OP_VAULT_NAME || import.meta.env.OP_VAULT_NAME;
+  const OP_ITEM_NAME =
+    process?.env.OP_ITEM_NAME || import.meta.env.OP_ITEM_NAME;
+
+  if (OP_VAULT_NAME && OP_ITEM_NAME) {
+    envVars['vaultTenantPath'] = `${OP_VAULT_NAME}/${OP_ITEM_NAME}`;
+  }
+
+  const handle = await tasks.trigger<typeof runJob>('run-job', {
+    jobId,
+    token,
+    ...envVars,
+    ...rest,
+  });
 
   if (handle) {
     return new Response(

--- a/src/trigger/exportProject/index.ts
+++ b/src/trigger/exportProject/index.ts
@@ -10,13 +10,12 @@ import { logger, task } from '@trigger.dev/sdk/v3';
 import { exportProfiles } from '@trigger/exportProject/users';
 import AdmZip from 'adm-zip';
 
-const SUPABASE_SERVER_URL = process.env.SUPABASE_SERVERCLIENT_URL || process.env.PUBLIC_SUPABASE;
-const SUPABASE_API_KEY = process.env.PUBLIC_SUPABASE_API_KEY;
-
 interface Payload {
   jobId: string;
   projectId?: string;
   token: string;
+  publicSupabaseUrl: string;
+  publicSupabaseApiKey: string;
 }
 
 const addToZip = (
@@ -40,9 +39,9 @@ const addDocumentsToZip = (
 export const exportProject = task({
   id: 'export-project',
   run: async (payload: Payload) => {
-    const { jobId, projectId, token } = payload;
+    const { jobId, projectId, token, publicSupabaseUrl, publicSupabaseApiKey } = payload;
 
-    if (!(SUPABASE_SERVER_URL && SUPABASE_API_KEY)) {
+    if (!(publicSupabaseUrl && publicSupabaseApiKey)) {
       logger.error('Invalid Supabase credentials');
       return;
     }
@@ -54,7 +53,7 @@ export const exportProject = task({
 
     logger.info('Creating Supabase client');
 
-    const supabase = createClient(SUPABASE_SERVER_URL, SUPABASE_API_KEY, {
+    const supabase = createClient(publicSupabaseUrl, publicSupabaseApiKey, {
       global: {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/src/trigger/importProject/index.ts
+++ b/src/trigger/importProject/index.ts
@@ -5,29 +5,56 @@ import { logger, task } from '@trigger.dev/sdk/v3';
 import { generatePassword } from '@util/auth';
 import AdmZip from 'adm-zip';
 import { v4 as uuidv4 } from 'uuid';
+import * as sdk from '@1password/sdk';
 
 interface Payload {
   jobId: string;
   token: string;
+  publicSupabaseUrl: string;
+  publicSupabaseApiKey: string;
+  iiifProjectId: string;
+  iiifUrl: string;
+  vaultTenantPath?: string;
 }
-
-const IIIF_KEY = process.env.IIIF_KEY;
-const IIIF_URL = process.env.IIIF_URL;
-const IIIF_PROJECT_ID = process.env.IIIF_PROJECT_ID;
-
-const SUPABASE_SERVER_URL = process.env.SUPABASE_SERVERCLIENT_URL || process.env.PUBLIC_SUPABASE;
-const SUPABASE_API_KEY = process.env.PUBLIC_SUPABASE_API_KEY;
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 
 const DOCUMENTS_PREFIX = 'documents/';
 const JSON_EXTENSION = '.json';
 
 const PASSWORD_LENGTH = 14;
 
+const getSecrets = async (vaultTenantPath?: string) => {
+  // allow multi-tenant setup with 1password service account and vault path
+  const isMultiTenant =
+    process.env.MULTI_TENANT === 'true' && process.env.OP_SERVICE_ACCOUNT_TOKEN;
+
+  if (!isMultiTenant || !vaultTenantPath) {
+    // otherwise just use env vars
+    return {
+      IIIF_KEY: process.env.IIIF_KEY || '',
+      SUPABASE_SERVICE_KEY: process.env.SUPABASE_SERVICE_KEY || '',
+    };
+  }
+  const client = await sdk.createClient({
+    auth: process.env.OP_SERVICE_ACCOUNT_TOKEN!,
+    integrationName: 'Trigger.dev import/export multi-tenant',
+    integrationVersion: '1.0.0',
+  });
+  const IIIF_KEY = await client.secrets.resolve(
+    `op://${vaultTenantPath}/IIIF_KEY`
+  );
+  const SUPABASE_SERVICE_KEY = await client.secrets.resolve(
+    `op://${vaultTenantPath}/SUPABASE_SERVICE_KEY`
+  );
+  return { IIIF_KEY, SUPABASE_SERVICE_KEY };
+};
+
 const createDocuments = async (
   supabase: SupabaseClient,
   importId: string,
-  zip: AdmZip
+  zip: AdmZip,
+  iiifProjectId: string,
+  iiifUrl: string,
+  iiifKey: string,
 ) => {
   const zipEntries = zip.getEntries();
 
@@ -74,7 +101,7 @@ const createDocuments = async (
         } else if (id && metadata?.protocol === 'IIIF_IMAGE') {
           logger.info(`Uploading image: ${id}`);
 
-          const { resource } = await uploadImage(name, file);
+          const { resource } = await uploadImage(name, file, iiifProjectId, iiifUrl, iiifKey);
           const url = resource.content_iiif_url.replace('full/max/0/default.jpg', 'info.json');
 
           const { data, error } = await updateDocumentMetadata(supabase, id, name, { ...metadata, url });
@@ -96,9 +123,11 @@ const createDocuments = async (
 
 const createUsers = async (
   supabase: SupabaseClient,
-  importId: string
+  importId: string,
+  publicSupabaseUrl: string,
+  supabaseServiceKey: string,
 ) => {
-  if (!(SUPABASE_SERVER_URL && SUPABASE_SERVICE_KEY)) {
+  if (!(publicSupabaseUrl && supabaseServiceKey)) {
     logger.error('Invalid admin credentials');
     return;
   }
@@ -112,7 +141,7 @@ const createUsers = async (
 
   if (profiles) {
     // Import jobs can only ever be run by an org admin user, so we'll use the service key to create the user
-    const supa = await createClient(SUPABASE_SERVER_URL, SUPABASE_SERVICE_KEY);
+    const supa = await createClient(publicSupabaseUrl, supabaseServiceKey);
 
     for (const profile of profiles) {
       await supa.auth.admin.createUser({
@@ -232,9 +261,12 @@ const uploadFile = async (
 
 const uploadImage = async (
   name: string,
-  buffer: Buffer
+  buffer: Buffer,
+  iiifProjectId: string,
+  iiifUrl: string,
+  iiifKey: string,
 ) => {
-  if (!(IIIF_PROJECT_ID && IIIF_URL && IIIF_KEY)) {
+  if (!(iiifProjectId && iiifUrl && iiifKey)) {
     logger.error('Invalid IIIF credentials');
     return;
   }
@@ -245,13 +277,13 @@ const uploadImage = async (
   // Forward as outgoing FormData
   const formData = new FormData();
   formData.append('resource[name]', name);
-  formData.append('resource[project_id]', IIIF_PROJECT_ID);
+  formData.append('resource[project_id]', iiifProjectId);
   formData.append('resource[content]', file);
 
-  const response = await fetch(IIIF_URL, {
+  const response = await fetch(iiifUrl, {
     body: formData,
     headers: {
-      'X-API-KEY': IIIF_KEY,
+      'X-API-KEY': iiifKey,
     },
     method: 'POST'
   });
@@ -262,9 +294,17 @@ const uploadImage = async (
 export const importProject = task({
   id: 'import-project',
   run: async (payload: Payload) => {
-    const { jobId, token } = payload;
+    const {
+      jobId,
+      token,
+      publicSupabaseUrl,
+      publicSupabaseApiKey,
+      iiifProjectId,
+      iiifUrl,
+      vaultTenantPath,
+    } = payload;
 
-    if (!(SUPABASE_SERVER_URL && SUPABASE_API_KEY)) {
+    if (!(publicSupabaseUrl && publicSupabaseApiKey)) {
       logger.error('Invalid Supabase credentials');
       return;
     }
@@ -274,7 +314,7 @@ export const importProject = task({
 
     logger.info('Creating Supabase client');
 
-    const supabase = createClient(SUPABASE_SERVER_URL, SUPABASE_API_KEY, {
+    const supabase = createClient(publicSupabaseUrl, publicSupabaseApiKey, {
       global: {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -297,11 +337,13 @@ export const importProject = task({
     // Load the data into the database tables
     await load(supabase, importId);
 
+    const { IIIF_KEY, SUPABASE_SERVICE_KEY } = await getSecrets(vaultTenantPath);
+
     // Create documents in storage
-    await createDocuments(supabase, importId, zip);
+    await createDocuments(supabase, importId, zip, iiifProjectId, iiifUrl, IIIF_KEY);
 
     // Create users in auth schema
-    await createUsers(supabase, importId);
+    await createUsers(supabase, importId, publicSupabaseUrl, SUPABASE_SERVICE_KEY);
 
     logger.info(`Completed import: ${importId}`);
   }

--- a/src/trigger/runJob.ts
+++ b/src/trigger/runJob.ts
@@ -5,15 +5,15 @@ import type { exportProject } from '@trigger/exportProject';
 import type { importProject } from '@trigger/importProject';
 
 interface Payload {
-  key: string;
   jobId: string;
   projectId?: string;
-  serverURL: string;
   token: string;
+  publicSupabaseUrl: string;
+  publicSupabaseApiKey: string;
+  iiifProjectId: string;
+  iiifUrl: string;
+  vaultTenantPath?: string;
 }
-
-const SUPABASE_SERVER_URL = process.env.SUPABASE_SERVERCLIENT_URL || process.env.PUBLIC_SUPABASE;
-const SUPABASE_API_KEY = process.env.PUBLIC_SUPABASE_API_KEY;
 
 const TASK_EXPORT = 'export-project';
 const TASK_IMPORT = 'import-project';
@@ -21,14 +21,16 @@ const TASK_IMPORT = 'import-project';
 export const runJob = task({
   id: 'run-job',
   run: async (payload: Payload) => {
-    if (!(SUPABASE_SERVER_URL && SUPABASE_API_KEY)) {
+    const { publicSupabaseUrl, publicSupabaseApiKey } = payload;
+
+    if (!(publicSupabaseUrl && publicSupabaseApiKey)) {
       logger.error('Invalid Supabase credentials');
       return;
     }
 
     const { jobId, token, ...rest } = payload;
 
-    const supabase = createClient(SUPABASE_SERVER_URL, SUPABASE_API_KEY, {
+    const supabase = createClient(publicSupabaseUrl, publicSupabaseApiKey, {
       global: {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -54,7 +56,9 @@ export const runJob = task({
     }
 
     if (!task) {
-      logger.error(`Unable to find task for job_type: ${jobResp.data.job_type}`);
+      logger.error(
+        `Unable to find task for job_type: ${jobResp.data.job_type}`
+      );
       return;
     }
 
@@ -62,17 +66,19 @@ export const runJob = task({
     await updateJob(supabase, { id: jobId, job_status: 'PROCESSING' });
 
     // Run the job
-    const result = await tasks.triggerAndWait<typeof exportProject | typeof importProject>(task, {
+    const result = await tasks.triggerAndWait<
+      typeof exportProject | typeof importProject
+    >(task, {
       token,
       jobId,
-      ...rest
+      ...rest,
     });
 
     // Update the job status based on the result
     if (result.ok) {
-      await updateJob(supabase, { id: jobId, job_status: 'COMPLETE'});
+      await updateJob(supabase, { id: jobId, job_status: 'COMPLETE' });
     } else {
-      await updateJob(supabase, { id: jobId, job_status: 'ERROR'});
+      await updateJob(supabase, { id: jobId, job_status: 'ERROR' });
     }
-  }
+  },
 });

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -24,26 +24,21 @@ export default defineConfig({
   build: {
     extensions: [
       syncEnvVars(async (_) => {
-        return [
-          { name: 'IIIF_KEY', value: process.env.IIIF_KEY || '' },
-          { name: 'IIIF_URL', value: process.env.IIIF_URL || '' },
-          { name: 'IIIF_PROJECT_ID', value: process.env.IIIF_PROJECT_ID || '' },
-          {
-            name: 'SUPABASE_SERVICE_KEY',
-            value: process.env.SUPABASE_SERVICE_KEY || '',
-          },
-          {
-            name: 'PUBLIC_SUPABASE_API_KEY',
-            value: process.env.PUBLIC_SUPABASE_API_KEY || '',
-          },
-          {
-            name: 'SUPABASE_SERVERCLIENT_URL',
-            value:
-              process.env.SUPABASE_SERVERCLIENT_URL ||
-              process.env.PUBLIC_SUPABASE ||
-              '',
-          },
-        ];
+        return process.env.MULTI_TENANT && process.env.OP_SERVICE_ACCOUNT_TOKEN
+          ? [
+              { name: 'MULTI_TENANT', value: 'true' },
+              {
+                name: 'OP_SERVICE_ACCOUNT_TOKEN',
+                value: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+              },
+            ]
+          : [
+              { name: 'IIIF_KEY', value: process.env.IIIF_KEY || '' },
+              {
+                name: 'SUPABASE_SERVICE_KEY',
+                value: process.env.SUPABASE_SERVICE_KEY || '',
+              },
+            ];
       }),
     ],
   },


### PR DESCRIPTION
### In this PR

Per #443:
- Bump trigger to latest version
- Update trigger tasks:
   - Allow fetching environment secrets per-tenant via 1password Service Accounts using a global service account token, stored in Trigger; and the path to the vault item containing the secrets, passed from each tenant via POST
   - (and, if disabled, allow users to just use the environment variables in the Trigger environment as before)
   - Convert all non-secret environment variables into POST request params, to eliminate the need to add any new ones to 1pw
- Add project-level environment variables (`MULTI_TENANT` and `OP_SERVICE_ACCOUNT_TOKEN`) to `.env`
- Add tenant-level environment variables (`OP_VAULT_NAME`, `OP_ITEM_NAME`) to `.env`
- Populate some initial env vars in the config to deploy to Trigger
- Add some explanations to readme

And related to https://github.com/recogito/plugin-ner/pull/4:
- Include `TRIGGER_NER_SECRET_KEY` and explain in the readme how it should be used

### Notes

- We no longer need to create the trigger project (or seed it with the `MULTI_TENANT` and `OP_SERVICE_ACCOUNT_TOKEN` env vars) from `recogito-cloud`, as I already did that from my local; all tenants will use that project.
- We will, however, need to update `recogito-cloud` to set the `OP_VAULT_NAME`, `OP_ITEM_NAME`, and `TRIGGER_NER_SECRET_KEY` variables and pass them to every netlify instance.