### PR TITLE
Remove white-space: break-spaces style

### DIFF
--- a/src/apps/annotation-text/TextAnnotationDesktop.css
+++ b/src/apps/annotation-text/TextAnnotationDesktop.css
@@ -57,7 +57,6 @@ html, body {
   line-height: 190%;
   min-height: 100%;
   position: relative;
-  white-space: break-spaces;
   word-wrap: break-word;
 }
 


### PR DESCRIPTION
### In this PR
Improves the visual spacing of certain TEI documents by removing the `white-space: break-spaces;` CSS class.

Before: 
<img width="772" height="506" alt="image" src="https://github.com/user-attachments/assets/49dc3ec9-99b9-4bdb-a246-5b2054d5066e" />

After:
<img width="802" height="512" alt="image" src="https://github.com/user-attachments/assets/b5ae63c7-1b11-4f33-b73f-5f6ea907001d" />
