### PR TITLE
Hide upload notification container when there are no uploads

### DIFF
--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -401,12 +401,14 @@ export const DocumentsView = (props: DocumentsViewProps) => {
         onTogglePrivate={onTogglePrivate}
         isAdmin={props.isAdmin}
       />
-      <UploadTracker
-        show={showUploads}
-        closable={isIdle}
-        uploads={uploads}
-        onClose={() => setShowUploads(false)}
-      />
+      {uploads.length > 0 && (
+        <UploadTracker
+          show={showUploads}
+          closable={isIdle}
+          uploads={uploads}
+          onClose={() => setShowUploads(false)}
+        />
+      )}
       <input
         {...getInputProps()}
         aria-label={t('drag and drop target for documents', { ns: 'a11y' })}


### PR DESCRIPTION
# Summary

This PR addresses an issue where an empty notification toast container could be rendered on the project page.

While the viewport inside of the `Toast` component was conditionally rendered, there was a second viewport inside the `UploadTracker` component that was not conditionally rendered.

Note: If you upload something and then click the X on the toast, the empty container will remain. I wasn't sure if it was safe to clear the uploads list. If it is, I can update this PR to do that.