### PR TITLE
Move `DocumentLibrary` out of conditional block

### DIFF
--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -374,35 +374,33 @@ export const DocumentsView = (props: DocumentsViewProps) => {
               </DragOverlay>
             </main>
           </div>
-          <div>
-            <DocumentLibrary
-              open={addOpen}
-              onCancel={() => setAddOpen(false)}
-              user={props.user}
-              dataDirty={dataDirty || documentUpdated}
-              clearDirtyFlag={() => {
-                clearDirtyFlag();
-                setDocumentUpdated(false);
-              }}
-              UploadActions={
-                <UploadActions
-                  me={props.user}
-                  onUpload={open}
-                  onImport={onImportRemote}
-                  onSetUser={props.onSetUser}
-                />
-              }
-              onDocumentsSelected={onDocumentsSelected}
-              disabledIds={documentIds}
-              onUpdated={onUpdateDocument}
-              onError={onError}
-              onDeleteFromLibrary={onDeleteDocumentFromLibrary}
-              onTogglePrivate={onTogglePrivate}
-              isAdmin={props.isAdmin}
-            />
-          </div>
         </DndContext>
       )}
+      <DocumentLibrary
+        open={addOpen}
+        onCancel={() => setAddOpen(false)}
+        user={props.user}
+        dataDirty={dataDirty || documentUpdated}
+        clearDirtyFlag={() => {
+          clearDirtyFlag();
+          setDocumentUpdated(false);
+        }}
+        UploadActions={
+          <UploadActions
+            me={props.user}
+            onUpload={open}
+            onImport={onImportRemote}
+            onSetUser={props.onSetUser}
+          />
+        }
+        onDocumentsSelected={onDocumentsSelected}
+        disabledIds={documentIds}
+        onUpdated={onUpdateDocument}
+        onError={onError}
+        onDeleteFromLibrary={onDeleteDocumentFromLibrary}
+        onTogglePrivate={onTogglePrivate}
+        isAdmin={props.isAdmin}
+      />
       <UploadTracker
         show={showUploads}
         closable={isIdle}


### PR DESCRIPTION
# Summary

#459 introduced a regression where the `DocumentLibrary` model wouldn't render if there were 0 documents in a project, because it was inside the conditional. This PR moves it out of the conditional.

## Note

I think `DocumentLibrary` was originally inside of `DndContext`, and now it's not. I don't see any drag-and-drop functionality in the modal so I think it's fine, but I may have missed something.