### PR TITLE
Add `i18n` to node build config

### DIFF
--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -6,6 +6,13 @@ import node from '@astrojs/node';
 export default defineConfig({
   integrations: [react()],
   output: 'server',
+  i18n: {
+    locales: ['en', 'de'],
+    defaultLocale: 'en',
+    routing: {
+      prefixDefaultLocale: true,
+    },
+  },
   adapter: node({
     mode: 'standalone',
   }),


### PR DESCRIPTION
# Summary

This PR is an attempt to fix https://github.com/performant-software/cove-recogito/issues/235 by copying the `i18n` config from `astro.config.mjs` to `astro.config.node.mjs`.