### PR TITLE
Custom usersnap button (COVE #222)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import config from '../config.json';
 import { truncateString } from '@util/general';
+import UsersnapButton from './components/UsersnapButton.astro';
 import '@themes/default/index.css';
 
 export interface Props {
@@ -34,22 +35,7 @@ const tabTitle = truncateString(title, 61);
   </head>
   <body>
     <slot />
-    <script>
-      // @ts-ignore
-      window.onUsersnapLoad = function (api: any) {
-        api.init();
-        api.show(import.meta.env.PUBLIC_USERSNAP_PROJECT_API_KEY);
-      };
-
-      var script = document.createElement('script');
-      // @ts-ignore
-      script.defer = 1;
-      script.src = `https://widget.usersnap.com/global/load/${
-        import.meta.env.PUBLIC_USERSNAP_GLOBAL_API_KEY
-      }?onload=onUsersnapLoad`;
-
-      document.getElementsByTagName('head')[0].appendChild(script);
-    </script>
+    <UsersnapButton />
   </body>
 </html>
 

--- a/src/layouts/HeaderLayout.astro
+++ b/src/layouts/HeaderLayout.astro
@@ -2,6 +2,7 @@
 import { BrandHeader } from '@components/Branding';
 import '@themes/default/index.css';
 import config from 'src/config.json';
+import UsersnapButton from './components/UsersnapButton.astro';
 
 export interface Props {
   title: string;
@@ -31,22 +32,7 @@ const favicon = `/${config.branding.favicon}` || '/favicon.svg';
     <div class='slot-container'>
       <slot />
     </div>
-    <script>
-      // @ts-ignore
-      window.onUsersnapLoad = function (api: any) {
-        api.init();
-        api.show(import.meta.env.PUBLIC_USERSNAP_PROJECT_API_KEY);
-      };
-
-      var script = document.createElement('script');
-      // @ts-ignore
-      script.defer = 1;
-      script.src = `https://widget.usersnap.com/global/load/${
-        import.meta.env.PUBLIC_USERSNAP_GLOBAL_API_KEY
-      }?onload=onUsersnapLoad`;
-
-      document.getElementsByTagName('head')[0].appendChild(script);
-    </script>
+    <UsersnapButton />
   </body>
 </html>
 

--- a/src/layouts/components/UsersnapButton.astro
+++ b/src/layouts/components/UsersnapButton.astro
@@ -1,0 +1,42 @@
+---
+import './UsersnapButton.css';
+const projectKey = import.meta.env.PUBLIC_USERSNAP_PROJECT_API_KEY;
+const globalKey = import.meta.env.PUBLIC_USERSNAP_GLOBAL_API_KEY;
+const isUsersnapEnabled = !!(projectKey && globalKey);
+---
+
+{isUsersnapEnabled && (
+  <>
+    <aside class="usersnap" aria-label="Report a bug">
+      <button
+        id="usersnap"
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+      >
+        Report a bug
+      </button>
+    </aside>
+    <script is:inline define:vars={{ globalKey }}>
+      window.onUsersnapLoad = function (api) {
+        api.init();
+        const btn = document.getElementById('usersnap');
+        btn?.addEventListener('click', () => {
+          api.logEvent('open-usersnap'); 
+        });
+
+        api.on('open', () => {
+          btn?.setAttribute('aria-expanded', 'true');
+        });
+
+        api.on('close', () => {
+          btn?.setAttribute('aria-expanded', 'false');
+        });
+      };
+      const script = document.createElement('script');
+      script.defer = true;
+      script.src = `https://widget.usersnap.com/global/load/${globalKey}?onload=onUsersnapLoad`;
+      document.head.appendChild(script);
+    </script>
+  </>
+)}

--- a/src/layouts/components/UsersnapButton.css
+++ b/src/layouts/components/UsersnapButton.css
@@ -1,0 +1,46 @@
+aside.usersnap {
+  display: block;
+  z-index: 2147483647;
+  position: fixed;
+  font-family: 'Inter', 'Helvetica', 'Arial', sans-serif;
+}
+button#usersnap {
+  position: fixed;
+  border: none;
+  cursor: pointer;
+  margin: 0px;
+  display: flex;
+  outline: none;
+  padding: 0px 14px;
+  overflow: visible;
+  box-sizing: border-box;
+  align-items: center;
+  font-weight: 500;
+  white-space: nowrap;
+  justify-content: center;
+  appearance: none;
+  background: rgb(254, 210, 0);
+  color: rgb(0, 0, 0);
+  font-family: Inter, Helvetica, Arial, sans-serif;
+  bottom: 0px;
+  left: 2rem;
+  font-size: 1rem;
+  height: 2.375rem;
+  box-shadow: rgba(0, 0, 0, 0.1) -4px -12px 25px 0px;
+  border-radius: 20px 20px 0px 0px;
+  transform: translateY(0);
+  will-change: transform;
+  animation: usersnapSlide 400ms;
+  transition: transform 400ms;
+}
+button#usersnap[aria-expanded='true'] {
+  transform: translateY(100%);
+}
+@keyframes usersnapSlide {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
### In this PR

Per performant-software/cove-recogito#222:
- Use a custom usersnap button that calls the `open-usersnap` event to open the usersnap dialog
- Put it inside an ARIA `aside` landmark
- Add `aria-expanded` and `aria-haspopup` accessibility attrs
- Give it the same CSS as the original Usersnap button
- Make it DRY as a reusable component

### Notes

Requires setting the Usersnap "Target" --> "Activation" setting from "Button" to "API event", and then setting the api event name to `open-usersnap`, and delay to 0s.