### PR TITLE
Sanitize manifests to prevent bad "homepage" key from crashing UI

### DIFF
--- a/src/apps/annotation-image/IIIF/useIIIF.ts
+++ b/src/apps/annotation-image/IIIF/useIIIF.ts
@@ -104,6 +104,9 @@ export const useIIIF = (document: DocumentWithContext) => {
           console.log('Failed to parse IIIF manifest', parsed);
           setManifestError(`Failed to parse IIIF manifest: ${url}`);
         }
+      }).catch(error => {
+        console.error('Failed to load IIIF manifest', error);
+        setManifestError(`Failed to parse IIIF manifest: ${url}`);
       });
     }
   }, [document]);

--- a/src/apps/annotation-image/IIIF/useIIIF.ts
+++ b/src/apps/annotation-image/IIIF/useIIIF.ts
@@ -3,7 +3,7 @@ import type { ImageAnnotation } from '@annotorious/annotorious';
 import { Canvas, IIIF, type Metadata } from '@allmaps/iiif-parser';
 import type { DocumentWithContext, EmbeddedLayer } from 'src/Types';
 import { supabase } from '@backend/supabaseBrowserClient';
-import { parseManifestAnnotations } from '@util/iiif';
+import { parseManifestAnnotations, sanitizeManifest } from '@util/iiif';
 
 type ManifestType = 'PRESENTATION' | 'IMAGE';
 
@@ -90,7 +90,7 @@ export const useIIIF = (document: DocumentWithContext) => {
       }
     } else {
       fetch(url).then(res => res.json()).then(data => {
-        const parsed = IIIF.parse(data);
+        const parsed = IIIF.parse(sanitizeManifest(data));
         if (parsed.type === 'manifest') {
           setCanvases(parsed.canvases);
           setCurrentImage(parsed.canvases[0]);

--- a/src/apps/project-home/upload/dialogs/useIIIFValidation.ts
+++ b/src/apps/project-home/upload/dialogs/useIIIFValidation.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IIIF } from '@allmaps/iiif-parser';
-import { getResourceLabel } from 'src/util';
+import { getResourceLabel, sanitizeManifest } from 'src/util';
 
 /**
  * Some basic sanity checking on the URL string
@@ -43,7 +43,7 @@ export const validateIIIF = (url: string, locale: string): Promise<ValidationRes
       .then((response) => response.json())
       .then(data => {
           try {
-            const parsed = IIIF.parse(data);
+            const parsed = IIIF.parse(sanitizeManifest(data));
 
             if (parsed.type === 'image') {
               // Image API v1/2/3

--- a/src/util/iiif/index.ts
+++ b/src/util/iiif/index.ts
@@ -1,2 +1,3 @@
 export * from './getResourceLabel';
 export * from './parseManifestAnnotations';
+export * from './sanitizeManifest';

--- a/src/util/iiif/sanitizeManifest.ts
+++ b/src/util/iiif/sanitizeManifest.ts
@@ -1,0 +1,21 @@
+/**
+ * Some real-world IIIF manifests omit fields that the IIIF Presentation
+ * spec (via @allmaps/iiif-parser Zod schemas) require.
+ *
+ * This util mutates the given manifest object in place to sanitize unused
+ * but invalid fields from any otherwise valid manifest.
+ */
+export const sanitizeManifest = (data: any) => {
+  if (data && Array.isArray(data.homepage)) {
+    // drop homepage entries missing the required label property (for Getty manifests).
+    // we don't use it and it causes a Zod error in @allmaps/iiif-parser
+    data.homepage = data.homepage.filter((h: any) => h && h.label);
+
+    // if nothing valid remains, remove the field entirely
+    if (data.homepage.length === 0) {
+      delete data.homepage;
+    }
+  }
+
+  return data;
+};


### PR DESCRIPTION
### In this PR

Per Slack channel conversation:
- Remove `homepage` from IIIF manifests when it is missing a `label` key to fix the issue with Getty manifests (allmaps parser rejects it, as it's technically invalid IIIF, even though the official IIIF validator doesn't care)
- Improve error reporting in IIIF parsing