### PR TITLE
Improve plugin installation workflow with env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,17 @@ PUBLIC_ENABLE_USER_INVITE=TRUE    # When 'TRUE' Org Admins can invite email/pass
 # For Node builds, set to the public web address of your instance
 SITE_URL="http://localhost:4321"
 
+# Plugins to install and register, as a comma- or space-separated list of npm
+# package names. The packages must also be installed (npm install <name>).
+# Available Recogito Studio plugins:
+#   @recogito/plugin-geotagging             GeoTagger
+#   @recogito/plugin-reconciliation-service Reconciliation Service API
+#   @recogito/plugin-ner                    Named Entity Recognition
+#   @recogito/plugin-revisions              Revisions
+#   @recogito/plugin-tei-inliner            TEI Inliner
+#   @recogito/plugin-sandcastle-export      Sandcastle3D Export
+# INSTALLED_PLUGINS="@recogito/plugin-geotagging,@recogito/plugin-revisions"
+
 # Secret 'salt' to compute the realtime room identifiers
 ROOM_SECRET="your-room-secret"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ WORKDIR /app
 COPY . .
 
 RUN npm install
+
+# install any plugins in INSTALLED_PLUGINS env var via npm
+RUN if [ -f .env ]; then set -a && . ./.env && set +a; fi; \
+    if [ -n "$INSTALLED_PLUGINS" ]; then \
+      npm install $(echo "$INSTALLED_PLUGINS" | tr ',' ' '); \
+    fi
+
 RUN npm run build-node
 
 ENV HOST=0.0.0.0

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,9 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import netlify from '@astrojs/netlify';
+import { loadInstalledPlugins } from './installed-plugins.mjs';
+
+const plugins = await loadInstalledPlugins();
 
 export default defineConfig({
   adapter: netlify(),
@@ -11,7 +14,7 @@ export default defineConfig({
       prefixDefaultLocale: true,
     },
   },
-  integrations: [react()],
+  integrations: [react(), ...plugins],
   output: 'server',
   vite: {
     ssr: {

--- a/astro.config.node.mjs
+++ b/astro.config.node.mjs
@@ -2,6 +2,10 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import node from '@astrojs/node';
+import { loadInstalledPlugins } from './installed-plugins.mjs';
+
+// Install plugins declared in the INSTALLED_PLUGINS environment variable
+const plugins = await loadInstalledPlugins();
 
 // Read SITE_URL from environment variables; fallback is used in local dev
 const siteUrl = process.env.SITE_URL || 'http://localhost:4321';
@@ -13,7 +17,7 @@ const scheme = url.protocol.replace(':', '');
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react()],
+  integrations: [react(), ...plugins],
   output: 'server',
   i18n: {
     locales: ['en', 'de'],

--- a/installed-plugins.mjs
+++ b/installed-plugins.mjs
@@ -1,0 +1,43 @@
+/* global process */
+import 'dotenv/config';
+
+/**
+ * Loads the Recogito Studio plugins declared in the INSTALLED_PLUGINS
+ * environment variable and returns them as an array of Astro integrations to be
+ * added to `integrations` in the Astro config.
+ *
+ * INSTALLED_PLUGINS is a list of npm package names separated by commas and/or
+ * whitespace. Example:
+ *
+ *   INSTALLED_PLUGINS="@recogito/plugin-geotagging, @recogito/plugin-ner"
+ *
+ * The matching packages must be installed (present in package.json /
+ * node_modules) for the import to resolve.
+ */
+export async function loadInstalledPlugins() {
+  const names = [
+    ...new Set(
+      (process.env.INSTALLED_PLUGINS || '')
+        .split(/[\s,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  ];
+
+  const integrations = [];
+  for (const name of names) {
+    try {
+      const mod = await import(name);
+      integrations.push(mod.default());
+    } catch (err) {
+      throw new Error(
+        `Could not load plugin "${name}" declared in INSTALLED_PLUGINS. ` +
+          `Check that it is the exact npm package name and that it is installed. ` +
+          `(${err.message})`,
+        { cause: err }
+      );
+    }
+  }
+
+  return integrations;
+}


### PR DESCRIPTION
### In this PR

- Add `INSTALLED_PLUGINS` env var and parse it to populate astro config plugin integrations
- Add `npm install` step to the `Dockerfile` so that self-hosted installations get them installed when running install/upgrade scripts

### Notes

I realized while working on the self-hosting documentation that there's not really a clean way to integrate plugins while self-hosting, which has until now required maintaining a separate `astro.config.mjs` with the plugins listed in `integrations`. In practice, that means keeping a fork or modified clone of this repo, with the plugins imported in that file as well as installed via NPM.

I also have an existing [easy-upgrade shell script](https://github.com/recogito/recogito-studio/blob/main/upgrade.sh) in the self-hosting repo that is meant to upgrade everything end-to-end, but I never included logic for adding plugins with it, and therefore it uninstalls them on every upgrade.

We handled this in `recogito-cloud` by maintaining [separate copies of the Astro configs](https://github.com/performant-software/recogito-cloud/tree/develop/plugin-configs), but those tended to drift and added a maintenance burden. We already have a `PLUGINS` env var there to configure plugins per-tenant, so I took a cue from that, and from Django's `INSTALLED_APPS` setting, and added a new `INSTALLED_PLUGINS` env var to this repo.

Not sure whether to consider this a breaking change or not; technically anyone doing it the old way will have no breakage (they already maintain a separate copy of the config if they are using plugins), and omitting the env var on a fresh install just means you get no plugins.

### LLM Note

Claude wrote the parser script and dockerfile command (though they're pretty simple in retrospect).