### PR TITLE
Move annotation tags to `annotation` elements and deal with URI encoding

### DIFF
--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -132,12 +132,9 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
             } as Note)
         );
 
-        const tags: string[] = Array.from(el.querySelectorAll('rs[ana]'))
-          .reduce<string[]>(
-            (all, el) => [...all, ...el.getAttribute('ana')!.split(' ').map((tag) => decodeURI(tag))],
-            []
-          )
-          .map(resolveTag);
+        const tags: string[] = el.getAttribute('ana')
+          ? el.getAttribute('ana')!.split(' ').map((tag) => decodeURI(tag)).map(resolveTag)
+          : [];
 
         const created = changes.find((c) => c.status === 'created');
         const updated = changes.find((c) => c.status === 'modified');

--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -134,7 +134,7 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
 
         const tags: string[] = Array.from(el.querySelectorAll('rs[ana]'))
           .reduce<string[]>(
-            (all, el) => [...all, ...el.getAttribute('ana')!.split(' ')],
+            (all, el) => [...all, ...el.getAttribute('ana')!.split(' ').map((tag) => decodeURI(tag))],
             []
           )
           .map(resolveTag);

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -267,9 +267,10 @@ export const mergeAnnotations = (
         try {
           const tag: VocabularyTerm = JSON.parse(b.value!);
           const key = tag.id || tag.label;
-          return key.match(/^https?:/) ? key : `#${key}`;
+          // In the first case here we can assume the key is already a valid URI; in the second we should encode
+          return key.match(/^https?:/) ? key : `#${encodeURI(key)}`;
         } catch {
-          return b.value;
+          return encodeURI(b.value);
         }
       }
 

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -258,11 +258,9 @@ export const mergeAnnotations = (
       }
     });
 
-    // If there are any tags, create one rs element and add them as the ana attribute
+    // If there are any tags, add them as the ana attribute on the annotation element
     const tags = a.bodies.filter((b) => b.purpose === 'tagging' && b.value);
     if (tags.length > 0) {
-      const rsEl = document.createElement('rs');
-
       const getKey = (b: AnnotationBody) => { 
         try {
           const tag: VocabularyTerm = JSON.parse(b.value!);
@@ -274,11 +272,10 @@ export const mergeAnnotations = (
         }
       }
 
-      rsEl.setAttribute(
+      annotationEl.setAttribute(
         'ana',
         tags.map((b) => getKey(b)).join(' ')
       );
-      annotationEl.appendChild(rsEl);
     }
 
     // Append respStmt elements for each contributing user


### PR DESCRIPTION
### In this PR
- Moves the list of tags for an annotation from separate `rs` elements to the `ana` attribute on the `annotation` element itself. This is more compatible with the FairCopy software TEI handling.
- Applies URI encoding/decoding to the individual tags to handle cases where tags contain spaces or other special characters. (Screenshot from local testing.) 
<img width="441" height="173" alt="image" src="https://github.com/user-attachments/assets/7cc344f2-8780-4bd1-a79b-16392836e276" />

Exported TEI from local testing:
```
<standOff type="recogito_studio_annotations">
  <listAnnotation>
    <annotation ana="#test #this%20is%20a%20test #//&??" target="/TEI[1]/teiHeader[1]/fileDesc[1]/editionStmt[1]/p[1]::0 /TEI[1]/teiHeader[1]/fileDesc[1]/editionStmt[1]/p[1]::26" xml:id="uid-7b186264-f5ce-4bb2-b060-e3eab90db94f">
      ...
    </annotation>
  </listAnnotation>
</standOff>
```