### PR TITLE
FIX: browser based routing for translations

### DIFF
--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -19,6 +19,7 @@ export default defineConfig({
     locales: ['en', 'de'],
     defaultLocale: 'en',
     routing: {
+      redirectToDefaultLocale: false,
       prefixDefaultLocale: true,
     },
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,14 @@
 ---
 import { getMyProfile } from '@backend/crud';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
+import { i18n } from 'astro:config/server';
+import parser from 'accept-language-parser';
 
-const lang = Astro.preferredLocale ?? 'en';
+const supported = (i18n?.locales as string[]) || ['en', 'de'];
+const defaultLocale = i18n?.defaultLocale || 'en';
+
+const accepts = Astro.request.headers.get('accept-language');
+const lang = accepts ? (parser.pick(supported, accepts) ?? defaultLocale) : defaultLocale;
 
 const supabase = await createSupabaseServerClient(Astro.request, Astro.cookies);
 


### PR DESCRIPTION
## PR Summary: Auto-detect browser language on root redirect

### Problem

This issue started from client `v.1.8.0`. Earlier versions didn't show this behavior: When users navigate to `/`, the application always redirected to `/en/` regardless of their browser's language preference, even when German (`de`) was configured as a supported locale.

### Root Cause

Two compounding issues:

**1. Astro i18n middleware intercepting `/` before the page ran**

`astro.config.node.mjs` had `i18n.routing` configured with `strategy: "pathname-prefix-always"` and no explicit `redirectToDefaultLocale` setting, which defaults to `true`. This caused Astro's built-in i18n middleware to intercept every request to `/` and immediately issue a `302` redirect to `/{defaultLocale}/` (i.e. `/en/`) — before `src/pages/index.astro` was ever executed.

**2. `index.astro` not reading `Accept-Language`**

The original `index.astro` (i.e. `v1.7.0` and lower) used `Astro.preferredLocale` / `Astro.currentLocale` for locale detection, which only inspects the URL path — not the browser's `Accept-Language` header. Even if the middleware had been disabled, the page would still have fallen back to the default locale for all requests to `/`.

### Changes

**`src/pages/index.astro`**

Replaced Astro's path-based locale detection with explicit `Accept-Language` header parsing using the `accept-language-parser` package:

```js
import parser from 'accept-language-parser';

const supported = i18n?.locales || ['en', 'de'];
const defaultLocale = i18n?.defaultLocale ?? 'en';
const accepts = Astro.request.headers.get('accept-language');
const lang = accepts
  ? parser.pick(supported, accepts) ?? defaultLocale
  : defaultLocale;
```

**`astro.config.node.mjs`** (relevant for a containerized setup)

Added `redirectToDefaultLocale: false` to the `i18n.routing` block to prevent Astro's middleware from short-circuiting requests to `/` before `index.astro` runs:

```js
i18n: {
  defaultLocale: 'en',
  locales: ['en', 'de'],
  routing: {
    redirectToDefaultLocale: false,  // allow index.astro to handle /
    // ... existing settings unchanged
  }
}
```

### Behaviour after fix

| Browser language | Redirect target |
|---|---|
| `de`, `de-DE`, `de-AT`, etc. | `/de/…` |
| `en`, `en-US`, `en-GB`, etc. | `/en/…` |
| Unsupported / no header | `/en/…` (default fallback) |

Existing behaviour for all other routes (`/en/*`, `/de/*`) is **unchanged**.

### Dependencies

`accept-language-parser` — already present in `package.json`.