### PR TITLE
Add presentation role to project card stat list

### DIFF
--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -108,7 +108,10 @@ export const ProjectCard = (props: ProjectCardProps) => {
         ) : (
           <p className='no-description'>{t('No description.', { ns: 'dashboard-projects' })}</p>
         )}
-        <ul className='document-stats'>
+        <ul
+          className='document-stats'
+          role='presentation'
+        >
           {contexts.length > 0 && (
             <li>
               <GraduationCap size={16} />


### PR DESCRIPTION
# Summary

The JAWS test was failing on the project card component because we're using a `ul` element for the list of stats. I think the short-term fix is to set `role='presentation'` on the `ul`.

In the long run, we will probably want `aria-label`s on each of the `li` elements describing what each one means, but I assume that's out of scope right now because we would need German versions of each one.