### PR TITLE
`develop` into `main` for 1.9.4

### DIFF
--- a/src/components/DocumentLibrary/DocumentLibrary.tsx
+++ b/src/components/DocumentLibrary/DocumentLibrary.tsx
@@ -388,8 +388,9 @@ export const DocumentLibrary = (props: DocumentLibraryProps) => {
                 (m: any) => m.label === 'Author' || m.label === 'Artist'
               )
             : null;
-        return author?.value.trim() ? (
-          author.value.trim()
+        const authorValue = author?.value?.trim();
+        return authorValue ? (
+          authorValue
         ) : (
           <MissingBadge text={t('No author/artist', { ns: 'project-home' })} />
         );


### PR DESCRIPTION
This release includes a bug fix for malformed author metadata.