### PR TITLE
Update astro node config allowedDomains

### DIFF
--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -3,9 +3,13 @@ import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import node from '@astrojs/node';
 
+// Read SITE_URL from environment variables; fallback is used in local dev
 const siteUrl = process.env.SITE_URL || 'http://localhost:4321';
+
+// Extract the hostname (e.g. "site.com") and scheme (protocol without ":")
 const url = new URL(siteUrl);
 const allowedDomain = url.hostname;
+const scheme = url.protocol.replace(':', '');
 
 // https://astro.build/config
 export default defineConfig({
@@ -28,6 +32,11 @@ export default defineConfig({
   },
   security: {
     checkOrigin: true,
-    allowedDomains: [allowedDomain]
+    allowedDomains: [
+      {
+        scheme,
+        host: allowedDomain,
+      },
+    ],
   }
 });


### PR DESCRIPTION
An update to `astro.config.node.mjs` to match the stated [requirements from Astro](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains) for this value.