### PR TITLE
Fix infinite re-render in invite user dialog

### DIFF
--- a/src/apps/project-collaboration/InviteUserDialog/InviteUserDialog.tsx
+++ b/src/apps/project-collaboration/InviteUserDialog/InviteUserDialog.tsx
@@ -104,10 +104,12 @@ export const InviteUserDialog = (props: InviteUserProps) => {
     onSubmit,
   });
 
+  const { resetForm } = formik;
+
   useEffect(() => {
-    formik.resetForm();
+    resetForm();
     setError(undefined);
-  }, [formik, props.open]);
+  }, [props.open, resetForm]);
 
   return (
     <Dialog.Root open={props.open} onOpenChange={props.onClose}>


### PR DESCRIPTION
Quick bug fix for something I found working locally, introduced by #501 as the `formik` dependency caused infinite re-renders.