### PR TITLE
Use `h1` on projects page

### DIFF
--- a/src/apps/dashboard-projects/Header/Header.css
+++ b/src/apps/dashboard-projects/Header/Header.css
@@ -33,6 +33,10 @@
   padding: 30px 30px 20px 30px;
 }
 
+.dashboard-header > section.dashboard-header-container > h1 {
+  font-size: 1.2rem;
+}
+
 .dashboard-header > section.dashboard-header-container > .dashboard-header-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -214,7 +214,7 @@ export const Header = (props: HeaderProps) => {
   return (
     <header className='dashboard-header'>
       <section className='dashboard-header-container'>
-        <h2>
+        <h1>
           {props.filter}
 
           {props.tagDefinition && (
@@ -261,7 +261,7 @@ export const Header = (props: HeaderProps) => {
               />
             </ConfirmedAction.Root>
           )}
-        </h2>
+        </h1>
 
         <div className='dashboard-header-actions'>
           <ul className='dashboard-header-list-actions'>


### PR DESCRIPTION
# Summary

This PR changes the main `h2` on the projects dashboard to an `h1`. I added a CSS rule to keep the text the same size because `h1`s seem to be styled really large by default.

Addresses https://github.com/performant-software/cove-recogito/issues/236