### PR TITLE
i18n email bugfix

### DIFF
--- a/src/i18n/serverless.ts
+++ b/src/i18n/serverless.ts
@@ -1,0 +1,42 @@
+import i18next from 'i18next';
+import { i18n } from 'astro:config/server';
+import type { ApiPostInviteUserToProject } from 'src/Types';
+import enEmail from '../../public/locales/en/email.json';
+import deEmail from '../../public/locales/de/email.json';
+// NOTE: i18n JSON has to be bundled directly here, as this runs
+// in a serverless function and will not have access to the filesystem
+
+export async function useTranslation(
+  request: Request,
+  body: ApiPostInviteUserToProject
+) {
+  // attempt to get lang from request headers or body; fallback to default en
+  const supportedLangs = (i18n?.locales as string[]) || ['en', 'de'];
+  const defaultLocale = i18n?.defaultLocale || 'en';
+  const headerLang = request.headers
+    .get('accept-language')
+    ?.split(',')[0]
+    .split('-')[0];
+  const lang =
+    [body.lang, headerLang].find((l) => l && supportedLangs.includes(l)) ||
+    defaultLocale;
+
+  // create a minimal i18next instance for a single serverless function invocation
+  const i18nextInstance = i18next.createInstance();
+  await i18nextInstance.init({
+    lng: lang,
+    fallbackLng: 'en',
+    ns: ['email'],
+    defaultNS: 'email',
+    interpolation: { escapeValue: false },
+    resources: {
+      en: { email: enEmail },
+      de: { email: deEmail },
+    },
+  });
+
+  return {
+    t: i18nextInstance.getFixedT(lang, 'email'),
+    lang,
+  };
+}

--- a/src/pages/api/invite-user-to-project.ts
+++ b/src/pages/api/invite-user-to-project.ts
@@ -3,15 +3,10 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import type { APIRoute } from 'astro';
 import { getMyProfile } from '@backend/crud';
 import nodemailer from 'nodemailer';
-import { i18n } from 'astro:config/server';
 import { render } from '@react-email/render';
 import { InviteUserEmail } from '@components/InviteUserEmail';
 import type { ApiPostInviteUserToProject } from 'src/Types';
-import i18next from 'i18next';
-import enEmail from '../../../public/locales/en/email.json';
-import deEmail from '../../../public/locales/de/email.json';
-// NOTE: i18n JSON has to be bundled directly here, as this runs
-// in a serverless function and will not have access to the filesystem
+import { useTranslation } from 'src/i18n/serverless';
 
 const MAIL_HOST = process.env.MAIL_HOST || import.meta.env.MAIL_HOST;
 const MAIL_PORT = process.env.MAIL_PORT || import.meta.env.MAIL_PORT;
@@ -34,32 +29,7 @@ export const POST: APIRoute = async ({ request, cookies, url }) => {
     });
 
   const body: ApiPostInviteUserToProject = await request.json();
-
-  // attempt to get lang from headers or req body
-  const supportedLangs = (i18n?.locales as string[]) || ['en', 'de'];
-  const defaultLocale = i18n?.defaultLocale || 'en';
-  const headerLang = request.headers
-    .get('accept-language')
-    ?.split(',')[0]
-    .split('-')[0];
-  const passedLangs = [body.lang, headerLang];
-  const lang =
-    passedLangs.find((l) => l && supportedLangs.includes(l)) || defaultLocale;
-
-  // create a minimal i18next instance for just this serverless function invocation
-  const i18nextInstance = i18next.createInstance();
-  await i18nextInstance.init({
-    lng: lang,
-    fallbackLng: 'en',
-    ns: ['email'],
-    defaultNS: 'email',
-    interpolation: { escapeValue: false },
-    resources: {
-      en: { email: enEmail },
-      de: { email: deEmail },
-    },
-  });
-  const t = i18nextInstance.getFixedT(lang, 'email');
+  const { t, lang } = await useTranslation(request, body);
 
   const respData = [];
   // Create the invites

--- a/src/pages/api/invite-user.ts
+++ b/src/pages/api/invite-user.ts
@@ -4,15 +4,10 @@ import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { createClient } from '@supabase/supabase-js';
 import type { APIRoute } from 'astro';
 import nodemailer from 'nodemailer';
-import { i18n } from 'astro:config/server';
 import { render } from '@react-email/render';
 import { InviteUserEmail } from '@components/InviteUserEmail';
 import { encrypt } from '@backend/crypto';
-import i18next from 'i18next';
-import enEmail from '../../../public/locales/en/email.json';
-import deEmail from '../../../public/locales/de/email.json';
-// NOTE: i18n JSON has to be bundled directly here, as this runs
-// in a serverless function and will not have access to the filesystem
+import { useTranslation } from 'src/i18n/serverless';
 
 const MAIL_HOST = process.env.MAIL_HOST || import.meta.env.MAIL_HOST;
 const MAIL_PORT = process.env.MAIL_PORT || import.meta.env.MAIL_PORT;
@@ -90,31 +85,7 @@ export const POST: APIRoute = async ({ request, cookies, url }) => {
   );
 
   const body = await request.json();
-
-  const supportedLangs = (i18n?.locales as string[]) || ['en', 'de'];
-  const defaultLocale = i18n?.defaultLocale || 'en';
-  const headerLang = request.headers
-    .get('accept-language')
-    ?.split(',')[0]
-    .split('-')[0];
-  const passedLangs = [body.lang, headerLang];
-  const lang =
-    passedLangs.find((l) => l && supportedLangs.includes(l)) || defaultLocale;
-
-  // create a minimal i18next instance for just this serverless function invocation
-  const i18nextInstance = i18next.createInstance();
-  await i18nextInstance.init({
-    lng: lang,
-    fallbackLng: 'en',
-    ns: ['email'],
-    defaultNS: 'email',
-    interpolation: { escapeValue: false },
-    resources: {
-      en: { email: enEmail },
-      de: { email: deEmail },
-    },
-  });
-  const t = i18nextInstance.getFixedT(lang, 'email');
+  const { t, lang } = await useTranslation(request, body);
 
   // Create the user and then send an invite
   const inviteResp = await supa.auth.admin.createUser({


### PR DESCRIPTION
### In this PR

- Fix an issue where i18n keys were not getting translated in emails, due to them being generated inside serverless functions, and `getFixedT` from `src/i18n/server` relying on filesystem access
   - Just directly bundles the json and instantiates i18next instances instead