### PR TITLE
Improvements to sign-in redirect flow (COVE #217)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,9 @@ export default defineConfig({
   i18n: {
     locales: ['en', 'de'],
     defaultLocale: 'en',
+    routing: {
+      prefixDefaultLocale: true,
+    },
   },
   integrations: [react()],
   output: 'server',

--- a/src/apps/auth-keycloak/AuthKeycloak.tsx
+++ b/src/apps/auth-keycloak/AuthKeycloak.tsx
@@ -18,25 +18,24 @@ const AuthKeycloak = () => {
   }
 
   useEffect(() => {
+    const callbackUrl = `${window.location.origin}/auth/callback`;
+    const next = redirectUrl || `/${i18n.language}/projects`;
     supabaseImplicit.auth
       .signInWithOAuth({
         provider: 'keycloak',
         options: {
           scopes: 'openid',
-          redirectTo: redirectUrl
-            ? redirectUrl
-            : `/${i18n.language}/projects`,
+          redirectTo: `${callbackUrl}?next=${next}`,
         },
       })
       .then(({ data, error }) => {
         if (data?.url) {
-          localStorage.removeItem('redirect-to');
           window.location.href = data.url;
         } else {
           console.error(error);
         }
       });
-  }, []);
+  }, [redirectUrl]);
 
   return <div className='keycloak-main'>{t('Redirecting', { ns: 'auth-login' })}</div>;
 };

--- a/src/apps/auth-login/Login.tsx
+++ b/src/apps/auth-login/Login.tsx
@@ -28,22 +28,19 @@ const clearCookies = () => {
   document.cookie = `sb-auth-token=; path=/; expires=${expires}; SameSite=Lax; secure`;
 };
 
-const Login = (props: {
-  methods: LoginMethod[];
-}) => {
+const Login = (props: { methods: LoginMethod[] }) => {
   const [isChecking, setIsChecking] = useState(true);
 
   const [primary, ...loginMethods] = props.methods;
   const { t, i18n } = useTranslation(['auth-login']);
 
-  const host =
-    window.location.port !== ''
-      ? `${window.location.protocol}//${window.location.hostname}:${window.location.port}`
-      : `${window.location.protocol}//${window.location.hostname}`;
-
   const url = new URLSearchParams(window.location.search);
   let redirectUrl = url.get('redirect-to');
   if (redirectUrl) {
+    if (redirectUrl.includes('/sign-in')) {
+      // don't allow loop back to sign-in from sign-in; go to projects instead
+      redirectUrl = `/${i18n.language}/projects`;
+    }
     localStorage.setItem('redirect-to', redirectUrl);
   } else {
     redirectUrl = localStorage.getItem('redirect-to');
@@ -51,47 +48,54 @@ const Login = (props: {
       redirectUrl = null;
     }
   }
+  const next = redirectUrl || `/${i18n.language}/projects`;
 
   useEffect(() => {
-    supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_OUT') {
-        clearCookies();
-        redirectUrl = null;
-      } else if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-        setCookies(session);
-        if (redirectUrl) {
-          localStorage.removeItem('redirect-to');
-          window.location.href = redirectUrl;
-        } else {
-          window.location.href = `/${i18n.language}/projects`;
+    let isRedirecting = false;
+
+    const performRedirect = (session: Session | null) => {
+      // prevent multiple redirects race condition
+      if (isRedirecting || !session) {
+        return;
+      }
+
+      // set session cookies, perform the redirect
+      isRedirecting = true;
+      setCookies(session);
+      localStorage.removeItem('redirect-to');
+      window.location.replace(next);
+    };
+
+    const { data: authListener } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        if (event === 'SIGNED_OUT') {
+          clearCookies();
+        } else if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+          performRedirect(session);
         }
       }
-    });
+    );
 
     isLoggedIn(supabase).then((loggedIn) => {
       if (loggedIn) {
         supabase.auth.getSession().then(({ data: { session } }) => {
-          setCookies(session);
-          if (redirectUrl) {
-            localStorage.removeItem('redirect-to');
-            window.location.href = redirectUrl;
-          } else {
-            window.location.href = `/${i18n.language}/projects`;
-          }
+          performRedirect(session);
         });
       } else {
         setIsChecking(false);
       }
     });
-  }, []);
+
+    // ensure we stop firing onAuthStateChange
+    return () => authListener.subscription.unsubscribe();
+  }, [next]);
 
   const signInWithSSO = (domain: string) => {
+    const redirectTo = `${window.location.origin}/auth/callback?next=${next}`;
     supabase.auth
       .signInWithSSO({
         domain: domain,
-        options: {
-          redirectTo: `${host}/auth/callback`,
-        },
+        options: { redirectTo },
       })
       .then(({ data, error }) => {
         if (data?.url) {
@@ -103,7 +107,7 @@ const Login = (props: {
   };
 
   const signInWithKeycloak = () => {
-    window.location.href = `/${i18n.language}/keycloak`;
+    window.location.href = `/${i18n.language}/keycloak?redirect-to=${next}`;
   };
 
   const renderLoginButton = useCallback(

--- a/src/apps/join-project/JoinProject.tsx
+++ b/src/apps/join-project/JoinProject.tsx
@@ -18,13 +18,8 @@ const JoinProject = (props: JoinProjectProps) => {
     joinProject(supabase, props.project.id).then((resp) => {
 
       if (resp) {
-        const url = new URLSearchParams(window.location.search);
-        const redirectUrl = url.get('redirect-to');
-        if (redirectUrl) {
-          window.location.href = redirectUrl;
-        } else {
-          window.location.href = `/${i18n.language}/projects`;
-        }
+        // redirect to project on success
+        window.location.href = `/${i18n.language}/projects/${props.project.id}`;
       } else {
         window.location.href = `/${i18n.language}/projects`;
       }

--- a/src/apps/project-request/ProjectRequest.tsx
+++ b/src/apps/project-request/ProjectRequest.tsx
@@ -10,10 +10,7 @@ import clientI18next from 'src/i18n/client';
 import './ProjectRequest.css';
 
 interface ProjectRequestProps {
-
   projectId: string;
-
-  isAlreadyMember: boolean;
 
   user: MyProfile;
 }
@@ -64,46 +61,26 @@ const ProjectRequest = (props: ProjectRequestProps) => {
       <>
         <TopBar onError={() => {}} me={props.user} />
         <div className='project-request-root'>
-          {!props.isAlreadyMember ? (
-            <>
-              <div className='project-request-title'>
-                {`${t('Do you wish to request membership for project', { ns: 'project-request' })}: ${projectName}?`}
-              </div>
+          <div className='project-request-title'>
+            {`${t('Do you wish to request membership for project', { ns: 'project-request' })}: ${projectName}?`}
+          </div>
 
-              <div className='project-request-button-container'>
-                <button
-                  className='project-request-dialog-button-cancel'
-                  onClick={() =>
-                    (window.location.href = `/${i18n.language}/projects`)
-                  }
-                >
-                  {t('Cancel', { ns: 'common' })}
-                </button>
-                <button
-                  className='project-request-dialog-button-join'
-                  onClick={handleRequest}
-                >
-                  {t('Request', { ns: 'project-request' })}
-                </button>
-              </div>
-            </>
-          ) : (
-            <>
-              <div className='project-request-title'>
-                {`${t('You are already a member of this project. You can navigate to it from the Projects screen > My Projects', { ns: 'project-request' })} > ${projectName}`}
-              </div>
-              <div className='project-request-button-container'>
-                <button
-                  className='primary project-request-dialog-button-cancel'
-                  onClick={() =>
-                    (window.location.href = `/${i18n.language}/projects/${props.projectId}`)
-                  }
-                >
-                  {t('Go To Project', { ns: 'project-request' })}
-                </button>
-              </div>
-            </>
-          )}
+          <div className='project-request-button-container'>
+            <button
+              className='project-request-dialog-button-cancel'
+              onClick={() =>
+                (window.location.href = `/${i18n.language}/projects`)
+              }
+            >
+              {t('Cancel', { ns: 'common' })}
+            </button>
+            <button
+              className='project-request-dialog-button-join'
+              onClick={handleRequest}
+            >
+              {t('Request', { ns: 'project-request' })}
+            </button>
+          </div>
         </div>
       </>
     );

--- a/src/components/CheckRedirect/CheckRedirect.tsx
+++ b/src/components/CheckRedirect/CheckRedirect.tsx
@@ -2,11 +2,17 @@ import { useEffect } from 'react';
 
 export const CheckRedirect = () => {
   useEffect(() => {
-    const redirectUrl = localStorage.getItem('redirect-to');
+    const params = new URLSearchParams(window.location.search);
+    const noRedirect = params.get('no-redirect');
+    if (noRedirect) {
+      localStorage.removeItem('redirect-to');
+      return;
+    }
+    const redirectUrl = params.get('next') || localStorage.getItem('redirect-to');
 
     if (redirectUrl && redirectUrl.length > 0) {
       localStorage.removeItem('redirect-to');
-      window.location.href = redirectUrl;
+      window.location.replace(redirectUrl);
     }
   }, []);
 

--- a/src/pages/[lang]/projects/[project]/accept-invite.astro
+++ b/src/pages/[lang]/projects/[project]/accept-invite.astro
@@ -24,7 +24,7 @@ const invitation = await supabase
   .single();
 
 if (!invitation.data || invitation.error) {
-  return Astro.redirect(`/${lang}/projects`);
+  return Astro.redirect(`/${lang}/projects?no-redirect=true`);
 }
 ---
 

--- a/src/pages/[lang]/projects/[project]/join.astro
+++ b/src/pages/[lang]/projects/[project]/join.astro
@@ -13,7 +13,7 @@ const projectId = Astro.params.project;
 
 const profile = await getMyProfile(supabase);
 if (profile.error || !profile.data) {
-  return Astro.redirect(`/${lang}/sign-in`);
+  return Astro.redirect(`/${lang}/sign-in?redirect-to=${Astro.url}`);
 }
 
 const project = await getProjectExtended(supabase, projectId as string);
@@ -25,6 +25,13 @@ if (project.error || !project.data) {
     statusText: 'Not Found',
   });
 }
+
+const isAlreadyMember = project.data?.users?.some(u => u.user.id === profile.data.id);
+if (isAlreadyMember) {
+   // skip the join page entirely if they are already in
+   return Astro.redirect(`/${lang}/projects/${projectId}`);
+}
+
 ---
 <HeaderLayout title='join'>
   <JoinProjectApp client:load project={project.data} />

--- a/src/pages/[lang]/projects/[project]/request.astro
+++ b/src/pages/[lang]/projects/[project]/request.astro
@@ -9,14 +9,21 @@ const lang = Astro.currentLocale;
 
 const supabase = await createSupabaseServerClient(Astro.request, Astro.cookies);
 
-const projectId = Astro.params.project;
-
-const project = await getProjectExtended(supabase, projectId as string);
-
 const profile = await getMyProfile(supabase);
 if (profile.error || !profile.data) {
   return Astro.redirect(`/${lang}/sign-in?redirect-to=${Astro.url}`);
 }
+
+const projectId = Astro.params.project;
+
+const project = await getProjectExtended(supabase, projectId as string);
+
+const isAlreadyMember = project.data?.users?.some(u => u.user.id === profile.data.id);
+if (isAlreadyMember) {
+   // skip the request page entirely if they are already in
+   return Astro.redirect(`/${lang}/projects/${projectId}`);
+}
+
 ---
 
 <BaseLayout title='join'>
@@ -24,7 +31,6 @@ if (profile.error || !profile.data) {
     client:only='react'
     projectId={projectId as string}
     user={profile.data}
-    isAlreadyMember={Boolean(project.data)}
   />
 </BaseLayout>
 

--- a/src/pages/auth/callback.ts
+++ b/src/pages/auth/callback.ts
@@ -4,7 +4,8 @@ import { type APIRoute } from 'astro';
 export const GET: APIRoute = async ({ request, cookies, redirect, url }) => {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get('code');
-  const next = requestUrl.searchParams.get('next') || '/';
+  // by default, redirect to projects dashboard after auth
+  const next = requestUrl.searchParams.get('next') || '/en/projects';
 
   if (code) {
     const supabase = createServerClient(
@@ -14,7 +15,12 @@ export const GET: APIRoute = async ({ request, cookies, redirect, url }) => {
       {
         cookies: {
           getAll() {
-            return parseCookieHeader(request.headers.get('Cookie') ?? '');
+            return parseCookieHeader(request.headers.get('Cookie') ?? '').map(
+              ({ name, value }) => ({
+                name,
+                value: value ?? '',
+              })
+            );
           },
           setAll(cookiesToSet) {
             cookiesToSet.forEach(({ name, value, options }) =>


### PR DESCRIPTION
### In this PR

Per performant-software/cove-recogito#217:
- Turn on `prefixDefaultLocale` to prevent locale stripping error in redirect
- Prevent race conditions where `onAuthStateChange` could trigger multiple redirects simultaneously
- Change `window.location.href` to `window.location.replace` to prevent back button loops
- Prevent redirect loops where sign-in could redirect to sign-in
- Redirect to `auth/callback` after both SSO and keycloak sign-in
- Remove redirect item from `localStorage` after successfully joining a project (and/or once logged in and redirect has completed successfully)
- Improve flow for request/join projects when already a member
- Fix a typescript error in `auth/callback` with cookies