### PR TITLE
Add focus styling for project card

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -26,7 +26,7 @@
 }
 
 .project-card:hover,
-.project-card:focus-within{
+.project-card:focus-within {
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 8px -2px rgba(0, 0, 0, 0.28);
 }
 


### PR DESCRIPTION
# Summary

This PR adds a `focus-within` rule to the existing `hover` style for the project cards on the Projects page. This will allow users who navigate with the tab key to be able to identify which project card is in focus.