### PR TITLE
Minor Fixes: Linter Warning, Tag Autosuggest Popover

### DIFF
--- a/src/components/AnnotationDesktop/ColorCoding/colorCodings/useColorByFirstTag.ts
+++ b/src/components/AnnotationDesktop/ColorCoding/colorCodings/useColorByFirstTag.ts
@@ -17,20 +17,16 @@ export const useColorByFirstTag = (vocabulary: VocabularyTerm[] = []): ColorCodi
 
   const tags = useMemo(() => enumerateTags(annotations), [annotations]);
 
-  const vocabularyJSON = JSON.stringify(vocabulary);
-
   const getColor = useMemo(() => {
     const palette = createPalette(PALETTE);
 
-    const parsedVocabulary = JSON.parse(vocabularyJSON) as VocabularyTerm[];
-
     const getColorFn = (tag: string)  => {
-      const preset = parsedVocabulary.find(t => t.label === tag)?.color as Color;
+      const preset = vocabulary.find(t => t.label === tag)?.color as Color;
       return preset || palette.getColor(tag);
     }
 
     return getColorFn;
-  }, [vocabularyJSON]);
+  }, [vocabulary]);
 
   const style = useMemo(() => {
     return (annotation: SupabaseAnnotation): Color => {

--- a/src/components/Autosuggest/Autosuggest.tsx
+++ b/src/components/Autosuggest/Autosuggest.tsx
@@ -150,30 +150,33 @@ export const Autosuggest = (props: AutosuggestProps) => {
           )}
         </Popover.Anchor>
 
-        <Popover.Content 
-          onOpenAutoFocus={evt => evt.preventDefault()}
-          sideOffset={8}
-          align="start">
-          <ul>
-            {suggestions.map((term, index) => (
-              <li 
-                key={`${term.label}-${index}`}
-                onClick={onSubmit}
-                onMouseEnter={() => setHighlightedIndex(index)}
-                className={highlightedIndex === index ? 'selected' : undefined}>
-                <span>{term.label}</span>
+        <Popover.Portal>
+          <Popover.Content 
+            className="autosuggest"
+            onOpenAutoFocus={evt => evt.preventDefault()}
+            sideOffset={8}
+            align="start">
+            <ul>
+              {suggestions.map((term, index) => (
+                <li 
+                  key={`${term.label}-${index}`}
+                  onClick={onSubmit}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  className={highlightedIndex === index ? 'selected' : undefined}>
+                  <span>{term.label}</span>
 
-                {term.color && (
-                  <span 
-                    className="term-color"
-                    style={{
-                      backgroundColor: term.color
-                    }}/>
-                )}
-              </li>
-            ))}
-          </ul>
-        </Popover.Content>
+                  {term.color && (
+                    <span 
+                      className="term-color"
+                      style={{
+                        backgroundColor: term.color
+                      }}/>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </Popover.Content>
+        </Popover.Portal>
       </div>
     </Popover.Root>
   )


### PR DESCRIPTION
## In this PR

As discussed in https://github.com/recogito/recogito-client/pull/501#pullrequestreview-4295731597, this PR removes the legacy hack in the "first tag" color coding hook.

This PR also fixes a bug I noticed while testing: the tag autocomplete dropdown was rendered as a child to the annotation card, which had `overflow-y` set, creating an odd broken layout:

<img width="549" height="333" alt="Bildschirmfoto 2026-05-16 um 09 36 29" src="https://github.com/user-attachments/assets/ad2cba1b-592a-4db0-81c1-32e026b1aa78" />

I'm pretty sure the extra overflow rule was added after we realized that some users were writing very long comments, and that would create annotation cards that exceed the screen height. The fix, fortunately, was easy. The dropdown is now in a portal.