### PR TITLE
`develop` into `main` for 1.9.6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ PUBLIC_ENABLE_USER_INVITE=TRUE    # When 'TRUE' Org Admins can invite email/pass
 # be used both on the server and the browser
 # SUPABASE_SERVERCLIENT_URL ="https://your-project.supabase.co"
 
+# For Node builds, set to the public web address of your instance
+SITE_URL="http://localhost:4321"
+
 # Secret 'salt' to compute the realtime room identifiers
 ROOM_SECRET="your-room-secret"
 

--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -1,6 +1,11 @@
+/* global process */
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import node from '@astrojs/node';
+
+const siteUrl = process.env.SITE_URL || 'http://localhost:4321';
+const url = new URL(siteUrl);
+const allowedDomain = url.hostname;
 
 // https://astro.build/config
 export default defineConfig({
@@ -20,5 +25,9 @@ export default defineConfig({
     ssr: {
       noExternal: ['clsx', '@phosphor-icons/*', '@radix-ui/*']
     }
+  },
+  security: {
+    checkOrigin: true,
+    allowedDomains: [allowedDomain]
   }
 });


### PR DESCRIPTION
Adds `SITE_URL` to the node build for self-hosted instances.