### PR TITLE
Fix for "'NO_I18NEXT_INSTANCE'  issue"

### DIFF
--- a/src/components/Branding/BrandFooter.tsx
+++ b/src/components/Branding/BrandFooter.tsx
@@ -1,33 +1,33 @@
 import CustomFooter from '@branding/Footer';
 import { RecogitoLogo } from '@components/RecogitoLogo';
 import config from 'src/config.json';
-import { useTranslation } from 'react-i18next';
 import './BrandFooter.css';
 
 const { bottom_logos_enabled: useFooter, contrast_color: textColor } =
   config.branding;
 
-export const BrandFooter = ({ ...rest }) => {
-  const { t } = useTranslation(['branding']);
+interface BrandFooterProps {
+  poweredBy?: string;
+  [key: string]: any;
+}
 
-  return (
-    <footer className='brand-footer' {...rest}>
-      {useFooter && (
-        <div className='bottom-links'>
-          <CustomFooter contrastColor={textColor} />
-        </div>
-      )}
-      {!useFooter && (
-        <div className='logo-container'>
-          <span>{t('powered by', { ns: 'branding' })}</span>
-          <RecogitoLogo
-            color='#FBBA00'
-            contrastColor='white'
-            height={42}
-            width={230}
-          />
-        </div>
-      )}
-    </footer>
-  );
-};
+export const BrandFooter = ({ poweredBy = 'powered by', ...rest }: BrandFooterProps) => (
+  <footer className='brand-footer' {...rest}>
+    {useFooter && (
+      <div className='bottom-links'>
+        <CustomFooter contrastColor={textColor} />
+      </div>
+    )}
+    {!useFooter && (
+      <div className='logo-container'>
+        <span>{poweredBy}</span>
+        <RecogitoLogo
+          color='#FBBA00'
+          contrastColor='white'
+          height={42}
+          width={230}
+        />
+      </div>
+    )}
+  </footer>
+);

--- a/src/layouts/login/LoginLayout.astro
+++ b/src/layouts/login/LoginLayout.astro
@@ -15,6 +15,8 @@ const { title, showLogo } = Astro.props;
 const lang = Astro.currentLocale;
 const t = await getFixedT(lang, ['branding']);
 
+const poweredBy = t('powered by', { ns: 'branding' });
+
 const backgroundColor = config.branding.background_color;
 const loginLogo = config.branding.login_logo;
 const splashURL = config.branding.home_banner;

--- a/src/layouts/login/LoginLayout.astro
+++ b/src/layouts/login/LoginLayout.astro
@@ -54,7 +54,7 @@ const useFooter = config.branding.bottom_logos_enabled;
             </div>
           )
         }
-        <BrandFooter />
+        <BrandFooter poweredBy={poweredBy} />
       </div>
     </main>
     <div class='img-container'>


### PR DESCRIPTION
## Problem

On every request to any page using `LoginLayout` (sign-in, keycloak auth, password reset, invites, etc.), the server was silently executing the browser-only i18n initialisation stack:

```
LoginLayout.astro
  └── <BrandFooter />          (rendered server-side, no client:only)
        └── useTranslation()   (react-i18next hook)
              └── clientI18next (src/i18n/client.ts)
                    ├── i18next-http-backend      ← fetches locale files via HTTP
                    └── i18next-browser-languagedetector  ← reads window/document
```

`BrandFooter` used `useTranslation` from `react-i18next` to translate a single string (`'powered by'`). Because it was rendered directly in an Astro layout without `client:only`, Astro SSR-rendered it, which caused `src/i18n/client.ts` to be included in the server bundle and executed on every page load.

This had two concrete consequences:

1. **Cold-start latency**: `i18next-http-backend` fetches locale JSON files by making an outbound HTTP request back to the server itself (e.g. `GET http://localhost/locales/en/branding.json`). On cold start, the server may not be ready to serve that request yet, causing a stall.
2. **Incorrect environment code on the server**: `i18next-browser-languagedetector` attempts to read `window.location`, `document.cookie`, and `navigator.language` — none of which exist in a Node.js SSR context.

## Root cause

`BrandFooter` is a purely presentational component that needed exactly one translated string. Using a client-side React hook (`useTranslation`) for this was unnecessary — `LoginLayout.astro` already had a server-side `getFixedT` call available for exactly this purpose.

## Fix

- **`BrandFooter.tsx`**: Removed `useTranslation` and the `react-i18next` import. The component now accepts the translated string as a `poweredBy` prop, with `'powered by'` as a fallback default.
- **`LoginLayout.astro`**: Translates `'powered by'` using the already-present `getFixedT` call and passes it down to `<BrandFooter poweredBy={poweredBy} />`.

## Result

`src/i18n/client.ts` is no longer included in the server bundle. `i18next-http-backend` and `i18next-browser-languagedetector` no longer execute on the server. The cold-start self-HTTP-fetch is eliminated.

The change is minimal and self-contained — `BrandFooter` has exactly one call site in the entire codebase (`LoginLayout.astro`), so there are no other consumers affected.