### PR TITLE
Set hidden file inputs to `aria-hidden`

### DIFF
--- a/public/locales/de/a11y.json
+++ b/public/locales/de/a11y.json
@@ -22,7 +22,6 @@
   "select all documents in project": "Alle Dokumente im Projekt auswählen",
   "add document": "Dokument",
   "to this assignment": "dem Arbeitsauftrag hinzufügen",
-  "drag and drop target for documents": "Zielbereich für Dokumente per drag-and-drop",
   "documents view": "Dokumenten-Ansicht",
   "assignments view": "Arbeitsauftrags-Ansicht",
   "set project visibility": "Projekt-Sichtbarkeit festlegen",

--- a/public/locales/en/a11y.json
+++ b/public/locales/en/a11y.json
@@ -23,7 +23,6 @@
   "select all documents in project": "select all documents in project",
   "add document": "add document",
   "to this assignment": "to this assignment",
-  "drag and drop target for documents": "drag and drop target for documents",
   "documents view": "documents view",
   "assignments view": "assignments view",
   "set project visibility": "set project visibility",

--- a/src/apps/collection-management/Collection/Collection.tsx
+++ b/src/apps/collection-management/Collection/Collection.tsx
@@ -517,7 +517,7 @@ const Collection = (props: CollectionsTableProps) => {
           />
           <input
             {...getInputProps()}
-            aria-label={t('drag and drop target for documents', { ns: 'a11y' })}
+            aria-hidden={true}
           />
           <DocumentLibrary
             clearDirtyFlag={() => {}}

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -418,7 +418,7 @@ export const Header = (props: HeaderProps) => {
         )}
         <input
           {...getInputProps()}
-          aria-label={t('drag and drop target for documents', { ns: 'a11y' })}
+          aria-hidden={true}
         />
       </section>
     </header>

--- a/src/apps/project-home/DocumentsView/DocumentsView.tsx
+++ b/src/apps/project-home/DocumentsView/DocumentsView.tsx
@@ -411,7 +411,7 @@ export const DocumentsView = (props: DocumentsViewProps) => {
       )}
       <input
         {...getInputProps()}
-        aria-label={t('drag and drop target for documents', { ns: 'a11y' })}
+        aria-hidden={true}
       />
     </>
   );


### PR DESCRIPTION
# Summary

This PR addresses an issue where the hidden `input` element used by the file upload feature was causing accessibility test failures because the screen reader was announcing the label even though the element is empty and invisible.

I took the quick and simple approach of replacing the label with `aria-hidden`. We're currently using a drag-and-drop library to handle uploads even though we don't offer drag-and-drop upload, but extricating the file upload from that would be a bit more time-consuming.