### PR TITLE
Fix optional chaining for author metadata

### DIFF
--- a/src/components/DocumentLibrary/DocumentLibrary.tsx
+++ b/src/components/DocumentLibrary/DocumentLibrary.tsx
@@ -388,8 +388,9 @@ export const DocumentLibrary = (props: DocumentLibraryProps) => {
                 (m: any) => m.label === 'Author' || m.label === 'Artist'
               )
             : null;
-        return author?.value.trim() ? (
-          author.value.trim()
+        const authorValue = author?.value?.trim();
+        return authorValue ? (
+          authorValue
         ) : (
           <MissingBadge text={t('No author/artist', { ns: 'project-home' })} />
         );


### PR DESCRIPTION
### In this PR

Fix for an issue that could crash the document library when a document had a metadata entry with `label: "Author"` but no `value`.