### PR TITLE
Update TEI standoff element

### DIFF
--- a/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
+++ b/src/apps/annotation-text/AnnotatedText/AnnotatedTEI/useEmbeddedAnnotations.ts
@@ -117,7 +117,7 @@ export const useEmbeddedTEIAnnotations = (xml?: string) => {
         const users: User[] = Array.from(el.querySelectorAll('respStmt')).map(
           (el) =>
             ({
-              id: el.getAttribute('xml:id'),
+              id: normalizeId(el.getAttribute('ref')),
               name: el.textContent,
             } as User)
         );

--- a/src/util/export/tei/teiExporter.ts
+++ b/src/util/export/tei/teiExporter.ts
@@ -153,12 +153,25 @@ export const mergeAnnotations = (
     // Should never happen
     throw new Error('No TEI root element found in the XML');
 
+  const getOrCreateChild = (parent: any, childName: string) => {
+    const existing = parent.querySelector(childName);
+    if (!existing) {
+      const child = document.createElement(childName);
+      parent.appendChild(child);
+      return child;
+    } else {
+      return existing;
+    }
+  };
+
   // https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-standOff.html
-  const standOffEl = document.createElement('standOff');
+  const standOffEl = teiElement.querySelector('standOff[type="recogito_studio_annotations"]') || document.createElement('standOff');
   standOffEl.setAttribute('type', 'recogito_studio_annotations');
 
-  const listAnnotationEl = document.createElement('listAnnotation');
-  standOffEl.appendChild(listAnnotationEl);
+  const listAnnotationEl = getOrCreateChild(standOffEl, 'listAnnotation');
+
+  // Create a list of contributers
+  const listPersonEl = getOrCreateChild(standOffEl, 'listPerson');
 
   const { taxonomyEl, taxonomy } = createTaxonomy(annotations, document);
 
@@ -175,7 +188,7 @@ export const mergeAnnotations = (
 
   const createRespStmtEl = (user: User) => {
     const respStmtEl = document.createElement('respStmt');
-    respStmtEl.setAttribute('xml:id', `uid-${user.id}`);
+    respStmtEl.setAttribute('ref', `#uid-${user.id}`);
 
     const nameEl = document.createElement('name');
     nameEl.innerHTML = user.name || 'Anonymous';
@@ -281,10 +294,21 @@ export const mergeAnnotations = (
     }
 
     // Append respStmt elements for each contributing user
+    // and add to listPerson if necessary
     const contributors = getContributors(a);
-    contributors.forEach((user) =>
-      annotationEl.appendChild(createRespStmtEl(user))
-    );
+    contributors.forEach((user) => {
+      if (!listPersonEl.querySelector(`person[xml\\:id="uid-${user.id}"]`)) {
+        const personEl = document.createElement('person');
+        personEl.setAttribute('xml:id', `uid-${user.id}`);
+        if (user.name) {
+          const persNameEl = document.createElement('persName');
+          persNameEl.innerHTML = user.name;
+          personEl.appendChild(persNameEl);
+        }
+        listPersonEl.appendChild(personEl);
+      }
+      annotationEl.appendChild(createRespStmtEl(user));
+    });
 
     listAnnotationEl.appendChild(annotationEl);
   });
@@ -293,16 +317,6 @@ export const mergeAnnotations = (
   let teiHeader = teiElement.querySelector('teiHeader');
 
   if (Object.keys(taxonomy).length > 0) {
-    const getOrCreateChild = (parent: any, childName: string) => {
-      const existing = parent.querySelector(childName);
-      if (!existing) {
-        const child = document.createElement(childName);
-        parent.appendChild(child);
-        return child;
-      } else {
-        return existing;
-      }
-    };
 
     // Append taxonomy to teiHeader > encodingDesc > classDecl - create if necessary
     if (!teiHeader) {
@@ -317,27 +331,28 @@ export const mergeAnnotations = (
     encodingDesc.appendChild(classDecl);
     teiHeader.appendChild(encodingDesc);
   }
-
-  const existingStandOffEls = teiElement.querySelectorAll('standOff');
-
-  if (existingStandOffEls?.length > 0) {
-    // Insert after the last existing standOff element
-    const lastStandOff = existingStandOffEls[existingStandOffEls.length - 1];
-    const nextSibling = lastStandOff.nextSibling;
-
-    if (nextSibling) teiElement.insertBefore(standOffEl, nextSibling);
-    else teiElement.appendChild(standOffEl);
-  } else if (teiHeader) {
-    // No existing standOffs, but header - insert after header
-    const nextSibling = teiHeader.nextSibling;
-
-    if (nextSibling) {
-      teiElement.insertBefore(standOffEl, nextSibling);
+  
+  if (!standOffEl.parent) {  
+    const existingStandOffEls = teiElement.querySelectorAll('standOff');
+    if (existingStandOffEls?.length > 0) {
+      // Insert after the last existing standOff element
+      const lastStandOff = existingStandOffEls[existingStandOffEls.length - 1];
+      const nextSibling = lastStandOff.nextSibling;
+  
+      if (nextSibling) teiElement.insertBefore(standOffEl, nextSibling);
+      else teiElement.appendChild(standOffEl);
+    } else if (teiHeader) {
+      // No existing standOffs, but header - insert after header
+      const nextSibling = teiHeader.nextSibling;
+  
+      if (nextSibling) {
+        teiElement.insertBefore(standOffEl, nextSibling);
+      } else {
+        teiElement.appendChild(standOffEl);
+      }
     } else {
-      teiElement.appendChild(standOffEl);
+      teiElement.prepend(standOffEl);
     }
-  } else {
-    teiElement.prepend(standOffEl);
   }
 
   return document.toString();


### PR DESCRIPTION
### In this PR
This is a first pass at an attempt to address some TEI schema issues with the standoff that's generated on export; specifically, it's possible for multiple different `respStmt` elements to be generated with the same `xml:id`, coming from the ID of the user that generated the annotation. This PR attempt to address that issue by...
- If an existing Recogito annotation standoff is found in the document, add new annotation data to it rather than create a separate standoff;
- Add unique contributors to a `listPerson` element inside the standoff, where each `person` element receives an `xml:id` based on the user's ID;
- In the `respStmt` element for each annotation, use the `ref` attribute to point to the corresponding `person`.

This has been tested locally and seems to produce the desired result, at least starting from a clean document with no existing annotations -- I imported, made annotations with two different users, exported, then re-imported and made more annotations, and got the following XML when exporting:
```
  <standOff type="recogito_studio_annotations">
    <listAnnotation>
      <annotation
        target="//text[@xml:id='text-1']/body[1]/div[1]/p[1]::6 //text[@xml:id='text-1']/body[1]/div[1]/p[1]::42"
        xml:id="uid-0a83a750-2133-4b0e-9418-8d17c0363216">
        <revisionDesc>
          <change who="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7" when="2026-04-25T05:03:25.227Z"
            status="created" />
          <change who="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7" when="2026-04-25T05:03:23.228Z"
            status="modified" />
        </revisionDesc>
        <note resp="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7">stars can't stand, dummy</note>
        <note resp="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">it's a metaphor you moron</note>
        <rs ana="#tag" />
        <respStmt ref="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7">
          <name>Anonymous</name>
        </respStmt>
        <respStmt ref="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">
          <name>bekka</name>
        </respStmt>
      </annotation>
      <annotation
        target="//text[@xml:id='text-1']/body[1]/div[1]/div[1]/lg[1]/l[6]::0 //text[@xml:id='text-1']/body[1]/div[1]/div[1]/lg[1]/l[8]::23"
        xml:id="uid-9338ec8f-4dc8-4b80-b3ef-394a13986278">
        <revisionDesc>
          <change who="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b" when="2026-04-25T05:04:54.296Z"
            status="created" />
          <change who="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b" when="2026-04-25T05:04:48.516Z"
            status="modified" />
        </revisionDesc>
        <note resp="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">geeeeeeeeeeeeeeeeeeeeeeetttttttt
          dunked on</note>
        <rs ana="#sans" />
        <respStmt ref="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">
          <name>bekka</name>
        </respStmt>
      </annotation>
      <annotation
        target="//text[@xml:id='text-1']/body[1]/div[1]/div[1]/lg[1]/l[3]::0 //text[@xml:id='text-1']/body[1]/div[1]/div[1]/lg[1]/l[4]::20"
        xml:id="uid-ba095b50-dea4-4a72-8505-c1c7955cd8c7">
        <revisionDesc>
          <change who="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7" when="2026-04-25T05:08:06.994Z"
            status="created" />
          <change who="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7" when="2026-04-25T05:07:54.923Z"
            status="modified" />
        </revisionDesc>
        <note resp="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7">olympic gold???</note>
        <note resp="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">too sooooon</note>
        <respStmt ref="#uid-9ff01bc7-6006-433a-9943-22df3fbf62d7">
          <name>Anonymous</name>
        </respStmt>
        <respStmt ref="#uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">
          <name>bekka</name>
        </respStmt>
      </annotation>
    </listAnnotation>
    <listPerson>
      <person xml:id="uid-9ff01bc7-6006-433a-9943-22df3fbf62d7">
        <persName>Anonymous</persName>
      </person>
      <person xml:id="uid-52e56aa4-7d3b-47b6-a5f3-d68ccecad47b">
        <persName>bekka</persName>
      </person>
    </listPerson>
  </standOff>
```

### Notes and questions
- I'm not sure what the logic had been for creating a new standoff element each time the document is exported rather than checking for an existing one of the right type; if there's some utility in that system, then we'd just need to think harder about where exactly the `listPerson` element belongs if we want to make sure not to duplicate XML IDs across the different standoffs (or is it okay if they're in separate standoff elements from each other? My assumption was that a given XML document should only have one element with each XML ID).
- There is now some redundancy with the `respStmt` elements; is it possible that with the `note` elements already being tagged with the `ref`, we don't actually need the `respStmt` elements at all? I wasn't sure exactly what the right semantics are here.