### PR TITLE
Handle no component in doc-actions extension point

### DIFF
--- a/src/themes/default/dropdown/index.css
+++ b/src/themes/default/dropdown/index.css
@@ -111,6 +111,11 @@
   margin: 0.25rem 0.5rem;
 }
 
+/* handle null mounted component */
+.dropdown-separator + .dropdown-separator {
+  display: none;
+}
+
 .dropdown-label {
   color: var(--gray-500);
   font-size: 12px;


### PR DESCRIPTION
### In this PR

- Minor CSS change that goes along with https://github.com/recogito/metaphor-annotation-plugin/pull/5, to hide double separators when there is no mounted (lazy-loaded) component
